### PR TITLE
kube-controller-manager: use context-aware client-go

### DIFF
--- a/cmd/kube-controller-manager/app/bootstrap.go
+++ b/cmd/kube-controller-manager/app/bootstrap.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	"k8s.io/kubernetes/pkg/controller/bootstrap"
 )
@@ -40,6 +41,7 @@ func newBootstrapSignerController(ctx context.Context, controllerContext Control
 	}
 
 	bsc, err := bootstrap.NewSigner(
+		klog.FromContext(ctx),
 		client,
 		controllerContext.InformerFactory.Core().V1().Secrets(),
 		controllerContext.InformerFactory.Core().V1().ConfigMaps(),
@@ -68,6 +70,7 @@ func newTokenCleanerController(ctx context.Context, controllerContext Controller
 	}
 
 	tcc, err := bootstrap.NewTokenCleaner(
+		klog.FromContext(ctx),
 		client,
 		controllerContext.InformerFactory.Core().V1().Secrets(),
 		bootstrap.DefaultTokenCleanerOptions(),

--- a/cmd/kube-controller-manager/app/bootstrap.go
+++ b/cmd/kube-controller-manager/app/bootstrap.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	"k8s.io/kubernetes/pkg/controller/bootstrap"
 )
@@ -41,7 +40,7 @@ func newBootstrapSignerController(ctx context.Context, controllerContext Control
 	}
 
 	bsc, err := bootstrap.NewSigner(
-		klog.FromContext(ctx),
+		ctx,
 		client,
 		controllerContext.InformerFactory.Core().V1().Secrets(),
 		controllerContext.InformerFactory.Core().V1().ConfigMaps(),
@@ -70,7 +69,7 @@ func newTokenCleanerController(ctx context.Context, controllerContext Controller
 	}
 
 	tcc, err := bootstrap.NewTokenCleaner(
-		klog.FromContext(ctx),
+		ctx,
 		client,
 		controllerContext.InformerFactory.Core().V1().Secrets(),
 		bootstrap.DefaultTokenCleanerOptions(),

--- a/cmd/kube-controller-manager/app/certificates.go
+++ b/cmd/kube-controller-manager/app/certificates.go
@@ -273,6 +273,7 @@ func newRootCACertificatePublisherController(ctx context.Context, controllerCont
 	}
 
 	sac, err := rootcacertpublisher.NewPublisher(
+		klog.FromContext(ctx),
 		controllerContext.InformerFactory.Core().V1().ConfigMaps(),
 		controllerContext.InformerFactory.Core().V1().Namespaces(),
 		client,
@@ -295,7 +296,7 @@ func newKubeAPIServerSignerClusterTrustBundledPublisherDescriptor() *ControllerD
 	}
 }
 
-type controllerConstructor func(string, dynamiccertificates.CAContentProvider, kubernetes.Interface) (ctbpublisher.PublisherRunner, error)
+type controllerConstructor func(klog.Logger, string, dynamiccertificates.CAContentProvider, kubernetes.Interface) (ctbpublisher.PublisherRunner, error)
 
 func newKubeAPIServerSignerClusterTrustBundledPublisherController(
 	ctx context.Context, controllerContext ControllerContext, controllerName string,
@@ -340,6 +341,7 @@ func newKubeAPIServerSignerClusterTrustBundledPublisherController(
 		}
 
 		runner, err = schemaControllerMapping[gv](
+			klog.FromContext(ctx),
 			"kubernetes.io/kube-apiserver-serving",
 			servingSigners,
 			apiserverSignerClient,

--- a/cmd/kube-controller-manager/app/certificates.go
+++ b/cmd/kube-controller-manager/app/certificates.go
@@ -273,7 +273,7 @@ func newRootCACertificatePublisherController(ctx context.Context, controllerCont
 	}
 
 	sac, err := rootcacertpublisher.NewPublisher(
-		klog.FromContext(ctx),
+		ctx,
 		controllerContext.InformerFactory.Core().V1().ConfigMaps(),
 		controllerContext.InformerFactory.Core().V1().Namespaces(),
 		client,

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -353,15 +353,16 @@ func Run(ctx context.Context, c *config.CompletedConfig) error {
 		}
 
 		// Start lease candidate controller for coordinated leader election
-		leaseCandidate, waitForSync, err := leaderelection.NewCandidate(
-			c.Client,
-			"kube-system",
-			id,
-			kubeControllerManager,
-			binaryVersion.FinalizeVersion(),
-			emulationVersion.FinalizeVersion(),
-			coordinationv1.OldestEmulationVersion,
-		)
+		leaseCandidate, waitForSync, err := leaderelection.NewCandidateWithConfig(leaderelection.CandidateConfig{
+			Logger:             &logger,
+			Clientset:          c.Client,
+			CandidateNamespace: "kube-system",
+			CandidateName:      id,
+			TargetLease:        kubeControllerManager,
+			BinaryVersion:      binaryVersion.FinalizeVersion(),
+			EmulationVersion:   emulationVersion.FinalizeVersion(),
+			Strategy:           coordinationv1.OldestEmulationVersion,
+		})
 		if err != nil {
 			return err
 		}

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -585,10 +585,9 @@ func newServiceAccountController(ctx context.Context, controllerContext Controll
 	if err != nil {
 		return nil, err
 	}
-	logger := klog.FromContext(ctx)
 
 	sac, err := serviceaccountcontroller.NewServiceAccountsController(
-		logger,
+		ctx,
 		controllerContext.InformerFactory.Core().V1().ServiceAccounts(),
 		controllerContext.InformerFactory.Core().V1().Namespaces(),
 		client,
@@ -727,7 +726,7 @@ func newPersistentVolumeClaimProtectionController(ctx context.Context, controlle
 	}
 
 	pvcProtectionController, err := pvcprotection.NewPVCProtectionController(
-		klog.FromContext(ctx),
+		ctx,
 		controllerContext.InformerFactory.Core().V1().PersistentVolumeClaims(),
 		controllerContext.InformerFactory.Core().V1().Pods(),
 		client,
@@ -756,7 +755,7 @@ func newPersistentVolumeProtectionController(ctx context.Context, controllerCont
 	}
 
 	pvpc, err := pvprotection.NewPVProtectionController(
-		klog.FromContext(ctx),
+		ctx,
 		controllerContext.InformerFactory.Core().V1().PersistentVolumes(),
 		client,
 	)
@@ -785,7 +784,7 @@ func newVolumeAttributesClassProtectionController(ctx context.Context, controlle
 	}
 
 	vacProtectionController, err := vacprotection.NewVACProtectionController(
-		klog.FromContext(ctx),
+		ctx,
 		client,
 		controllerContext.InformerFactory.Core().V1().PersistentVolumeClaims(),
 		controllerContext.InformerFactory.Core().V1().PersistentVolumes(),

--- a/cmd/kube-controller-manager/app/rbac.go
+++ b/cmd/kube-controller-manager/app/rbac.go
@@ -19,6 +19,7 @@ package app
 import (
 	"context"
 
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	"k8s.io/kubernetes/pkg/controller/clusterroleaggregation"
 )
@@ -38,6 +39,7 @@ func newClusterRoleAggregationController(ctx context.Context, controllerContext 
 	}
 
 	crac := clusterroleaggregation.NewClusterRoleAggregation(
+		klog.FromContext(ctx),
 		controllerContext.InformerFactory.Rbac().V1().ClusterRoles(),
 		client.RbacV1(),
 	)

--- a/cmd/kube-controller-manager/app/rbac.go
+++ b/cmd/kube-controller-manager/app/rbac.go
@@ -19,7 +19,6 @@ package app
 import (
 	"context"
 
-	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	"k8s.io/kubernetes/pkg/controller/clusterroleaggregation"
 )
@@ -39,7 +38,7 @@ func newClusterRoleAggregationController(ctx context.Context, controllerContext 
 	}
 
 	crac := clusterroleaggregation.NewClusterRoleAggregation(
-		klog.FromContext(ctx),
+		ctx,
 		controllerContext.InformerFactory.Rbac().V1().ClusterRoles(),
 		client.RbacV1(),
 	)

--- a/cmd/kube-controller-manager/app/service_accounts.go
+++ b/cmd/kube-controller-manager/app/service_accounts.go
@@ -79,7 +79,7 @@ func newServiceAccountTokenController(
 		return nil, fmt.Errorf("failed to build token generator: %w", err)
 	}
 	tokenController, err := serviceaccountcontroller.NewTokensController(
-		klog.FromContext(ctx),
+		ctx,
 		controllerContext.InformerFactory.Core().V1().ServiceAccounts(),
 		controllerContext.InformerFactory.Core().V1().Secrets(),
 		client,

--- a/cmd/kube-controller-manager/app/validatingadmissionpolicystatus.go
+++ b/cmd/kube-controller-manager/app/validatingadmissionpolicystatus.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apiserver/pkg/cel/openapi/resolver"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/component-base/featuregate"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	"k8s.io/kubernetes/pkg/controller/validatingadmissionpolicystatus"
 	"k8s.io/kubernetes/pkg/generated/openapi"
@@ -58,6 +59,7 @@ func newValidatingAdmissionPolicyStatusController(ctx context.Context, controlle
 	}
 
 	c, err := validatingadmissionpolicystatus.NewController(
+		klog.FromContext(ctx),
 		controllerContext.InformerFactory.Admissionregistration().V1().ValidatingAdmissionPolicies(),
 		client.AdmissionregistrationV1().ValidatingAdmissionPolicies(),
 		typeChecker,

--- a/cmd/kube-controller-manager/app/validatingadmissionpolicystatus.go
+++ b/cmd/kube-controller-manager/app/validatingadmissionpolicystatus.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apiserver/pkg/cel/openapi/resolver"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	"k8s.io/kubernetes/pkg/controller/validatingadmissionpolicystatus"
 	"k8s.io/kubernetes/pkg/generated/openapi"
@@ -59,7 +58,7 @@ func newValidatingAdmissionPolicyStatusController(ctx context.Context, controlle
 	}
 
 	c, err := validatingadmissionpolicystatus.NewController(
-		klog.FromContext(ctx),
+		ctx,
 		controllerContext.InformerFactory.Admissionregistration().V1().ValidatingAdmissionPolicies(),
 		client.AdmissionregistrationV1().ValidatingAdmissionPolicies(),
 		typeChecker,

--- a/pkg/controller/bootstrap/bootstrapsigner.go
+++ b/pkg/controller/bootstrap/bootstrapsigner.go
@@ -93,7 +93,7 @@ type Signer struct {
 }
 
 // NewSigner returns a new *Signer.
-func NewSigner(cl clientset.Interface, secrets informers.SecretInformer, configMaps informers.ConfigMapInformer, options SignerOptions) (*Signer, error) {
+func NewSigner(logger klog.Logger, cl clientset.Interface, secrets informers.SecretInformer, configMaps informers.ConfigMapInformer, options SignerOptions) (*Signer, error) {
 	e := &Signer{
 		client:             cl,
 		configMapKey:       options.ConfigMapNamespace + "/" + options.ConfigMapName,
@@ -107,12 +107,13 @@ func NewSigner(cl clientset.Interface, secrets informers.SecretInformer, configM
 		syncQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "bootstrap_signer_queue",
+				Logger: &logger,
+				Name:   "bootstrap_signer_queue",
 			},
 		),
 	}
 
-	configMaps.Informer().AddEventHandlerWithResyncPeriod(
+	_, _ = configMaps.Informer().AddEventHandlerWithOptions(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: func(obj interface{}) bool {
 				switch t := obj.(type) {
@@ -128,10 +129,13 @@ func NewSigner(cl clientset.Interface, secrets informers.SecretInformer, configM
 				UpdateFunc: func(_, _ interface{}) { e.pokeConfigMapSync() },
 			},
 		},
-		options.ConfigMapResync,
+		cache.HandlerOptions{
+			Logger:       &logger,
+			ResyncPeriod: &options.ConfigMapResync,
+		},
 	)
 
-	secrets.Informer().AddEventHandlerWithResyncPeriod(
+	_, _ = secrets.Informer().AddEventHandlerWithOptions(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: func(obj interface{}) bool {
 				switch t := obj.(type) {
@@ -148,7 +152,10 @@ func NewSigner(cl clientset.Interface, secrets informers.SecretInformer, configM
 				DeleteFunc: func(_ interface{}) { e.pokeConfigMapSync() },
 			},
 		},
-		options.SecretResync,
+		cache.HandlerOptions{
+			Logger:       &logger,
+			ResyncPeriod: &options.SecretResync,
+		},
 	)
 
 	return e, nil
@@ -156,7 +163,7 @@ func NewSigner(cl clientset.Interface, secrets informers.SecretInformer, configM
 
 // Run runs controller loops and returns when they are done
 func (e *Signer) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.V(5).Info("Starting")

--- a/pkg/controller/bootstrap/bootstrapsigner.go
+++ b/pkg/controller/bootstrap/bootstrapsigner.go
@@ -93,7 +93,8 @@ type Signer struct {
 }
 
 // NewSigner returns a new *Signer.
-func NewSigner(logger klog.Logger, cl clientset.Interface, secrets informers.SecretInformer, configMaps informers.ConfigMapInformer, options SignerOptions) (*Signer, error) {
+func NewSigner(ctx context.Context, cl clientset.Interface, secrets informers.SecretInformer, configMaps informers.ConfigMapInformer, options SignerOptions) (*Signer, error) {
+	logger := klog.FromContext(ctx)
 	e := &Signer{
 		client:             cl,
 		configMapKey:       options.ConfigMapNamespace + "/" + options.ConfigMapName,

--- a/pkg/controller/bootstrap/bootstrapsigner_test.go
+++ b/pkg/controller/bootstrap/bootstrapsigner_test.go
@@ -30,17 +30,19 @@ import (
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 const testTokenID = "abc123"
 
-func newSigner() (*Signer, *fake.Clientset, coreinformers.SecretInformer, coreinformers.ConfigMapInformer, error) {
+func newSigner(t *testing.T) (*Signer, *fake.Clientset, coreinformers.SecretInformer, coreinformers.ConfigMapInformer, error) {
+	tCtx := ktesting.Init(t)
 	options := DefaultSignerOptions()
 	cl := fake.NewSimpleClientset()
 	informers := informers.NewSharedInformerFactory(fake.NewSimpleClientset(), controller.NoResyncPeriodFunc())
 	secrets := informers.Core().V1().Secrets()
 	configMaps := informers.Core().V1().ConfigMaps()
-	bsc, err := NewSigner(cl, secrets, configMaps, options)
+	bsc, err := NewSigner(tCtx.Logger(), cl, secrets, configMaps, options)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -65,7 +67,7 @@ func newConfigMap(tokenID, signature string) *v1.ConfigMap {
 }
 
 func TestNoConfigMap(t *testing.T) {
-	signer, cl, _, _, err := newSigner()
+	signer, cl, _, _, err := newSigner(t)
 	if err != nil {
 		t.Fatalf("error creating Signer: %v", err)
 	}
@@ -74,7 +76,7 @@ func TestNoConfigMap(t *testing.T) {
 }
 
 func TestSimpleSign(t *testing.T) {
-	signer, cl, secrets, configMaps, err := newSigner()
+	signer, cl, secrets, configMaps, err := newSigner(t)
 	if err != nil {
 		t.Fatalf("error creating Signer: %v", err)
 	}
@@ -98,7 +100,7 @@ func TestSimpleSign(t *testing.T) {
 }
 
 func TestNoSignNeeded(t *testing.T) {
-	signer, cl, secrets, configMaps, err := newSigner()
+	signer, cl, secrets, configMaps, err := newSigner(t)
 	if err != nil {
 		t.Fatalf("error creating Signer: %v", err)
 	}
@@ -116,7 +118,7 @@ func TestNoSignNeeded(t *testing.T) {
 }
 
 func TestUpdateSignature(t *testing.T) {
-	signer, cl, secrets, configMaps, err := newSigner()
+	signer, cl, secrets, configMaps, err := newSigner(t)
 	if err != nil {
 		t.Fatalf("error creating Signer: %v", err)
 	}
@@ -140,7 +142,7 @@ func TestUpdateSignature(t *testing.T) {
 }
 
 func TestRemoveSignature(t *testing.T) {
-	signer, cl, _, configMaps, err := newSigner()
+	signer, cl, _, configMaps, err := newSigner(t)
 	if err != nil {
 		t.Fatalf("error creating Signer: %v", err)
 	}

--- a/pkg/controller/bootstrap/bootstrapsigner_test.go
+++ b/pkg/controller/bootstrap/bootstrapsigner_test.go
@@ -42,7 +42,7 @@ func newSigner(t *testing.T) (*Signer, *fake.Clientset, coreinformers.SecretInfo
 	informers := informers.NewSharedInformerFactory(fake.NewSimpleClientset(), controller.NoResyncPeriodFunc())
 	secrets := informers.Core().V1().Secrets()
 	configMaps := informers.Core().V1().ConfigMaps()
-	bsc, err := NewSigner(tCtx.Logger(), cl, secrets, configMaps, options)
+	bsc, err := NewSigner(tCtx, cl, secrets, configMaps, options)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/pkg/controller/bootstrap/tokencleaner.go
+++ b/pkg/controller/bootstrap/tokencleaner.go
@@ -73,7 +73,7 @@ type TokenCleaner struct {
 }
 
 // NewTokenCleaner returns a new *NewTokenCleaner.
-func NewTokenCleaner(cl clientset.Interface, secrets coreinformers.SecretInformer, options TokenCleanerOptions) (*TokenCleaner, error) {
+func NewTokenCleaner(logger klog.Logger, cl clientset.Interface, secrets coreinformers.SecretInformer, options TokenCleanerOptions) (*TokenCleaner, error) {
 	e := &TokenCleaner{
 		client:               cl,
 		secretLister:         secrets.Lister(),
@@ -82,12 +82,13 @@ func NewTokenCleaner(cl clientset.Interface, secrets coreinformers.SecretInforme
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "token_cleaner",
+				Logger: &logger,
+				Name:   "token_cleaner",
 			},
 		),
 	}
 
-	secrets.Informer().AddEventHandlerWithResyncPeriod(
+	_, _ = secrets.Informer().AddEventHandlerWithOptions(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: func(obj interface{}) bool {
 				switch t := obj.(type) {
@@ -103,7 +104,10 @@ func NewTokenCleaner(cl clientset.Interface, secrets coreinformers.SecretInforme
 				UpdateFunc: func(oldSecret, newSecret interface{}) { e.enqueueSecrets(newSecret) },
 			},
 		},
-		options.SecretResync,
+		cache.HandlerOptions{
+			Logger:       &logger,
+			ResyncPeriod: &options.SecretResync,
+		},
 	)
 
 	return e, nil
@@ -111,7 +115,7 @@ func NewTokenCleaner(cl clientset.Interface, secrets coreinformers.SecretInforme
 
 // Run runs controller loops and returns when they are done
 func (tc *TokenCleaner) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting token cleaner controller")

--- a/pkg/controller/bootstrap/tokencleaner.go
+++ b/pkg/controller/bootstrap/tokencleaner.go
@@ -73,7 +73,8 @@ type TokenCleaner struct {
 }
 
 // NewTokenCleaner returns a new *NewTokenCleaner.
-func NewTokenCleaner(logger klog.Logger, cl clientset.Interface, secrets coreinformers.SecretInformer, options TokenCleanerOptions) (*TokenCleaner, error) {
+func NewTokenCleaner(ctx context.Context, cl clientset.Interface, secrets coreinformers.SecretInformer, options TokenCleanerOptions) (*TokenCleaner, error) {
+	logger := klog.FromContext(ctx)
 	e := &TokenCleaner{
 		client:               cl,
 		secretLister:         secrets.Lister(),

--- a/pkg/controller/bootstrap/tokencleaner_test.go
+++ b/pkg/controller/bootstrap/tokencleaner_test.go
@@ -29,14 +29,16 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
-func newTokenCleaner() (*TokenCleaner, *fake.Clientset, coreinformers.SecretInformer, error) {
+func newTokenCleaner(t *testing.T) (*TokenCleaner, *fake.Clientset, coreinformers.SecretInformer, error) {
+	tCtx := ktesting.Init(t)
 	options := DefaultTokenCleanerOptions()
 	cl := fake.NewSimpleClientset()
 	informerFactory := informers.NewSharedInformerFactory(cl, options.SecretResync)
 	secrets := informerFactory.Core().V1().Secrets()
-	tcc, err := NewTokenCleaner(cl, secrets, options)
+	tcc, err := NewTokenCleaner(tCtx.Logger(), cl, secrets, options)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -44,7 +46,7 @@ func newTokenCleaner() (*TokenCleaner, *fake.Clientset, coreinformers.SecretInfo
 }
 
 func TestCleanerNoExpiration(t *testing.T) {
-	cleaner, cl, secrets, err := newTokenCleaner()
+	cleaner, cl, secrets, err := newTokenCleaner(t)
 	if err != nil {
 		t.Fatalf("error creating TokenCleaner: %v", err)
 	}
@@ -60,7 +62,7 @@ func TestCleanerNoExpiration(t *testing.T) {
 }
 
 func TestCleanerExpired(t *testing.T) {
-	cleaner, cl, secrets, err := newTokenCleaner()
+	cleaner, cl, secrets, err := newTokenCleaner(t)
 	if err != nil {
 		t.Fatalf("error creating TokenCleaner: %v", err)
 	}
@@ -85,7 +87,7 @@ func TestCleanerExpired(t *testing.T) {
 }
 
 func TestCleanerNotExpired(t *testing.T) {
-	cleaner, cl, secrets, err := newTokenCleaner()
+	cleaner, cl, secrets, err := newTokenCleaner(t)
 	if err != nil {
 		t.Fatalf("error creating TokenCleaner: %v", err)
 	}
@@ -102,7 +104,7 @@ func TestCleanerNotExpired(t *testing.T) {
 }
 
 func TestCleanerExpiredAt(t *testing.T) {
-	cleaner, cl, secrets, err := newTokenCleaner()
+	cleaner, cl, secrets, err := newTokenCleaner(t)
 	if err != nil {
 		t.Fatalf("error creating TokenCleaner: %v", err)
 	}

--- a/pkg/controller/bootstrap/tokencleaner_test.go
+++ b/pkg/controller/bootstrap/tokencleaner_test.go
@@ -38,7 +38,7 @@ func newTokenCleaner(t *testing.T) (*TokenCleaner, *fake.Clientset, coreinformer
 	cl := fake.NewSimpleClientset()
 	informerFactory := informers.NewSharedInformerFactory(cl, options.SecretResync)
 	secrets := informerFactory.Core().V1().Secrets()
-	tcc, err := NewTokenCleaner(tCtx.Logger(), cl, secrets, options)
+	tcc, err := NewTokenCleaner(tCtx, cl, secrets, options)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/controller/certificates/certificate_controller.go
+++ b/pkg/controller/certificates/certificate_controller.go
@@ -71,14 +71,15 @@ func NewCertificateController(
 				&workqueue.TypedBucketRateLimiter[string]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
 			),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "certificate",
+				Logger: &logger,
+				Name:   "certificate",
 			},
 		),
 		handler: handler,
 	}
 
 	// Manage the addition/update of certificate requests
-	csrInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = csrInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			csr := obj.(*certificates.CertificateSigningRequest)
 			logger.V(4).Info("Adding certificate request", "csr", csr.Name)
@@ -106,7 +107,7 @@ func NewCertificateController(
 			logger.V(4).Info("Deleting certificate request", "csr", csr.Name)
 			cc.enqueueCertificateRequest(obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	cc.csrLister = csrInformer.Lister()
 	cc.csrsSynced = csrInformer.Informer().HasSynced
 	return cc
@@ -114,7 +115,7 @@ func NewCertificateController(
 
 // Run the main goroutine responsible for watching and syncing jobs.
 func (cc *CertificateController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting certificate controller", "name", cc.name)

--- a/pkg/controller/certificates/certificate_controller_test.go
+++ b/pkg/controller/certificates/certificate_controller_test.go
@@ -66,8 +66,8 @@ func TestCertificateController(t *testing.T) {
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	informerFactory.Start(stopCh)
-	informerFactory.WaitForCacheSync(stopCh)
+	informerFactory.StartWithContext(ctx)
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 	wait.PollUntil(10*time.Millisecond, func() (bool, error) {
 		return controller.queue.Len() >= 1, nil
 	}, stopCh)

--- a/pkg/controller/certificates/cleaner/cleaner.go
+++ b/pkg/controller/certificates/cleaner/cleaner.go
@@ -77,7 +77,7 @@ func NewCSRCleanerController(
 
 // Run the main goroutine responsible for watching and syncing jobs.
 func (ccc *CSRCleanerController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting CSR cleaner controller")

--- a/pkg/controller/certificates/cleaner/pcrcleaner.go
+++ b/pkg/controller/certificates/cleaner/pcrcleaner.go
@@ -63,7 +63,7 @@ func NewPCRCleanerController(
 }
 
 func (c *PCRCleanerController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting PodCertificateRequest cleaner controller")

--- a/pkg/controller/certificates/clustertrustbundlepublisher/publisher.go
+++ b/pkg/controller/certificates/clustertrustbundlepublisher/publisher.go
@@ -197,6 +197,7 @@ func (f caContentListener) Enqueue() {
 // NewBetaClusterTrustBundlePublisher sets up a ClusterTrustBundlePublisher for the
 // v1 API
 func NewGAClusterTrustBundlePublisher(
+	logger klog.Logger,
 	signerName string,
 	caProvider dynamiccertificates.CAContentProvider,
 	kubeClient clientset.Interface,
@@ -210,6 +211,7 @@ func NewGAClusterTrustBundlePublisher(
 		})
 
 	return newClusterTrustBundlePublisher(
+		logger,
 		signerName,
 		caProvider,
 		kubeClient.CertificatesV1().ClusterTrustBundles(),
@@ -222,6 +224,7 @@ func NewGAClusterTrustBundlePublisher(
 // NewBetaClusterTrustBundlePublisher sets up a ClusterTrustBundlePublisher for the
 // v1beta1 API
 func NewBetaClusterTrustBundlePublisher(
+	logger klog.Logger,
 	signerName string,
 	caProvider dynamiccertificates.CAContentProvider,
 	kubeClient clientset.Interface,
@@ -236,6 +239,7 @@ func NewBetaClusterTrustBundlePublisher(
 		})
 
 	return newClusterTrustBundlePublisher(
+		logger,
 		signerName,
 		caProvider,
 		kubeClient.CertificatesV1beta1().ClusterTrustBundles(),
@@ -248,6 +252,7 @@ func NewBetaClusterTrustBundlePublisher(
 // NewAlphaClusterTrustBundlePublisher sets up a ClusterTrustBundlePublisher for the
 // v1alpha1 API
 func NewAlphaClusterTrustBundlePublisher(
+	logger klog.Logger,
 	signerName string,
 	caProvider dynamiccertificates.CAContentProvider,
 	kubeClient clientset.Interface,
@@ -262,6 +267,7 @@ func NewAlphaClusterTrustBundlePublisher(
 		})
 
 	return newClusterTrustBundlePublisher(
+		logger,
 		signerName,
 		caProvider,
 		kubeClient.CertificatesV1alpha1().ClusterTrustBundles(),
@@ -275,6 +281,7 @@ func NewAlphaClusterTrustBundlePublisher(
 // for a signer named `signerName`. The cluster trust bundle object contains the
 // CA from the `caProvider` in its .spec.TrustBundle.
 func newClusterTrustBundlePublisher[T clusterTrustBundle](
+	logger klog.Logger,
 	signerName string,
 	caProvider dynamiccertificates.CAContentProvider,
 	bundleClient clusterTrustBundlesClient[T],
@@ -300,12 +307,13 @@ func newClusterTrustBundlePublisher[T clusterTrustBundle](
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "ca_cert_publisher_cluster_trust_bundles",
+				Logger: &logger,
+				Name:   "ca_cert_publisher_cluster_trust_bundles",
 			},
 		),
 	}
 
-	_, err := p.ctbInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := p.ctbInformer.AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			p.queue.Add("")
 		},
@@ -315,7 +323,7 @@ func newClusterTrustBundlePublisher[T clusterTrustBundle](
 		DeleteFunc: func(_ interface{}) {
 			p.queue.Add("")
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		return nil, fmt.Errorf("failed to register ClusterTrustBundle event handler: %w", err)
 	}
@@ -331,7 +339,7 @@ func (p *ClusterTrustBundlePublisher[T]) caContentChangedListener() dynamiccerti
 }
 
 func (p *ClusterTrustBundlePublisher[T]) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting ClusterTrustBundle CA cert publisher controller")

--- a/pkg/controller/certificates/clustertrustbundlepublisher/publisher_test.go
+++ b/pkg/controller/certificates/clustertrustbundlepublisher/publisher_test.go
@@ -260,11 +260,11 @@ func TestCTBPublisherSync(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			testCtx := ktesting.Init(t)
+			tCtx := ktesting.Init(t)
 
 			fakeClient := fakeKubeClientSetWithCTBList(t, testSignerName, tt.existingCTBs...)
 
-			p, err := NewGAClusterTrustBundlePublisher(testSignerName, testCAProvider, fakeClient)
+			p, err := NewGAClusterTrustBundlePublisher(tCtx.Logger(), testSignerName, testCAProvider, fakeClient)
 			if err != nil {
 				t.Fatalf("failed to set up a new cluster trust bundle publisher: %v", err)
 			}
@@ -274,12 +274,12 @@ func TestCTBPublisherSync(t *testing.T) {
 				t.Fatalf("failed to assert the controller for the beta API")
 			}
 
-			go controller.ctbInformer.RunWithContext(testCtx)
-			if !cache.WaitForCacheSync(testCtx.Done(), controller.ctbInformer.HasSynced) {
+			go controller.ctbInformer.RunWithContext(tCtx)
+			if !cache.WaitForCacheSync(tCtx.Done(), controller.ctbInformer.HasSynced) {
 				t.Fatal("timed out waiting for informer to sync")
 			}
 
-			if err := controller.syncClusterTrustBundle(testCtx); (err != nil) != tt.wantErr {
+			if err := controller.syncClusterTrustBundle(tCtx); (err != nil) != tt.wantErr {
 				t.Errorf("syncClusterTrustBundle() error = %v, wantErr %v", err, tt.wantErr)
 			}
 

--- a/pkg/controller/certificates/rootcacertpublisher/publisher.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher.go
@@ -52,29 +52,30 @@ func init() {
 // NewPublisher construct a new controller which would manage the configmap
 // which stores certificates in each namespace. It will make sure certificate
 // configmap exists in each namespace.
-func NewPublisher(cmInformer coreinformers.ConfigMapInformer, nsInformer coreinformers.NamespaceInformer, cl clientset.Interface, rootCA []byte) (*Publisher, error) {
+func NewPublisher(logger klog.Logger, cmInformer coreinformers.ConfigMapInformer, nsInformer coreinformers.NamespaceInformer, cl clientset.Interface, rootCA []byte) (*Publisher, error) {
 	e := &Publisher{
 		client: cl,
 		rootCA: rootCA,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "root_ca_cert_publisher",
+				Logger: &logger,
+				Name:   "root_ca_cert_publisher",
 			},
 		),
 	}
 
-	cmInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = cmInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: e.configMapDeleted,
 		UpdateFunc: e.configMapUpdated,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	e.cmLister = cmInformer.Lister()
 	e.cmListerSynced = cmInformer.Informer().HasSynced
 
-	nsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = nsInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    e.namespaceAdded,
 		UpdateFunc: e.namespaceUpdated,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	e.nsListerSynced = nsInformer.Informer().HasSynced
 
 	e.syncHandler = e.syncNamespace
@@ -101,7 +102,7 @@ type Publisher struct {
 
 // Run starts process
 func (c *Publisher) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting root CA cert publisher controller")

--- a/pkg/controller/certificates/rootcacertpublisher/publisher.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher.go
@@ -52,7 +52,8 @@ func init() {
 // NewPublisher construct a new controller which would manage the configmap
 // which stores certificates in each namespace. It will make sure certificate
 // configmap exists in each namespace.
-func NewPublisher(logger klog.Logger, cmInformer coreinformers.ConfigMapInformer, nsInformer coreinformers.NamespaceInformer, cl clientset.Interface, rootCA []byte) (*Publisher, error) {
+func NewPublisher(ctx context.Context, cmInformer coreinformers.ConfigMapInformer, nsInformer coreinformers.NamespaceInformer, cl clientset.Interface, rootCA []byte) (*Publisher, error) {
+	logger := klog.FromContext(ctx)
 	e := &Publisher{
 		client: cl,
 		rootCA: rootCA,

--- a/pkg/controller/certificates/rootcacertpublisher/publisher_test.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher_test.go
@@ -31,6 +31,7 @@ import (
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func TestConfigMapCreation(t *testing.T) {
@@ -122,11 +123,12 @@ func TestConfigMapCreation(t *testing.T) {
 
 	for k, tc := range testcases {
 		t.Run(k, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
 			client := fake.NewSimpleClientset(caConfigMap, existNS)
 			informers := informers.NewSharedInformerFactory(fake.NewSimpleClientset(), controller.NoResyncPeriodFunc())
 			cmInformer := informers.Core().V1().ConfigMaps()
 			nsInformer := informers.Core().V1().Namespaces()
-			controller, err := NewPublisher(cmInformer, nsInformer, client, fakeRootCA)
+			controller, err := NewPublisher(tCtx.Logger(), cmInformer, nsInformer, client, fakeRootCA)
 			if err != nil {
 				t.Fatalf("error creating ServiceAccounts controller: %v", err)
 			}
@@ -155,9 +157,8 @@ func TestConfigMapCreation(t *testing.T) {
 				cmStore.Add(tc.UpdatedConfigMap)
 				controller.configMapUpdated(nil, tc.UpdatedConfigMap)
 			}
-			ctx := context.TODO()
 			for controller.queue.Len() != 0 {
-				controller.processNextWorkItem(ctx)
+				controller.processNextWorkItem(tCtx)
 			}
 
 			actions := client.Actions()

--- a/pkg/controller/certificates/rootcacertpublisher/publisher_test.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher_test.go
@@ -128,7 +128,7 @@ func TestConfigMapCreation(t *testing.T) {
 			informers := informers.NewSharedInformerFactory(fake.NewSimpleClientset(), controller.NoResyncPeriodFunc())
 			cmInformer := informers.Core().V1().ConfigMaps()
 			nsInformer := informers.Core().V1().Namespaces()
-			controller, err := NewPublisher(tCtx.Logger(), cmInformer, nsInformer, client, fakeRootCA)
+			controller, err := NewPublisher(tCtx, cmInformer, nsInformer, client, fakeRootCA)
 			if err != nil {
 				t.Fatalf("error creating ServiceAccounts controller: %v", err)
 			}

--- a/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
+++ b/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
@@ -53,7 +53,7 @@ type ClusterRoleAggregationController struct {
 }
 
 // NewClusterRoleAggregation creates a new controller
-func NewClusterRoleAggregation(clusterRoleInformer rbacinformers.ClusterRoleInformer, clusterRoleClient rbacclient.ClusterRolesGetter) *ClusterRoleAggregationController {
+func NewClusterRoleAggregation(logger klog.Logger, clusterRoleInformer rbacinformers.ClusterRoleInformer, clusterRoleClient rbacclient.ClusterRolesGetter) *ClusterRoleAggregationController {
 	c := &ClusterRoleAggregationController{
 		clusterRoleClient:  clusterRoleClient,
 		clusterRoleLister:  clusterRoleInformer.Lister(),
@@ -62,13 +62,14 @@ func NewClusterRoleAggregation(clusterRoleInformer rbacinformers.ClusterRoleInfo
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "ClusterRoleAggregator",
+				Logger: &logger,
+				Name:   "ClusterRoleAggregator",
 			},
 		),
 	}
 	c.syncHandler = c.syncClusterRole
 
-	clusterRoleInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = clusterRoleInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			c.enqueue()
 		},
@@ -78,7 +79,7 @@ func NewClusterRoleAggregation(clusterRoleInformer rbacinformers.ClusterRoleInfo
 		DeleteFunc: func(uncast interface{}) {
 			c.enqueue()
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	return c
 }
 
@@ -170,7 +171,7 @@ func ruleExists(haystack []rbacv1.PolicyRule, needle rbacv1.PolicyRule) bool {
 
 // Run starts the controller and blocks until stopCh is closed.
 func (c *ClusterRoleAggregationController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting ClusterRoleAggregator controller")

--- a/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
+++ b/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
@@ -53,7 +53,8 @@ type ClusterRoleAggregationController struct {
 }
 
 // NewClusterRoleAggregation creates a new controller
-func NewClusterRoleAggregation(logger klog.Logger, clusterRoleInformer rbacinformers.ClusterRoleInformer, clusterRoleClient rbacclient.ClusterRolesGetter) *ClusterRoleAggregationController {
+func NewClusterRoleAggregation(ctx context.Context, clusterRoleInformer rbacinformers.ClusterRoleInformer, clusterRoleClient rbacclient.ClusterRolesGetter) *ClusterRoleAggregationController {
+	logger := klog.FromContext(ctx)
 	c := &ClusterRoleAggregationController{
 		clusterRoleClient:  clusterRoleClient,
 		clusterRoleLister:  clusterRoleInformer.Lister(),

--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -94,7 +94,8 @@ func NewControllerV2(ctx context.Context, jobInformer batchv1informers.JobInform
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "cronjob",
+				Logger: &logger,
+				Name:   "cronjob",
 			},
 		),
 		kubeClient:  kubeClient,
@@ -114,13 +115,13 @@ func NewControllerV2(ctx context.Context, jobInformer batchv1informers.JobInform
 		now: time.Now,
 	}
 
-	jobInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = jobInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    jm.addJob,
 		UpdateFunc: jm.updateJob,
 		DeleteFunc: jm.deleteJob,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 
-	cronJobsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = cronJobsInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			jm.enqueueController(obj)
 		},
@@ -130,7 +131,7 @@ func NewControllerV2(ctx context.Context, jobInformer batchv1informers.JobInform
 		DeleteFunc: func(obj interface{}) {
 			jm.enqueueController(obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 
 	err := jobInformer.Informer().AddIndexers(cache.Indexers{
 		jobControllerUIDIndex: func(obj interface{}) ([]string, error) {
@@ -155,7 +156,7 @@ func NewControllerV2(ctx context.Context, jobInformer batchv1informers.JobInform
 
 // Run starts the main goroutine responsible for watching and syncing jobs.
 func (jm *ControllerV2) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start event processing pipeline.
 	jm.broadcaster.StartStructuredLogging(3)

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -209,19 +209,21 @@ func NewDaemonSetsController(
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "daemonset",
+				Logger: &logger,
+				Name:   "daemonset",
 			},
 		),
 		nodeUpdateQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "daemonset-node-updates",
+				Logger: &logger,
+				Name:   "daemonset-node-updates",
 			},
 		),
 		consistencyStore: consistencyStore,
 	}
 
-	daemonSetInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = daemonSetInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			dsc.addDaemonset(logger, obj)
 		},
@@ -231,11 +233,11 @@ func NewDaemonSetsController(
 		DeleteFunc: func(obj interface{}) {
 			dsc.deleteDaemonset(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	dsc.dsLister = daemonSetInformer.Lister()
 	dsc.dsStoreSynced = daemonSetInformer.Informer().HasSynced
 
-	historyInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = historyInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			dsc.addHistory(logger, obj)
 		},
@@ -245,14 +247,14 @@ func NewDaemonSetsController(
 		DeleteFunc: func(obj interface{}) {
 			dsc.deleteHistory(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	dsc.historyLister = historyInformer.Lister()
 	dsc.historyStoreSynced = historyInformer.Informer().HasSynced
 
 	// Watch for creation/deletion of pods. The reason we watch is that we don't want a daemon set to create/delete
 	// more pods until all the effects (expectations) of a daemon set's create/delete have been observed.
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			dsc.addPod(logger, obj)
 		},
@@ -262,14 +264,14 @@ func NewDaemonSetsController(
 		DeleteFunc: func(obj interface{}) {
 			dsc.deletePod(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	dsc.podLister = podInformer.Lister()
 	dsc.podStoreSynced = podInformer.Informer().HasSynced
 	controller.AddPodNodeNameIndexer(podInformer.Informer())
 	controller.AddPodControllerIndexer(podInformer.Informer())
 	dsc.podIndexer = podInformer.Informer().GetIndexer()
 
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = nodeInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			dsc.addNode(logger, obj)
 		},
@@ -277,6 +279,7 @@ func NewDaemonSetsController(
 			dsc.updateNode(logger, oldObj, newObj)
 		},
 	},
+		cache.HandlerOptions{Logger: &logger},
 	)
 	dsc.nodeStoreSynced = nodeInformer.Informer().HasSynced
 	dsc.nodeLister = nodeInformer.Lister()
@@ -354,7 +357,7 @@ func (dsc *DaemonSetsController) deleteDaemonset(logger klog.Logger, obj interfa
 
 // Run begins watching and syncing daemon sets.
 func (dsc *DaemonSetsController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	dsc.eventBroadcaster.StartStructuredLogging(3)
 	dsc.eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: dsc.kubeClient.CoreV1().Events("")})

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -552,8 +552,8 @@ func TestExpectationsOnRecreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f.Start(ctx.Done())
-	for ty, ok := range f.WaitForCacheSync(ctx.Done()) {
+	f.StartWithContext(ctx)
+	for ty, ok := range f.WaitForCacheSyncWithContext(ctx).Synced {
 		if !ok {
 			t.Fatalf("caches failed to sync: %v", ty)
 		}

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -111,7 +111,8 @@ func NewDeploymentController(ctx context.Context, dInformer appsinformers.Deploy
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "deployment",
+				Logger: &logger,
+				Name:   "deployment",
 			},
 		),
 	}
@@ -120,7 +121,7 @@ func NewDeploymentController(ctx context.Context, dInformer appsinformers.Deploy
 		Recorder:   dc.eventRecorder,
 	}
 
-	dInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = dInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			dc.addDeployment(logger, obj)
 		},
@@ -131,8 +132,8 @@ func NewDeploymentController(ctx context.Context, dInformer appsinformers.Deploy
 		DeleteFunc: func(obj interface{}) {
 			dc.deleteDeployment(logger, obj)
 		},
-	})
-	rsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	}, cache.HandlerOptions{Logger: &logger})
+	_, _ = rsInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			dc.addReplicaSet(logger, obj)
 		},
@@ -142,12 +143,12 @@ func NewDeploymentController(ctx context.Context, dInformer appsinformers.Deploy
 		DeleteFunc: func(obj interface{}) {
 			dc.deleteReplicaSet(logger, obj)
 		},
-	})
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	}, cache.HandlerOptions{Logger: &logger})
+	_, _ = podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: func(obj interface{}) {
 			dc.deletePod(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 
 	dc.syncHandler = dc.syncDeployment
 	dc.enqueueDeployment = dc.enqueue
@@ -169,7 +170,7 @@ func NewDeploymentController(ctx context.Context, dInformer appsinformers.Deploy
 
 // Run begins watching and syncing.
 func (dc *DeploymentController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	dc.eventBroadcaster.StartStructuredLogging(3)

--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -221,7 +221,7 @@ func (f *fixture) run_(ctx context.Context, deploymentName string, startInformer
 	if startInformers {
 		stopCh := make(chan struct{})
 		defer close(stopCh)
-		informers.Start(stopCh)
+		informers.StartWithContext(ctx)
 	}
 
 	err = c.syncDeployment(ctx, deploymentName)
@@ -497,7 +497,7 @@ func TestGetReplicaSetsForDeployment(t *testing.T) {
 	}
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	informers.Start(stopCh)
+	informers.StartWithContext(ctx)
 
 	rsList, err := c.getReplicaSetsForDeployment(ctx, d1)
 	if err != nil {
@@ -549,7 +549,7 @@ func TestGetReplicaSetsForDeploymentAdoptRelease(t *testing.T) {
 	}
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	informers.Start(stopCh)
+	informers.StartWithContext(ctx)
 
 	rsList, err := c.getReplicaSetsForDeployment(ctx, d)
 	if err != nil {
@@ -598,7 +598,7 @@ func TestGetPodMapForReplicaSets(t *testing.T) {
 	}
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	informers.Start(stopCh)
+	informers.StartWithContext(ctx)
 
 	podMap, err := c.getPodMapForDeployment(d, f.rsLister)
 	if err != nil {
@@ -1003,7 +1003,7 @@ func BenchmarkGetPodMapForDeployment(b *testing.B) {
 			}
 			stopCh := make(chan struct{})
 			defer close(stopCh)
-			informers.Start(stopCh)
+			informers.StartWithContext(ctx)
 
 			b.ReportAllocs()
 			b.ResetTimer()

--- a/pkg/controller/deployment/sync_test.go
+++ b/pkg/controller/deployment/sync_test.go
@@ -431,8 +431,8 @@ func TestDeploymentController_cleanupDeployment(t *testing.T) {
 
 		stopCh := make(chan struct{})
 		defer close(stopCh)
-		informers.Start(stopCh)
-		informers.WaitForCacheSync(stopCh)
+		informers.StartWithContext(ctx)
+		informers.WaitForCacheSyncWithContext(ctx)
 
 		t.Logf(" &test.revisionHistoryLimit: %d", test.revisionHistoryLimit)
 		d := newDeployment("foo", 1, &test.revisionHistoryLimit, nil, nil, map[string]string{"foo": "bar"})
@@ -567,7 +567,7 @@ func TestDeploymentController_cleanupDeploymentOrder(t *testing.T) {
 
 		stopCh := make(chan struct{})
 		defer close(stopCh)
-		informers.Start(stopCh)
+		informers.StartWithContext(ctx)
 
 		d := newDeployment("foo", 1, &test.revisionHistoryLimit, nil, nil, map[string]string{"foo": "bar"})
 		controller.cleanupDeployment(ctx, test.oldRSs, d)
@@ -635,7 +635,7 @@ func TestDeploymentController_generateReplicaSetName(t *testing.T) {
 
 		stopCh := make(chan struct{})
 		defer close(stopCh)
-		informers.Start(stopCh)
+		informers.StartWithContext(ctx)
 
 		d := newDeployment(test.deploymentName, 1, nil, nil, nil, map[string]string{"foo": "bar"})
 

--- a/pkg/controller/devicetainteviction/device_taint_eviction.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction.go
@@ -780,7 +780,7 @@ func newWithFeatures(c clientset.Interface, podInformer coreinformers.PodInforme
 // Run starts the controller which will run until the context is done.
 // An error is returned for startup problems.
 func (tc *Controller) Run(ctx context.Context, numWorkers int) error {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting", "controller", tc.name, "numWorkers", numWorkers)
 	defer logger.Info("Shut down controller", "controller", tc.name, "reason", context.Cause(ctx))
@@ -810,6 +810,7 @@ func (tc *Controller) Run(ctx context.Context, numWorkers int) error {
 	tc.workqueue = workqueue.NewTypedRateLimitingQueueWithConfig(
 		workqueue.DefaultTypedControllerRateLimiter[workItem](),
 		workqueue.TypedRateLimitingQueueConfig[workItem]{
+			Logger:        &logger,
 			Name:          tc.name,
 			DelayingQueue: delayingQueue,
 		},

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -183,6 +183,7 @@ func NewDisruptionControllerInternal(ctx context.Context,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
 				DelayingQueue: workqueue.NewTypedDelayingQueueWithConfig(workqueue.TypedDelayingQueueConfig[string]{
 					Logger: &logger,
 					Clock:  clock,
@@ -198,6 +199,7 @@ func NewDisruptionControllerInternal(ctx context.Context,
 		stalePodDisruptionQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
 				DelayingQueue: workqueue.NewTypedDelayingQueueWithConfig(workqueue.TypedDelayingQueueConfig[string]{
 					Logger: &logger,
 					Clock:  clock,
@@ -212,7 +214,7 @@ func NewDisruptionControllerInternal(ctx context.Context,
 
 	dc.getUpdater = func() updater { return dc.writePdbStatus }
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			dc.addPod(logger, obj)
 		},
@@ -222,11 +224,11 @@ func NewDisruptionControllerInternal(ctx context.Context,
 		DeleteFunc: func(obj interface{}) {
 			dc.deletePod(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	dc.podLister = podInformer.Lister()
 	dc.podListerSynced = podInformer.Informer().HasSynced
 
-	pdbInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = pdbInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			dc.addDB(logger, obj)
 		},
@@ -236,7 +238,7 @@ func NewDisruptionControllerInternal(ctx context.Context,
 		DeleteFunc: func(obj interface{}) {
 			dc.removeDB(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	dc.pdbLister = pdbInformer.Lister()
 	dc.pdbListerSynced = pdbInformer.Informer().HasSynced
 
@@ -445,7 +447,7 @@ func verifyGroupKind(controllerRef *metav1.OwnerReference, expectedKind string, 
 }
 
 func (dc *DisruptionController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	// Start events processing pipeline.

--- a/pkg/controller/disruption/disruption_test.go
+++ b/pkg/controller/disruption/disruption_test.go
@@ -188,8 +188,8 @@ func newFakeDisruptionControllerWithTime(ctx context.Context, now time.Time) (*d
 	dc.dListerSynced = alwaysReady
 	dc.ssListerSynced = alwaysReady
 	dc.recorder = record.NewFakeRecorder(100)
-	informerFactory.Start(ctx.Done())
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.StartWithContext(ctx)
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 
 	return &disruptionController{
 		dc,

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -79,6 +79,7 @@ const (
 // NewEndpointController returns a new *Controller.
 func NewEndpointController(ctx context.Context, podInformer coreinformers.PodInformer, serviceInformer coreinformers.ServiceInformer,
 	endpointsInformer coreinformers.EndpointsInformer, client clientset.Interface, endpointUpdatesBatchPeriod time.Duration) *Controller {
+	logger := klog.FromContext(ctx)
 	broadcaster := record.NewBroadcaster(record.WithContext(ctx))
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: ControllerName})
 
@@ -87,34 +88,40 @@ func NewEndpointController(ctx context.Context, podInformer coreinformers.PodInf
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "endpoint",
+				Logger: &logger,
+				Name:   "endpoint",
 			},
 		),
-		podQueue:         workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[*endpointsliceutil.PodProjectionKey]()),
+		podQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[*endpointsliceutil.PodProjectionKey](),
+			workqueue.TypedRateLimitingQueueConfig[*endpointsliceutil.PodProjectionKey]{
+				Logger: &logger,
+			},
+		),
 		workerLoopPeriod: time.Second,
 	}
 
-	serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = serviceInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: e.onServiceUpdate,
 		UpdateFunc: func(old, cur interface{}) {
 			e.onServiceUpdate(cur)
 		},
 		DeleteFunc: e.onServiceDelete,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	e.serviceLister = serviceInformer.Lister()
 	e.servicesSynced = serviceInformer.Informer().HasSynced
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj interface{}) { e.onPodUpdate(nil, obj) },
 		UpdateFunc: e.onPodUpdate,
 		DeleteFunc: func(obj interface{}) { e.onPodUpdate(obj, nil) },
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	e.podLister = podInformer.Lister()
 	e.podsSynced = podInformer.Informer().HasSynced
 
-	endpointsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = endpointsInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: e.onEndpointsDelete,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	e.endpointsLister = endpointsInformer.Lister()
 	e.endpointsSynced = endpointsInformer.Informer().HasSynced
 
@@ -182,7 +189,7 @@ type Controller struct {
 // Run will not return until stopCh is closed. workers determines how many
 // endpoints will be handled in parallel.
 func (e *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	e.eventBroadcaster.StartStructuredLogging(3)

--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -88,6 +88,7 @@ func NewController(ctx context.Context, podInformer coreinformers.PodInformer,
 	client clientset.Interface,
 	endpointUpdatesBatchPeriod time.Duration,
 ) *Controller {
+	logger := klog.FromContext(ctx)
 	broadcaster := record.NewBroadcaster(record.WithContext(ctx))
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "endpoint-slice-controller"})
 
@@ -109,43 +110,55 @@ func NewController(ctx context.Context, podInformer coreinformers.PodInformer,
 				&workqueue.TypedBucketRateLimiter[string]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
 			),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "endpoint_slice",
+				Logger: &logger,
+				Name:   "endpoint_slice",
 			},
 		),
-		podQueue:         workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[*endpointsliceutil.PodProjectionKey]()),
-		topologyQueue:    workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+		podQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[*endpointsliceutil.PodProjectionKey](),
+			workqueue.TypedRateLimitingQueueConfig[*endpointsliceutil.PodProjectionKey]{
+				Logger: &logger,
+				Name:   "endpoint_slice_pods",
+			},
+		),
+		topologyQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "endpoint_slice_topology",
+			},
+		),
 		workerLoopPeriod: time.Second,
 	}
 
-	serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = serviceInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: c.onServiceUpdate,
 		UpdateFunc: func(old, cur interface{}) {
 			c.onServiceUpdate(cur)
 		},
 		DeleteFunc: c.onServiceDelete,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	c.serviceLister = serviceInformer.Lister()
 	c.servicesSynced = serviceInformer.Informer().HasSynced
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj interface{}) { c.onPodUpdate(nil, obj) },
 		UpdateFunc: c.onPodUpdate,
 		DeleteFunc: func(obj interface{}) { c.onPodUpdate(obj, nil) },
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	c.podLister = podInformer.Lister()
 	c.podsSynced = podInformer.Informer().HasSynced
 
 	c.nodeLister = nodeInformer.Lister()
 	c.nodesSynced = nodeInformer.Informer().HasSynced
 
-	logger := klog.FromContext(ctx)
-	endpointSliceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = endpointSliceInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: c.onEndpointSliceAdd,
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			c.onEndpointSliceUpdate(logger, oldObj, newObj)
 		},
 		DeleteFunc: c.onEndpointSliceDelete,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 
 	c.endpointSliceLister = endpointSliceInformer.Lister()
 	c.endpointSlicesSynced = endpointSliceInformer.Informer().HasSynced
@@ -160,7 +173,7 @@ func NewController(ctx context.Context, podInformer coreinformers.PodInformer,
 
 	c.endpointUpdatesBatchPeriod = endpointUpdatesBatchPeriod
 
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = nodeInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(_ interface{}) {
 			c.addNode()
 		},
@@ -170,7 +183,7 @@ func NewController(ctx context.Context, podInformer coreinformers.PodInformer,
 		DeleteFunc: func(_ interface{}) {
 			c.deleteNode()
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	c.topologyCache = topologycache.NewTopologyCache()
 
 	c.reconciler = endpointslicerec.NewReconciler(
@@ -266,7 +279,7 @@ type Controller struct {
 
 // Run will not return until stopCh is closed.
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	c.eventBroadcaster.StartLogging(klog.Infof)

--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
@@ -96,13 +96,14 @@ func NewController(ctx context.Context, endpointsInformer coreinformers.Endpoint
 			&workqueue.TypedBucketRateLimiter[string]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
 		),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "endpoint_slice_mirroring",
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "endpoint_slice_mirroring",
 			},
 		),
 		workerLoopPeriod: time.Second,
 	}
 
-	endpointsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = endpointsInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			c.onEndpointsAdd(logger, obj)
 		},
@@ -112,17 +113,17 @@ func NewController(ctx context.Context, endpointsInformer coreinformers.Endpoint
 		DeleteFunc: func(obj interface{}) {
 			c.onEndpointsDelete(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	c.endpointsLister = endpointsInformer.Lister()
 	c.endpointsSynced = endpointsInformer.Informer().HasSynced
 
-	endpointSliceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = endpointSliceInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: c.onEndpointSliceAdd,
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			c.onEndpointSliceUpdate(logger, oldObj, newObj)
 		},
 		DeleteFunc: c.onEndpointSliceDelete,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 
 	c.endpointSliceLister = endpointSliceInformer.Lister()
 	c.endpointSlicesSynced = endpointSliceInformer.Informer().HasSynced
@@ -130,11 +131,11 @@ func NewController(ctx context.Context, endpointsInformer coreinformers.Endpoint
 
 	c.serviceLister = serviceInformer.Lister()
 	c.servicesSynced = serviceInformer.Informer().HasSynced
-	serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = serviceInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onServiceAdd,
 		UpdateFunc: c.onServiceUpdate,
 		DeleteFunc: c.onServiceDelete,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 
 	c.maxEndpointsPerSubset = maxEndpointsPerSubset
 
@@ -215,7 +216,7 @@ type Controller struct {
 
 // Run will not return until stopCh is closed.
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	c.eventBroadcaster.StartLogging(klog.Infof)

--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -130,7 +130,7 @@ func (gc *GarbageCollector) resyncMonitors(logger klog.Logger, deletableResource
 
 // Run starts garbage collector workers.
 func (gc *GarbageCollector) Run(ctx context.Context, workers int, initialSyncTimeout time.Duration) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	gc.eventBroadcaster.StartStructuredLogging(3)

--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -47,9 +47,6 @@ import (
 	"k8s.io/kubernetes/pkg/controller/garbagecollector/metrics"
 )
 
-// ResourceResyncTime defines the resync period of the garbage collector's informers.
-const ResourceResyncTime time.Duration = 0
-
 // GarbageCollector runs reflectors to watch for changes of managed API
 // objects, funnels the results to a single-threaded dependencyGraphBuilder,
 // which builds a graph caching the dependencies among objects. Triggered by the

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -230,7 +230,7 @@ func setupGC(t *testing.T, config *restclient.Config) garbageCollector {
 		t.Fatal(err)
 	}
 	stop := make(chan struct{})
-	sharedInformers.Start(stop)
+	sharedInformers.StartWithContext(ctx)
 	return garbageCollector{gc, stop}
 }
 
@@ -541,12 +541,12 @@ func TestProcessEvent(t *testing.T) {
 
 		dependencyGraphBuilder := &GraphBuilder{
 			informersStarted: alwaysStarted,
-			graphChanges:     workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[*event]()),
+			graphChanges:     workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[*event]()), //nolint:logcheck // Intentionally testing old API here.
 			uidToNode: &concurrentUIDToNode{
 				uidToNodeLock: sync.RWMutex{},
 				uidToNode:     make(map[types.UID]*node),
 			},
-			attemptToDelete:  workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[*node]()),
+			attemptToDelete:  workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[*node]()), //nolint:logcheck // Intentionally testing old API here.
 			absentOwnerCache: NewReferenceCache(2),
 		}
 		for i := 0; i < len(scenario.events); i++ {

--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -133,7 +133,7 @@ type monitor struct {
 // Run is intended to be called in a goroutine. Multiple calls of this is an
 // error.
 func (m *monitor) Run() {
-	m.controller.Run(m.stopCh)
+	m.controller.RunWithContext(wait.ContextForChannel(m.stopCh))
 }
 
 type monitors map[schema.GroupVersionResource]*monitor
@@ -151,13 +151,15 @@ func NewDependencyGraphBuilder(
 	attemptToDelete := workqueue.NewTypedRateLimitingQueueWithConfig(
 		workqueue.DefaultTypedControllerRateLimiter[*node](),
 		workqueue.TypedRateLimitingQueueConfig[*node]{
-			Name: "garbage_collector_attempt_to_delete",
+			Logger: new(klog.FromContext(ctx)),
+			Name:   "garbage_collector_attempt_to_delete",
 		},
 	)
 	attemptToOrphan := workqueue.NewTypedRateLimitingQueueWithConfig(
 		workqueue.DefaultTypedControllerRateLimiter[*node](),
 		workqueue.TypedRateLimitingQueueConfig[*node]{
-			Name: "garbage_collector_attempt_to_orphan",
+			Logger: new(klog.FromContext(ctx)),
+			Name:   "garbage_collector_attempt_to_orphan",
 		},
 	)
 	absentOwnerCache := NewReferenceCache(500)
@@ -170,7 +172,8 @@ func NewDependencyGraphBuilder(
 		graphChanges: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[*event](),
 			workqueue.TypedRateLimitingQueueConfig[*event]{
-				Name: "garbage_collector_graph_changes",
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "garbage_collector_graph_changes",
 			},
 		),
 		uidToNode: &concurrentUIDToNode{
@@ -229,7 +232,13 @@ func (gb *GraphBuilder) controllerFor(logger klog.Logger, resource schema.GroupV
 	}
 	logger.V(4).Info("using a shared informer", "resource", resource, "kind", kind)
 	// need to clone because it's from a shared cache
-	shared.Informer().AddEventHandlerWithResyncPeriod(handlers, ResourceResyncTime)
+	resyncPeriod := ResourceResyncTime
+	if _, err := shared.Informer().AddEventHandlerWithOptions(handlers, cache.HandlerOptions{
+		Logger:       &logger,
+		ResyncPeriod: &resyncPeriod,
+	}); err != nil {
+		return nil, nil, err
+	}
 	return shared.Informer().GetController(), shared.Informer().GetStore(), nil
 }
 

--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -231,8 +231,7 @@ func (gb *GraphBuilder) controllerFor(logger klog.Logger, resource schema.GroupV
 		return nil, nil, err
 	}
 	logger.V(4).Info("using a shared informer", "resource", resource, "kind", kind)
-	// need to clone because it's from a shared cache
-	resyncPeriod := ResourceResyncTime
+	resyncPeriod := time.Duration(0)
 	if _, err := shared.Informer().AddEventHandlerWithOptions(handlers, cache.HandlerOptions{
 		Logger:       &logger,
 		ResyncPeriod: &resyncPeriod,

--- a/pkg/controller/history/controller_history_test.go
+++ b/pkg/controller/history/controller_history_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
 )
 
@@ -58,12 +59,13 @@ func TestRealHistory_ListControllerRevisions(t *testing.T) {
 
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 		for i := range test.revisions {
 			informer.Informer().GetIndexer().Add(test.revisions[i])
 		}
@@ -158,12 +160,13 @@ func TestFakeHistory_ListControllerRevisions(t *testing.T) {
 
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 		for i := range test.revisions {
 			informer.Informer().GetIndexer().Add(test.revisions[i])
 		}
@@ -260,12 +263,13 @@ func TestRealHistory_CreateControllerRevision(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 		history := NewHistory(client, informer.Lister(), informer.Informer().GetIndexer())
 
 		var collisionCount int32
@@ -395,12 +399,13 @@ func TestFakeHistory_CreateControllerRevision(t *testing.T) {
 
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 		history := NewFakeHistory(informer)
 
 		var collisionCount int32
@@ -548,12 +553,13 @@ func TestRealHistory_UpdateControllerRevision(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 		history := NewHistory(client, informer.Lister(), informer.Informer().GetIndexer())
 		var collisionCount int32
 		for i := range test.existing {
@@ -678,12 +684,13 @@ func TestFakeHistory_UpdateControllerRevision(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 		history := NewFakeHistory(informer)
 		var collisionCount int32
 		for i := range test.existing {
@@ -769,12 +776,13 @@ func TestRealHistory_DeleteControllerRevision(t *testing.T) {
 
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 		history := NewHistory(client, informer.Lister(), informer.Informer().GetIndexer())
 		var collisionCount int32
 		for i := range test.existing {
@@ -875,12 +883,13 @@ func TestFakeHistory_DeleteControllerRevision(t *testing.T) {
 
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 		history := NewFakeHistory(informer)
 		var collisionCount int32
 		for i := range test.existing {
@@ -1015,12 +1024,13 @@ func TestRealHistory_AdoptControllerRevision(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 
 		history := NewHistory(client, informer.Lister(), informer.Informer().GetIndexer())
 		var collisionCount int32
@@ -1124,12 +1134,13 @@ func TestFakeHistory_AdoptControllerRevision(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 
 		history := NewFakeHistory(informer)
 		var collisionCount int32
@@ -1272,12 +1283,13 @@ func TestRealHistory_ReleaseControllerRevision(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 
 		history := NewHistory(client, informer.Lister(), informer.Informer().GetIndexer())
 		var collisionCount int32
@@ -1397,12 +1409,13 @@ func TestFakeHistory_ReleaseControllerRevision(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 		history := NewFakeHistory(informer)
 		var collisionCount int32
 		for i := range test.existing {

--- a/pkg/controller/history/controller_history_test.go
+++ b/pkg/controller/history/controller_history_test.go
@@ -33,6 +33,7 @@ import (
 	core "k8s.io/client-go/testing"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/test/utils/ktesting"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -41,7 +42,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
 )
 
@@ -53,34 +53,32 @@ func TestRealHistory_ListControllerRevisions(t *testing.T) {
 		revisions []*apps.ControllerRevision
 		want      map[string]bool
 	}
-	testFn := func(test *testcase, t *testing.T) {
+	testFn := func(tCtx ktesting.TContext, test *testcase) {
 		client := fake.NewSimpleClientset()
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 
-		stop := make(chan struct{})
-		defer close(stop)
-		ctx := wait.ContextForChannel(stop)
-		informerFactory.StartWithContext(ctx)
+		informerFactory.StartWithContext(tCtx)
+		tCtx.Cleanup(func() {
+			informerFactory.Shutdown()
+		})
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
-			t.Fatalf("failed to add indexer: %v", err)
+			tCtx.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSyncWithContext(ctx)
+		informerFactory.WaitForCacheSyncWithContext(tCtx)
 		for i := range test.revisions {
 			informer.Informer().GetIndexer().Add(test.revisions[i])
 		}
 
 		history := NewHistory(client, informer.Lister(), informer.Informer().GetIndexer())
 		revisions, err := history.ListControllerRevisions(test.parent, parentKind, test.selector)
-		if err != nil {
-			t.Errorf("%s: %s", test.name, err)
-		}
+		tCtx.ExpectNoError(err, "list controller revisions")
 		got := make(map[string]bool)
 		for i := range revisions {
 			got[revisions[i].Name] = true
 		}
 		if !reflect.DeepEqual(test.want, got) {
-			t.Errorf("%s: want %v got %v", test.name, test.want, got)
+			tCtx.Errorf("want %v got %v", test.want, got)
 		}
 	}
 	ss1 := newStatefulSet(3, "ss1", types.UID("ss1"), map[string]string{"foo": "bar"})
@@ -142,7 +140,9 @@ func TestRealHistory_ListControllerRevisions(t *testing.T) {
 		},
 	}
 	for i := range tests {
-		testFn(&tests[i], t)
+		t.Run(tests[i].name, func(t *testing.T) {
+			testFn(ktesting.Init(t), &tests[i])
+		})
 	}
 }
 
@@ -154,19 +154,19 @@ func TestFakeHistory_ListControllerRevisions(t *testing.T) {
 		revisions []*apps.ControllerRevision
 		want      map[string]bool
 	}
-	testFn := func(test *testcase, t *testing.T) {
+	testFn := func(tCtx ktesting.TContext, test *testcase) {
 		client := fake.NewSimpleClientset()
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 
-		stop := make(chan struct{})
-		defer close(stop)
-		ctx := wait.ContextForChannel(stop)
-		informerFactory.StartWithContext(ctx)
+		informerFactory.StartWithContext(tCtx)
+		tCtx.Cleanup(func() {
+			informerFactory.Shutdown()
+		})
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
-			t.Fatalf("failed to add indexer: %v", err)
+			tCtx.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSyncWithContext(ctx)
+		informerFactory.WaitForCacheSyncWithContext(tCtx)
 		for i := range test.revisions {
 			informer.Informer().GetIndexer().Add(test.revisions[i])
 		}
@@ -174,14 +174,14 @@ func TestFakeHistory_ListControllerRevisions(t *testing.T) {
 		history := NewFakeHistory(informer)
 		revisions, err := history.ListControllerRevisions(test.parent, parentKind, test.selector)
 		if err != nil {
-			t.Errorf("%s: %s", test.name, err)
+			tCtx.Errorf("%s", err)
 		}
 		got := make(map[string]bool)
 		for i := range revisions {
 			got[revisions[i].Name] = true
 		}
 		if !reflect.DeepEqual(test.want, got) {
-			t.Errorf("%s: want %v got %v", test.name, test.want, got)
+			tCtx.Errorf("want %v got %v", test.want, got)
 		}
 	}
 	ss1 := newStatefulSet(3, "ss1", types.UID("ss1"), map[string]string{"foo": "bar"})
@@ -243,7 +243,9 @@ func TestFakeHistory_ListControllerRevisions(t *testing.T) {
 		},
 	}
 	for i := range tests {
-		testFn(&tests[i], t)
+		t.Run(tests[i].name, func(t *testing.T) {
+			testFn(ktesting.Init(t), &tests[i])
+		})
 	}
 }
 
@@ -258,54 +260,54 @@ func TestRealHistory_CreateControllerRevision(t *testing.T) {
 		}
 		rename bool
 	}
-	testFn := func(test *testcase, t *testing.T) {
+	testFn := func(tCtx ktesting.TContext, test *testcase) {
 		client := fake.NewSimpleClientset()
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
-		stop := make(chan struct{})
-		defer close(stop)
-		ctx := wait.ContextForChannel(stop)
-		informerFactory.StartWithContext(ctx)
+		informerFactory.StartWithContext(tCtx)
+		tCtx.Cleanup(func() {
+			informerFactory.Shutdown()
+		})
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
-			t.Fatalf("failed to add indexer: %v", err)
+			tCtx.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSyncWithContext(ctx)
+		informerFactory.WaitForCacheSyncWithContext(tCtx)
 		history := NewHistory(client, informer.Lister(), informer.Informer().GetIndexer())
 
 		var collisionCount int32
 		for _, item := range test.existing {
 			_, err := client.AppsV1().ControllerRevisions(item.parent.GetNamespace()).Create(context.TODO(), item.revision, metav1.CreateOptions{})
 			if err != nil {
-				t.Fatal(err)
+				tCtx.Fatal(err)
 			}
 		}
 		// Clear collisionCount before creating the test revision
 		collisionCount = 0
 		created, err := history.CreateControllerRevision(test.parent, test.revision, &collisionCount)
 		if err != nil {
-			t.Errorf("%s: %s", test.name, err)
+			tCtx.Errorf("%s", err)
 		}
 
 		if test.rename {
 			if created.Name == test.revision.Name {
-				t.Errorf("%s: wanted rename got %s %s", test.name, created.Name, test.revision.Name)
+				tCtx.Errorf("wanted rename got %s %s", created.Name, test.revision.Name)
 			}
 			expectedName := ControllerRevisionName(test.parent.GetName(), HashControllerRevision(test.revision, &collisionCount))
 			if created.Name != expectedName {
-				t.Errorf("%s: on name collision wanted new name %s got %s", test.name, expectedName, created.Name)
+				tCtx.Errorf("on name collision wanted new name %s got %s", expectedName, created.Name)
 			}
 
 			// Second name collision will be caused by an identical revision, so no need to do anything
 			_, err = history.CreateControllerRevision(test.parent, test.revision, &collisionCount)
 			if err != nil {
-				t.Errorf("%s: %s", test.name, err)
+				tCtx.Errorf("%s", err)
 			}
 			if collisionCount != 1 {
-				t.Errorf("%s: on second name collision wanted collisionCount 1 got %d", test.name, collisionCount)
+				tCtx.Errorf("on second name collision wanted collisionCount 1 got %d", collisionCount)
 			}
 		}
 		if !test.rename && created.Name != test.revision.Name {
-			t.Errorf("%s: wanted %s got %s", test.name, test.revision.Name, created.Name)
+			tCtx.Errorf("wanted %s got %s", test.revision.Name, created.Name)
 		}
 	}
 	ss1 := newStatefulSet(3, "ss1", types.UID("ss1"), map[string]string{"foo": "bar"})
@@ -378,7 +380,9 @@ func TestRealHistory_CreateControllerRevision(t *testing.T) {
 		},
 	}
 	for i := range tests {
-		testFn(&tests[i], t)
+		t.Run(tests[i].name, func(t *testing.T) {
+			testFn(ktesting.Init(t), &tests[i])
+		})
 	}
 }
 
@@ -393,55 +397,55 @@ func TestFakeHistory_CreateControllerRevision(t *testing.T) {
 		}
 		rename bool
 	}
-	testFn := func(test *testcase, t *testing.T) {
+	testFn := func(tCtx ktesting.TContext, test *testcase) {
 		client := fake.NewSimpleClientset()
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 
-		stop := make(chan struct{})
-		defer close(stop)
-		ctx := wait.ContextForChannel(stop)
-		informerFactory.StartWithContext(ctx)
+		informerFactory.StartWithContext(tCtx)
+		tCtx.Cleanup(func() {
+			informerFactory.Shutdown()
+		})
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
-			t.Fatalf("failed to add indexer: %v", err)
+			tCtx.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSyncWithContext(ctx)
+		informerFactory.WaitForCacheSyncWithContext(tCtx)
 		history := NewFakeHistory(informer)
 
 		var collisionCount int32
 		for i := range test.existing {
 			_, err := history.CreateControllerRevision(test.existing[i].parent, test.existing[i].revision, &collisionCount)
 			if err != nil {
-				t.Fatal(err)
+				tCtx.Fatal(err)
 			}
 		}
 		// Clear collisionCount before creating the test revision
 		collisionCount = 0
 		created, err := history.CreateControllerRevision(test.parent, test.revision, &collisionCount)
 		if err != nil {
-			t.Errorf("%s: %s", test.name, err)
+			tCtx.Errorf("%s", err)
 		}
 
 		if test.rename {
 			if created.Name == test.revision.Name {
-				t.Errorf("%s: wanted rename got %s %s", test.name, created.Name, test.revision.Name)
+				tCtx.Errorf("wanted rename got %s %s", created.Name, test.revision.Name)
 			}
 			expectedName := ControllerRevisionName(test.parent.GetName(), HashControllerRevision(test.revision, &collisionCount))
 			if created.Name != expectedName {
-				t.Errorf("%s: on name collision wanted new name %s got %s", test.name, expectedName, created.Name)
+				tCtx.Errorf("on name collision wanted new name %s got %s", expectedName, created.Name)
 			}
 
 			// Second name collision should have incremented collisionCount to 2
 			_, err = history.CreateControllerRevision(test.parent, test.revision, &collisionCount)
 			if err != nil {
-				t.Errorf("%s: %s", test.name, err)
+				tCtx.Errorf("%s", err)
 			}
 			if collisionCount != 2 {
-				t.Errorf("%s: on second name collision wanted collisionCount 1 got %d", test.name, collisionCount)
+				tCtx.Errorf("on second name collision wanted collisionCount 1 got %d", collisionCount)
 			}
 		}
 		if !test.rename && created.Name != test.revision.Name {
-			t.Errorf("%s: wanted %s got %s", test.name, test.revision.Name, created.Name)
+			tCtx.Errorf("wanted %s got %s", test.revision.Name, created.Name)
 		}
 	}
 	ss1 := newStatefulSet(3, "ss1", types.UID("ss1"), map[string]string{"foo": "bar"})
@@ -505,7 +509,9 @@ func TestFakeHistory_CreateControllerRevision(t *testing.T) {
 		},
 	}
 	for i := range tests {
-		testFn(&tests[i], t)
+		t.Run(tests[i].name, func(t *testing.T) {
+			testFn(ktesting.Init(t), &tests[i])
+		})
 	}
 }
 
@@ -547,25 +553,25 @@ func TestRealHistory_UpdateControllerRevision(t *testing.T) {
 		}
 	}
 
-	testFn := func(test *testcase, t *testing.T) {
+	testFn := func(tCtx ktesting.TContext, test *testcase) {
 		client := fake.NewSimpleClientset()
 
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
-		stop := make(chan struct{})
-		defer close(stop)
-		ctx := wait.ContextForChannel(stop)
-		informerFactory.StartWithContext(ctx)
+		informerFactory.StartWithContext(tCtx)
+		tCtx.Cleanup(func() {
+			informerFactory.Shutdown()
+		})
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
-			t.Fatalf("failed to add indexer: %v", err)
+			tCtx.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSyncWithContext(ctx)
+		informerFactory.WaitForCacheSyncWithContext(tCtx)
 		history := NewHistory(client, informer.Lister(), informer.Informer().GetIndexer())
 		var collisionCount int32
 		for i := range test.existing {
 			_, err := history.CreateControllerRevision(test.existing[i].parent, test.existing[i].revision, &collisionCount)
 			if err != nil {
-				t.Fatal(err)
+				tCtx.Fatal(err)
 			}
 		}
 		if test.reactor != nil {
@@ -573,13 +579,13 @@ func TestRealHistory_UpdateControllerRevision(t *testing.T) {
 		}
 		updated, err := history.UpdateControllerRevision(test.revision, test.newRevision)
 		if !test.err && err != nil {
-			t.Errorf("%s: %s", test.name, err)
+			tCtx.Errorf("%s", err)
 		}
 		if !test.err && updated.Revision != test.newRevision {
-			t.Errorf("%s: got %d want %d", test.name, updated.Revision, test.newRevision)
+			tCtx.Errorf("got %d want %d", updated.Revision, test.newRevision)
 		}
 		if test.err && err == nil {
-			t.Errorf("%s: expected error", test.name)
+			tCtx.Errorf("expected error")
 		}
 	}
 	ss1 := newStatefulSet(3, "ss1", types.UID("ss1"), map[string]string{"foo": "bar"})
@@ -662,7 +668,9 @@ func TestRealHistory_UpdateControllerRevision(t *testing.T) {
 	}
 	for i := range tests {
 		conflictAttempts = 0
-		testFn(&tests[i], t)
+		t.Run(tests[i].name, func(t *testing.T) {
+			testFn(ktesting.Init(t), &tests[i])
+		})
 	}
 }
 
@@ -678,36 +686,36 @@ func TestFakeHistory_UpdateControllerRevision(t *testing.T) {
 		err bool
 	}
 
-	testFn := func(test *testcase, t *testing.T) {
+	testFn := func(tCtx ktesting.TContext, test *testcase) {
 		client := fake.NewSimpleClientset()
 
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
-		stop := make(chan struct{})
-		defer close(stop)
-		ctx := wait.ContextForChannel(stop)
-		informerFactory.StartWithContext(ctx)
+		informerFactory.StartWithContext(tCtx)
+		tCtx.Cleanup(func() {
+			informerFactory.Shutdown()
+		})
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
-			t.Fatalf("failed to add indexer: %v", err)
+			tCtx.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSyncWithContext(ctx)
+		informerFactory.WaitForCacheSyncWithContext(tCtx)
 		history := NewFakeHistory(informer)
 		var collisionCount int32
 		for i := range test.existing {
 			_, err := history.CreateControllerRevision(test.existing[i].parent, test.existing[i].revision, &collisionCount)
 			if err != nil {
-				t.Fatal(err)
+				tCtx.Fatal(err)
 			}
 		}
 		updated, err := history.UpdateControllerRevision(test.revision, test.newRevision)
 		if !test.err && err != nil {
-			t.Errorf("%s: %s", test.name, err)
+			tCtx.Errorf("%s", err)
 		}
 		if !test.err && updated.Revision != test.newRevision {
-			t.Errorf("%s: got %d want %d", test.name, updated.Revision, test.newRevision)
+			tCtx.Errorf("got %d want %d", updated.Revision, test.newRevision)
 		}
 		if test.err && err == nil {
-			t.Errorf("%s: expected error", test.name)
+			tCtx.Errorf("expected error")
 		}
 	}
 	ss1 := newStatefulSet(3, "ss1", types.UID("ss1"), map[string]string{"foo": "bar"})
@@ -756,7 +764,9 @@ func TestFakeHistory_UpdateControllerRevision(t *testing.T) {
 		},
 	}
 	for i := range tests {
-		testFn(&tests[i], t)
+		t.Run(tests[i].name, func(t *testing.T) {
+			testFn(ktesting.Init(t), &tests[i])
+		})
 	}
 }
 
@@ -770,33 +780,33 @@ func TestRealHistory_DeleteControllerRevision(t *testing.T) {
 		}
 		err bool
 	}
-	testFn := func(test *testcase, t *testing.T) {
+	testFn := func(tCtx ktesting.TContext, test *testcase) {
 		client := fake.NewSimpleClientset()
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 
-		stop := make(chan struct{})
-		defer close(stop)
-		ctx := wait.ContextForChannel(stop)
-		informerFactory.StartWithContext(ctx)
+		informerFactory.StartWithContext(tCtx)
+		tCtx.Cleanup(func() {
+			informerFactory.Shutdown()
+		})
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
-			t.Fatalf("failed to add indexer: %v", err)
+			tCtx.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSyncWithContext(ctx)
+		informerFactory.WaitForCacheSyncWithContext(tCtx)
 		history := NewHistory(client, informer.Lister(), informer.Informer().GetIndexer())
 		var collisionCount int32
 		for i := range test.existing {
 			_, err := history.CreateControllerRevision(test.existing[i].parent, test.existing[i].revision, &collisionCount)
 			if err != nil {
-				t.Fatal(err)
+				tCtx.Fatal(err)
 			}
 		}
 		err := history.DeleteControllerRevision(test.revision)
 		if !test.err && err != nil {
-			t.Errorf("%s: %s", test.name, err)
+			tCtx.Errorf("%s", err)
 		}
 		if test.err && err == nil {
-			t.Errorf("%s: expected error", test.name)
+			tCtx.Errorf("expected error")
 		}
 	}
 	ss1 := newStatefulSet(3, "ss1", types.UID("ss1"), map[string]string{"foo": "bar"})
@@ -863,7 +873,9 @@ func TestRealHistory_DeleteControllerRevision(t *testing.T) {
 		},
 	}
 	for i := range tests {
-		testFn(&tests[i], t)
+		t.Run(tests[i].name, func(t *testing.T) {
+			testFn(ktesting.Init(t), &tests[i])
+		})
 	}
 }
 
@@ -877,33 +889,33 @@ func TestFakeHistory_DeleteControllerRevision(t *testing.T) {
 		}
 		err bool
 	}
-	testFn := func(test *testcase, t *testing.T) {
+	testFn := func(tCtx ktesting.TContext, test *testcase) {
 		client := fake.NewSimpleClientset()
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 
-		stop := make(chan struct{})
-		defer close(stop)
-		ctx := wait.ContextForChannel(stop)
-		informerFactory.StartWithContext(ctx)
+		informerFactory.StartWithContext(tCtx)
+		tCtx.Cleanup(func() {
+			informerFactory.Shutdown()
+		})
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
-			t.Fatalf("failed to add indexer: %v", err)
+			tCtx.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSyncWithContext(ctx)
+		informerFactory.WaitForCacheSyncWithContext(tCtx)
 		history := NewFakeHistory(informer)
 		var collisionCount int32
 		for i := range test.existing {
 			_, err := history.CreateControllerRevision(test.existing[i].parent, test.existing[i].revision, &collisionCount)
 			if err != nil {
-				t.Fatal(err)
+				tCtx.Fatal(err)
 			}
 		}
 		err := history.DeleteControllerRevision(test.revision)
 		if !test.err && err != nil {
-			t.Errorf("%s: %s", test.name, err)
+			tCtx.Errorf("%s", err)
 		}
 		if test.err && err == nil {
-			t.Errorf("%s: expected error", test.name)
+			tCtx.Errorf("expected error")
 		}
 	}
 	ss1 := newStatefulSet(3, "ss1", types.UID("ss1"), map[string]string{"foo": "bar"})
@@ -970,7 +982,9 @@ func TestFakeHistory_DeleteControllerRevision(t *testing.T) {
 		},
 	}
 	for i := range tests {
-		testFn(&tests[i], t)
+		t.Run(tests[i].name, func(t *testing.T) {
+			testFn(ktesting.Init(t), &tests[i])
+		})
 	}
 }
 
@@ -985,7 +999,7 @@ func TestRealHistory_AdoptControllerRevision(t *testing.T) {
 		}
 		err bool
 	}
-	testFn := func(test *testcase, t *testing.T) {
+	testFn := func(tCtx ktesting.TContext, test *testcase) {
 		client := fake.NewSimpleClientset()
 		client.AddReactor("*", "*", func(action core.Action) (bool, runtime.Object, error) {
 			switch action := action.(type) {
@@ -1022,33 +1036,33 @@ func TestRealHistory_AdoptControllerRevision(t *testing.T) {
 
 		})
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
-		stop := make(chan struct{})
-		defer close(stop)
-		ctx := wait.ContextForChannel(stop)
-		informerFactory.StartWithContext(ctx)
+		informerFactory.StartWithContext(tCtx)
+		tCtx.Cleanup(func() {
+			informerFactory.Shutdown()
+		})
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
-			t.Fatalf("failed to add indexer: %v", err)
+			tCtx.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSyncWithContext(ctx)
+		informerFactory.WaitForCacheSyncWithContext(tCtx)
 
 		history := NewHistory(client, informer.Lister(), informer.Informer().GetIndexer())
 		var collisionCount int32
 		for i := range test.existing {
 			_, err := history.CreateControllerRevision(test.existing[i].parent, test.existing[i].revision, &collisionCount)
 			if err != nil {
-				t.Fatal(err)
+				tCtx.Fatal(err)
 			}
 		}
 		adopted, err := history.AdoptControllerRevision(test.parent, parentKind, test.revision)
 		if !test.err && err != nil {
-			t.Errorf("%s: %s", test.name, err)
+			tCtx.Errorf("%s", err)
 		}
 		if !test.err && !metav1.IsControlledBy(adopted, test.parent) {
-			t.Errorf("%s: adoption failed", test.name)
+			tCtx.Errorf("adoption failed")
 		}
 		if test.err && err == nil {
-			t.Errorf("%s: expected error", test.name)
+			tCtx.Errorf("expected error")
 		}
 	}
 
@@ -1112,7 +1126,9 @@ func TestRealHistory_AdoptControllerRevision(t *testing.T) {
 		},
 	}
 	for i := range tests {
-		testFn(&tests[i], t)
+		t.Run(tests[i].name, func(t *testing.T) {
+			testFn(ktesting.Init(t), &tests[i])
+		})
 	}
 }
 
@@ -1128,37 +1144,37 @@ func TestFakeHistory_AdoptControllerRevision(t *testing.T) {
 		}
 		err bool
 	}
-	testFn := func(test *testcase, t *testing.T) {
+	testFn := func(tCtx ktesting.TContext, test *testcase) {
 		client := fake.NewSimpleClientset()
 
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
-		stop := make(chan struct{})
-		defer close(stop)
-		ctx := wait.ContextForChannel(stop)
-		informerFactory.StartWithContext(ctx)
+		informerFactory.StartWithContext(tCtx)
+		tCtx.Cleanup(func() {
+			informerFactory.Shutdown()
+		})
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
-			t.Fatalf("failed to add indexer: %v", err)
+			tCtx.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSyncWithContext(ctx)
+		informerFactory.WaitForCacheSyncWithContext(tCtx)
 
 		history := NewFakeHistory(informer)
 		var collisionCount int32
 		for i := range test.existing {
 			_, err := history.CreateControllerRevision(test.existing[i].parent, test.existing[i].revision, &collisionCount)
 			if err != nil {
-				t.Fatal(err)
+				tCtx.Fatal(err)
 			}
 		}
 		adopted, err := history.AdoptControllerRevision(test.parent, parentKind, test.revision)
 		if !test.err && err != nil {
-			t.Errorf("%s: %s", test.name, err)
+			tCtx.Errorf("%s", err)
 		}
 		if !test.err && !metav1.IsControlledBy(adopted, test.parent) {
-			t.Errorf("%s: adoption failed", test.name)
+			tCtx.Errorf("adoption failed")
 		}
 		if test.err && err == nil {
-			t.Errorf("%s: expected error", test.name)
+			tCtx.Errorf("expected error")
 		}
 	}
 
@@ -1225,7 +1241,9 @@ func TestFakeHistory_AdoptControllerRevision(t *testing.T) {
 		},
 	}
 	for i := range tests {
-		testFn(&tests[i], t)
+		t.Run(tests[i].name, func(t *testing.T) {
+			testFn(ktesting.Init(t), &tests[i])
+		})
 	}
 }
 
@@ -1240,7 +1258,7 @@ func TestRealHistory_ReleaseControllerRevision(t *testing.T) {
 		}
 		err bool
 	}
-	testFn := func(test *testcase, t *testing.T) {
+	testFn := func(tCtx ktesting.TContext, test *testcase) {
 		client := fake.NewSimpleClientset()
 		client.AddReactor("*", "*", func(action core.Action) (bool, runtime.Object, error) {
 			switch action := action.(type) {
@@ -1281,38 +1299,38 @@ func TestRealHistory_ReleaseControllerRevision(t *testing.T) {
 
 		})
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
-		stop := make(chan struct{})
-		defer close(stop)
-		ctx := wait.ContextForChannel(stop)
-		informerFactory.StartWithContext(ctx)
+		informerFactory.StartWithContext(tCtx)
+		tCtx.Cleanup(func() {
+			informerFactory.Shutdown()
+		})
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
-			t.Fatalf("failed to add indexer: %v", err)
+			tCtx.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSyncWithContext(ctx)
+		informerFactory.WaitForCacheSyncWithContext(tCtx)
 
 		history := NewHistory(client, informer.Lister(), informer.Informer().GetIndexer())
 		var collisionCount int32
 		for i := range test.existing {
 			_, err := history.CreateControllerRevision(test.existing[i].parent, test.existing[i].revision, &collisionCount)
 			if err != nil {
-				t.Fatal(err)
+				tCtx.Fatal(err)
 			}
 		}
 		adopted, err := history.ReleaseControllerRevision(test.parent, test.revision)
 		if !test.err {
 			if err != nil {
-				t.Errorf("%s: %s", test.name, err)
+				tCtx.Errorf("%s", err)
 			}
 			if adopted == nil {
 				return
 			}
 			if metav1.IsControlledBy(adopted, test.parent) {
-				t.Errorf("%s: release failed", test.name)
+				tCtx.Errorf("release failed")
 			}
 		}
 		if test.err && err == nil {
-			t.Errorf("%s: expected error", test.name)
+			tCtx.Errorf("expected error")
 		}
 	}
 
@@ -1389,7 +1407,9 @@ func TestRealHistory_ReleaseControllerRevision(t *testing.T) {
 		},
 	}
 	for i := range tests {
-		testFn(&tests[i], t)
+		t.Run(tests[i].name, func(t *testing.T) {
+			testFn(ktesting.Init(t), &tests[i])
+		})
 	}
 }
 
@@ -1404,40 +1424,40 @@ func TestFakeHistory_ReleaseControllerRevision(t *testing.T) {
 		}
 		err bool
 	}
-	testFn := func(test *testcase, t *testing.T) {
+	testFn := func(tCtx ktesting.TContext, test *testcase) {
 		client := fake.NewSimpleClientset()
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
-		stop := make(chan struct{})
-		defer close(stop)
-		ctx := wait.ContextForChannel(stop)
-		informerFactory.StartWithContext(ctx)
+		informerFactory.StartWithContext(tCtx)
+		tCtx.Cleanup(func() {
+			informerFactory.Shutdown()
+		})
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
-			t.Fatalf("failed to add indexer: %v", err)
+			tCtx.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSyncWithContext(ctx)
+		informerFactory.WaitForCacheSyncWithContext(tCtx)
 		history := NewFakeHistory(informer)
 		var collisionCount int32
 		for i := range test.existing {
 			_, err := history.CreateControllerRevision(test.existing[i].parent, test.existing[i].revision, &collisionCount)
 			if err != nil {
-				t.Fatal(err)
+				tCtx.Fatal(err)
 			}
 		}
 		adopted, err := history.ReleaseControllerRevision(test.parent, test.revision)
 		if !test.err {
 			if err != nil {
-				t.Errorf("%s: %s", test.name, err)
+				tCtx.Errorf("%s", err)
 			}
 			if adopted == nil {
 				return
 			}
 			if metav1.IsControlledBy(adopted, test.parent) {
-				t.Errorf("%s: release failed", test.name)
+				tCtx.Errorf("release failed")
 			}
 		}
 		if test.err && err == nil {
-			t.Errorf("%s: expected error", test.name)
+			tCtx.Errorf("expected error")
 		}
 	}
 
@@ -1516,7 +1536,9 @@ func TestFakeHistory_ReleaseControllerRevision(t *testing.T) {
 		},
 	}
 	for i := range tests {
-		testFn(&tests[i], t)
+		t.Run(tests[i].name, func(t *testing.T) {
+			testFn(ktesting.Init(t), &tests[i])
+		})
 	}
 }
 
@@ -1527,14 +1549,14 @@ func TestFindEqualRevisions(t *testing.T) {
 		revisions []*apps.ControllerRevision
 		want      map[string]bool
 	}
-	testFn := func(test *testcase, t *testing.T) {
+	testFn := func(tCtx ktesting.TContext, test *testcase) {
 		found := FindEqualRevisions(test.revisions, test.revision)
 		if len(found) != len(test.want) {
-			t.Errorf("%s: want %d revisions found %d", test.name, len(test.want), len(found))
+			tCtx.Errorf("want %d revisions found %d", len(test.want), len(found))
 		}
 		for i := range found {
 			if !test.want[found[i].Name] {
-				t.Errorf("%s: wanted %s not found", test.name, found[i].Name)
+				tCtx.Errorf("wanted %s not found", found[i].Name)
 			}
 
 		}
@@ -1585,7 +1607,9 @@ func TestFindEqualRevisions(t *testing.T) {
 		},
 	}
 	for i := range tests {
-		testFn(&tests[i], t)
+		t.Run(tests[i].name, func(t *testing.T) {
+			testFn(ktesting.Init(t), &tests[i])
+		})
 	}
 }
 
@@ -1595,15 +1619,13 @@ func TestSortControllerRevisions(t *testing.T) {
 		revisions []*apps.ControllerRevision
 		want      []string
 	}
-	testFn := func(test *testcase, t *testing.T) {
-		t.Run(test.name, func(t *testing.T) {
-			SortControllerRevisions(test.revisions)
-			for i := range test.revisions {
-				if test.revisions[i].Name != test.want[i] {
-					t.Errorf("%s: want %s at %d got %s", test.name, test.want[i], i, test.revisions[i].Name)
-				}
+	testFn := func(tCtx ktesting.TContext, test *testcase) {
+		SortControllerRevisions(test.revisions)
+		for i := range test.revisions {
+			if test.revisions[i].Name != test.want[i] {
+				tCtx.Errorf("want %s at %d got %s", test.want[i], i, test.revisions[i].Name)
 			}
-		})
+		}
 	}
 	ss1 := newStatefulSet(3, "ss1", types.UID("ss1"), map[string]string{"foo": "bar"})
 	ss1.Status.CollisionCount = new(int32)
@@ -1667,7 +1689,9 @@ func TestSortControllerRevisions(t *testing.T) {
 		},
 	}
 	for i := range tests {
-		testFn(&tests[i], t)
+		t.Run(tests[i].name, func(t *testing.T) {
+			testFn(ktesting.Init(t), &tests[i])
+		})
 	}
 }
 

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -257,10 +257,18 @@ func newControllerWithClock(ctx context.Context, kubeClient clientset.Interface,
 			Recorder:   eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "job-controller"}),
 			OnWrite:    podWriteCallback,
 		},
-		expectations:            controller.NewControllerExpectations(),
-		finalizerExpectations:   newUIDTrackingExpectations(),
-		queue:                   workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.NewTypedItemExponentialFailureRateLimiter[string](DefaultJobApiBackOff, MaxJobApiBackOff), workqueue.TypedRateLimitingQueueConfig[string]{Name: "job", Clock: clock}),
-		orphanQueue:             workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.NewTypedItemExponentialFailureRateLimiter[orphanPodKey](DefaultJobApiBackOff, MaxJobApiBackOff), workqueue.TypedRateLimitingQueueConfig[orphanPodKey]{Name: "job_orphan_pod", Clock: clock}),
+		expectations:          controller.NewControllerExpectations(),
+		finalizerExpectations: newUIDTrackingExpectations(),
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.NewTypedItemExponentialFailureRateLimiter[string](DefaultJobApiBackOff, MaxJobApiBackOff), workqueue.TypedRateLimitingQueueConfig[string]{
+			Logger: new(klog.FromContext(ctx)),
+			Name:   "job",
+			Clock:  clock,
+		}),
+		orphanQueue: workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.NewTypedItemExponentialFailureRateLimiter[orphanPodKey](DefaultJobApiBackOff, MaxJobApiBackOff), workqueue.TypedRateLimitingQueueConfig[orphanPodKey]{
+			Logger: new(klog.FromContext(ctx)),
+			Name:   "job_orphan_pod",
+			Clock:  clock,
+		}),
 		broadcaster:             eventBroadcaster,
 		recorder:                eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "job-controller"}),
 		clock:                   clock,
@@ -269,7 +277,7 @@ func newControllerWithClock(ctx context.Context, kubeClient clientset.Interface,
 		consistencyStore:        consistencyStore,
 	}
 
-	if _, err := jobInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	if _, err := jobInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			jm.addJob(logger, obj)
 		},
@@ -279,13 +287,13 @@ func newControllerWithClock(ctx context.Context, kubeClient clientset.Interface,
 		DeleteFunc: func(obj interface{}) {
 			jm.deleteJob(logger, obj)
 		},
-	}); err != nil {
+	}, cache.HandlerOptions{Logger: &logger}); err != nil {
 		return nil, fmt.Errorf("adding Job event handler: %w", err)
 	}
 	jm.jobLister = jobInformer.Lister()
 	jm.jobStoreSynced = jobInformer.Informer().HasSynced
 
-	if _, err := podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	if _, err := podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			jm.addPod(logger, obj)
 		},
@@ -295,7 +303,7 @@ func newControllerWithClock(ctx context.Context, kubeClient clientset.Interface,
 		DeleteFunc: func(obj interface{}) {
 			jm.deletePod(logger, obj, true)
 		},
-	}); err != nil {
+	}, cache.HandlerOptions{Logger: &logger}); err != nil {
 		return nil, fmt.Errorf("adding Pod event handler: %w", err)
 	}
 	jm.podStore = podInformer.Lister()
@@ -323,7 +331,7 @@ func newControllerWithClock(ctx context.Context, kubeClient clientset.Interface,
 
 // Run the main goroutine responsible for watching and syncing jobs.
 func (jm *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	jm.broadcaster.StartStructuredLogging(3)

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -2726,8 +2726,8 @@ func TestPastDeadlineJobFinished(t *testing.T) {
 		controller.NewControllerExpectations(), true, func() {
 		},
 	}
-	sharedInformerFactory.Start(ctx.Done())
-	sharedInformerFactory.WaitForCacheSync(ctx.Done())
+	sharedInformerFactory.StartWithContext(ctx)
+	sharedInformerFactory.WaitForCacheSyncWithContext(ctx)
 
 	go manager.Run(ctx, 1)
 
@@ -6132,8 +6132,8 @@ func TestWatchJobs(t *testing.T) {
 	}
 	// Start only the job watcher and the workqueue, send a watch event,
 	// and make sure it hits the sync method.
-	sharedInformerFactory.Start(ctx.Done())
-	sharedInformerFactory.WaitForCacheSync(ctx.Done())
+	sharedInformerFactory.StartWithContext(ctx)
+	sharedInformerFactory.WaitForCacheSyncWithContext(ctx)
 	go manager.Run(ctx, 1)
 
 	// We're sending new job to see if it reaches syncHandler.
@@ -7196,8 +7196,8 @@ func TestFinalizerCleanup(t *testing.T) {
 	manager.jobStoreSynced = alwaysReady
 
 	// Start the Pod and Job informers.
-	sharedInformers.Start(ctx.Done())
-	sharedInformers.WaitForCacheSync(ctx.Done())
+	sharedInformers.StartWithContext(ctx)
+	sharedInformers.WaitForCacheSyncWithContext(ctx)
 	// Initialize the controller with 1 worker to make sure the
 	// pod finalizers are removed by the "syncJob" function.
 	go manager.Run(ctx, 1)
@@ -7590,8 +7590,8 @@ func TestSyncJobPodSchedulingGroup(t *testing.T) {
 				return job, nil
 			}
 
-			sharedInformers.Start(ctx.Done())
-			sharedInformers.WaitForCacheSync(ctx.Done())
+			sharedInformers.StartWithContext(ctx)
+			sharedInformers.WaitForCacheSyncWithContext(ctx)
 
 			if err := sharedInformers.Batch().V1().Jobs().Informer().GetIndexer().Add(tc.job); err != nil {
 				t.Fatalf("Failed to insert job in index: %v", err)

--- a/pkg/controller/job/job_scheduling_manager_test.go
+++ b/pkg/controller/job/job_scheduling_manager_test.go
@@ -816,8 +816,8 @@ func TestEnsureWorkloadAndPodGroup(t *testing.T) {
 				})
 			}
 
-			sharedInformers.Start(ctx.Done())
-			sharedInformers.WaitForCacheSync(ctx.Done())
+			sharedInformers.StartWithContext(ctx)
+			sharedInformers.WaitForCacheSyncWithContext(ctx)
 
 			_, pg, err := jm.ensureWorkloadAndPodGroup(ctx, tc.job, tc.pods)
 			if tc.wantErr {

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -71,20 +71,22 @@ func NewNamespaceController(
 	namespaceInformer coreinformers.NamespaceInformer,
 	resyncPeriod time.Duration,
 	finalizerToken v1.FinalizerName) *NamespaceController {
+	logger := klog.FromContext(ctx)
 
 	// create the controller so we can inject the enqueue function
 	namespaceController := &NamespaceController{
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			nsControllerRateLimiter(),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "namespace",
+				Logger: &logger,
+				Name:   "namespace",
 			},
 		),
 		namespacedResourcesDeleter: deletion.NewNamespacedResourcesDeleter(ctx, kubeClient.CoreV1().Namespaces(), metadataClient, kubeClient.CoreV1(), discoverResourcesFn, finalizerToken),
 	}
 
 	// configure the namespace informer event handlers
-	namespaceInformer.Informer().AddEventHandlerWithResyncPeriod(
+	_, _ = namespaceInformer.Informer().AddEventHandlerWithOptions(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				namespace := obj.(*v1.Namespace)
@@ -95,7 +97,7 @@ func NewNamespaceController(
 				namespaceController.enqueueNamespace(ctx, namespace)
 			},
 		},
-		resyncPeriod,
+		cache.HandlerOptions{Logger: &logger, ResyncPeriod: &resyncPeriod},
 	)
 	namespaceController.lister = namespaceInformer.Lister()
 	namespaceController.listerSynced = namespaceInformer.Informer().HasSynced

--- a/pkg/controller/nodeipam/ipam/range_allocator.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator.go
@@ -59,7 +59,7 @@ type rangeAllocator struct {
 
 	// queues are where incoming work is placed to de-dup and to allow "easy"
 	// rate limited requeues on errors
-	queue workqueue.RateLimitingInterface
+	queue workqueue.TypedRateLimitingInterface[string]
 }
 
 var _ CIDRAllocator = &rangeAllocator{}
@@ -98,7 +98,13 @@ func NewCIDRRangeAllocator(ctx context.Context, client clientset.Interface, node
 		nodesSynced:  nodeInformer.Informer().HasSynced,
 		broadcaster:  eventBroadcaster,
 		recorder:     recorder,
-		queue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "cidrallocator_node"),
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "cidrallocator_node",
+			},
+		),
 	}
 
 	if allocatorParams.ServiceCIDR != nil {
@@ -130,7 +136,7 @@ func NewCIDRRangeAllocator(ctx context.Context, client clientset.Interface, node
 		}
 	}
 
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = nodeInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			key, err := cache.MetaNamespaceKeyFunc(obj)
 			if err == nil {
@@ -163,7 +169,7 @@ func NewCIDRRangeAllocator(ctx context.Context, client clientset.Interface, node
 				utilruntime.HandleErrorWithContext(ctx, err, "Error while processing CIDR Release")
 			}
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 
 	return ra, nil
 }
@@ -210,35 +216,20 @@ func (r *rangeAllocator) runWorker(ctx context.Context) {
 // processNextWorkItem will read a single work item off the queue and
 // attempt to process it, by calling the syncHandler.
 func (r *rangeAllocator) processNextNodeWorkItem(ctx context.Context) bool {
-	obj, shutdown := r.queue.Get()
+	key, shutdown := r.queue.Get()
 	if shutdown {
 		return false
 	}
 
 	// We wrap this block in a func so we can defer r.queue.Done.
-	err := func(logger klog.Logger, obj interface{}) error {
+	err := func(logger klog.Logger, key string) error {
 		// We call Done here so the workNodeQueue knows we have finished
 		// processing this item. We also must remember to call Forget if we
 		// do not want this work item being re-queued. For example, we do
 		// not call Forget if a transient error occurs, instead the item is
 		// put back on the queue and attempted again after a back-off
 		// period.
-		defer r.queue.Done(obj)
-		var key string
-		var ok bool
-		// We expect strings to come off the workNodeQueue. These are of the
-		// form namespace/name. We do this as the delayed nature of the
-		// workNodeQueue means the items in the informer cache may actually be
-		// more up to date that when the item was initially put onto the
-		// workNodeQueue.
-		if key, ok = obj.(string); !ok {
-			// As the item in the workNodeQueue is actually invalid, we call
-			// Forget here else we'd go into a loop of attempting to
-			// process a work item that is invalid.
-			r.queue.Forget(obj)
-			utilruntime.HandleErrorWithContext(ctx, nil, "Expected string but got unexpected type in work node queue", "type", fmt.Sprintf("%T", obj))
-			return nil
-		}
+		defer r.queue.Done(key)
 		// Run the syncHandler, passing it the namespace/name string of the
 		// Foo resource to be synced.
 		if err := r.syncNode(ctx, key); err != nil {
@@ -248,10 +239,10 @@ func (r *rangeAllocator) processNextNodeWorkItem(ctx context.Context) bool {
 		}
 		// Finally, if no error occurs we Forget this item so it does not
 		// get queue again until another change happens.
-		r.queue.Forget(obj)
+		r.queue.Forget(key)
 		logger.V(4).Info("Successfully synced", "key", key)
 		return nil
-	}(klog.FromContext(ctx), obj)
+	}(klog.FromContext(ctx), key)
 
 	if err != nil {
 		utilruntime.HandleErrorWithContext(ctx, err, "Error processing node work item")

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -357,7 +357,8 @@ func NewNodeLifecycleController(
 		podUpdateQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[podUpdateItem](),
 			workqueue.TypedRateLimitingQueueConfig[podUpdateItem]{
-				Name: "node_lifecycle_controller_pods",
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "node_lifecycle_controller_pods",
 			},
 		),
 	}
@@ -366,7 +367,7 @@ func NewNodeLifecycleController(
 	nc.enterFullDisruptionFunc = nc.HealthyQPSFunc
 	nc.computeZoneStateFunc = nc.ComputeZoneState
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			pod := obj.(*v1.Pod)
 			nc.podUpdated(nil, pod)
@@ -376,7 +377,7 @@ func NewNodeLifecycleController(
 			newPod := obj.(*v1.Pod)
 			nc.podUpdated(prevPod, newPod)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	nc.podInformerSynced = podInformer.Informer().HasSynced
 	controller.AddPodNodeNameIndexer(podInformer.Informer())
 	podIndexer := podInformer.Informer().GetIndexer()
@@ -408,7 +409,7 @@ func NewNodeLifecycleController(
 	}
 
 	logger.Info("Controller will reconcile labels")
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = nodeInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: controllerutil.CreateAddNodeHandler(func(node *v1.Node) error {
 			nc.nodeUpdateQueue.Add(node.Name)
 			return nil
@@ -421,7 +422,7 @@ func NewNodeLifecycleController(
 			nc.nodesToRetry.Delete(node.Name)
 			return nil
 		}),
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 
 	nc.leaseLister = leaseInformer.Lister()
 	nc.leaseInformerSynced = leaseInformer.Informer().HasSynced

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -150,6 +150,7 @@ func NewHorizontalController(
 	cpuInitializationPeriod,
 	delayOfInitialReadinessStatus time.Duration,
 ) *HorizontalController {
+	logger := klog.FromContext(ctx)
 	broadcaster := record.NewBroadcaster(record.WithContext(ctx))
 	broadcaster.StartStructuredLogging(3)
 	broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: evtNamespacer.Events("")})
@@ -174,7 +175,8 @@ func NewHorizontalController(
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			NewDefaultHPARateLimiter(resyncPeriod),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "horizontalpodautoscaler",
+				Logger: &logger,
+				Name:   "horizontalpodautoscaler",
 			},
 		),
 		mapper:              mapper,
@@ -193,13 +195,13 @@ func NewHorizontalController(
 		hpaController.selectorTracker = newBiMultimapSelectorTracker()
 	}
 
-	hpaInformer.Informer().AddEventHandlerWithResyncPeriod(
+	_, _ = hpaInformer.Informer().AddEventHandlerWithOptions(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    hpaController.enqueueHPA,
 			UpdateFunc: hpaController.updateHPA,
 			DeleteFunc: hpaController.deleteHPA,
 		},
-		resyncPeriod,
+		cache.HandlerOptions{Logger: &logger, ResyncPeriod: &resyncPeriod},
 	)
 	hpaController.hpaLister = hpaInformer.Lister()
 	hpaController.hpaListerSynced = hpaInformer.Informer().HasSynced
@@ -222,7 +224,7 @@ func NewHorizontalController(
 
 // Run begins watching and syncing.
 func (a *HorizontalController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting HPA controller")

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -416,8 +416,8 @@ func newHorizontalSetup(t *testing.T, s *horizontalScenario, testClient *fake.Cl
 		hpaController.recommendations["test-namespace/test-hpa"] = s.recommendations
 	}
 
-	informerFactory.Start(tCtx.Done())
-	informerFactory.WaitForCacheSync(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
+	informerFactory.WaitForCacheSyncWithContext(tCtx)
 
 	return &horizontalSetup{
 		controller:      hpaController,
@@ -6244,6 +6244,7 @@ func TestOneMetricEmptyExternalError(t *testing.T) {
 }
 
 func TestMultipleHPAs(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	const hpaCount = 1000
 	const testNamespace = "dummy-namespace"
 
@@ -6252,8 +6253,8 @@ func TestMultipleHPAs(t *testing.T) {
 	testClient := &fake.Clientset{}
 	testScaleClient := &scalefake.FakeScaleClient{}
 	testMetricsClient := &metricsfake.Clientset{}
-	hpaWatcher := watch.NewFake()
-	podWatcher := watch.NewFake()
+	hpaWatcher := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
+	podWatcher := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 
 	testClient.AddWatchReactor("horizontalpodautoscalers", core.DefaultWatchReactor(hpaWatcher, nil))
 	testClient.AddWatchReactor("pods", core.DefaultWatchReactor(podWatcher, nil))
@@ -6500,7 +6501,7 @@ func TestMultipleHPAs(t *testing.T) {
 	monitor.NumHorizontalPodAutoscalers.Set(0)
 	hpaController.monitor = monitor.New()
 
-	informerFactory.Start(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
 	go hpaController.Run(tCtx, 5)
 
 	timeoutTime := time.After(15 * time.Second)

--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -228,7 +228,7 @@ func newReplicaCalcSetup(t *testing.T, f *calcScenario) *replicaCalcSetup {
 	calc := NewReplicaCalculator(metricsClient, informer.Lister(),
 		defaultTestingCPUInitializationPeriod, defaultTestingDelayOfInitialReadinessStatus)
 
-	informerFactory.Start(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
 
 	syncCtx, cancel := context.WithTimeout(tCtx, 10*time.Second)
 	defer cancel()

--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -74,6 +74,7 @@ func NewPodGC(ctx context.Context, kubeClient clientset.Interface, podInformer c
 // This function is only intended for integration tests
 func NewPodGCInternal(ctx context.Context, kubeClient clientset.Interface, podInformer coreinformers.PodInformer,
 	nodeInformer coreinformers.NodeInformer, terminatedPodThreshold int, gcCheckPeriod, quarantineTime time.Duration) *PodGCController {
+
 	gcc := &PodGCController{
 		kubeClient:             kubeClient,
 		terminatedPodThreshold: terminatedPodThreshold,
@@ -81,9 +82,12 @@ func NewPodGCInternal(ctx context.Context, kubeClient clientset.Interface, podIn
 		podListerSynced:        podInformer.Informer().HasSynced,
 		nodeLister:             nodeInformer.Lister(),
 		nodeListerSynced:       nodeInformer.Informer().HasSynced,
-		nodeQueue:              workqueue.NewTypedDelayingQueueWithConfig(workqueue.TypedDelayingQueueConfig[string]{Name: "orphaned_pods_nodes"}),
-		gcCheckPeriod:          gcCheckPeriod,
-		quarantineTime:         quarantineTime,
+		nodeQueue: workqueue.NewTypedDelayingQueueWithConfig(workqueue.TypedDelayingQueueConfig[string]{
+			Logger: new(klog.FromContext(ctx)),
+			Name:   "orphaned_pods_nodes",
+		}),
+		gcCheckPeriod:  gcCheckPeriod,
+		quarantineTime: quarantineTime,
 	}
 
 	// Register prometheus metrics

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -213,14 +213,17 @@ func NewBaseController(logger klog.Logger, rsInformer appsinformers.ReplicaSetIn
 		expectations:     controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: queueName},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   queueName,
+			},
 		),
 		clock:              clock.RealClock{},
 		controllerFeatures: controllerFeatures,
 		consistencyStore:   consistencyStore,
 	}
 
-	rsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = rsInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			rsc.addRS(logger, obj)
 		},
@@ -230,7 +233,7 @@ func NewBaseController(logger klog.Logger, rsInformer appsinformers.ReplicaSetIn
 		DeleteFunc: func(obj interface{}) {
 			rsc.deleteRS(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	rsInformer.Informer().AddIndexers(cache.Indexers{
 		controllerUIDIndex: func(obj interface{}) ([]string, error) {
 			rs, ok := obj.(*apps.ReplicaSet)
@@ -248,7 +251,7 @@ func NewBaseController(logger klog.Logger, rsInformer appsinformers.ReplicaSetIn
 	rsc.rsLister = rsInformer.Lister()
 	rsc.rsListerSynced = rsInformer.Informer().HasSynced
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			rsc.addPod(logger, obj)
 		},
@@ -261,7 +264,7 @@ func NewBaseController(logger klog.Logger, rsInformer appsinformers.ReplicaSetIn
 		DeleteFunc: func(obj interface{}) {
 			rsc.deletePod(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	rsc.podLister = podInformer.Lister()
 	rsc.podListerSynced = podInformer.Informer().HasSynced
 	controller.AddPodControllerIndexer(podInformer.Informer()) //nolint:errcheck
@@ -273,7 +276,7 @@ func NewBaseController(logger klog.Logger, rsInformer appsinformers.ReplicaSetIn
 
 // Run begins watching and syncing.
 func (rsc *ReplicaSetController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	rsc.eventBroadcaster.StartStructuredLogging(3)

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -184,7 +184,7 @@ func NewReplicaSetController(ctx context.Context, rsInformer appsinformers.Repli
 		consistencyStore = consistencyutil.NewNoopConsistencyStore()
 	}
 
-	return NewBaseController(logger, rsInformer, podInformer, kubeClient, burstReplicas,
+	return NewBaseController(ctx, rsInformer, podInformer, kubeClient, burstReplicas,
 		apps.SchemeGroupVersion.WithKind("ReplicaSet"),
 		"replicaset_controller",
 		"replicaset",
@@ -201,8 +201,9 @@ func NewReplicaSetController(ctx context.Context, rsInformer appsinformers.Repli
 
 // NewBaseController is the implementation of NewReplicaSetController with additional injected
 // parameters so that it can also serve as the implementation of NewReplicationController.
-func NewBaseController(logger klog.Logger, rsInformer appsinformers.ReplicaSetInformer, podInformer coreinformers.PodInformer, kubeClient clientset.Interface, burstReplicas int,
+func NewBaseController(ctx context.Context, rsInformer appsinformers.ReplicaSetInformer, podInformer coreinformers.PodInformer, kubeClient clientset.Interface, burstReplicas int,
 	gvk schema.GroupVersionKind, metricOwnerName, queueName string, podControl controller.PodControlInterface, eventBroadcaster record.EventBroadcaster, controllerFeatures ReplicaSetControllerFeatures, consistencyStore consistencyutil.ConsistencyStore) *ReplicaSetController {
+	logger := klog.FromContext(ctx)
 
 	rsc := &ReplicaSetController{
 		GroupVersionKind: gvk,

--- a/pkg/controller/replicaset/replica_set_test.go
+++ b/pkg/controller/replicaset/replica_set_test.go
@@ -640,8 +640,8 @@ func TestWatchControllers(t *testing.T) {
 		client,
 		BurstReplicas,
 	)
-	informers.Start(stopCh)
-	informers.WaitForCacheSync(stopCh)
+	informers.StartWithContext(tCtx)
+	informers.WaitForCacheSyncWithContext(tCtx)
 
 	var testRSSpec apps.ReplicaSet
 	received := make(chan string)
@@ -879,7 +879,7 @@ func TestControllerUpdateRequeue(t *testing.T) {
 	manager.podControl = &fakePodControl
 
 	// Enqueue once. Then process it. Disable rate-limiting for this.
-	manager.queue = workqueue.NewTypedRateLimitingQueue(workqueue.NewTypedMaxOfRateLimiter[string]())
+	manager.queue = workqueue.NewTypedRateLimitingQueue(workqueue.NewTypedMaxOfRateLimiter[string]()) //nolint:logcheck // Intentionally testing old API here.
 	manager.enqueueRS(rs)
 	manager.processNextWorkItem(ctx)
 	// It should have been requeued.
@@ -1210,8 +1210,8 @@ func TestExpectationsOnRecreate(t *testing.T) {
 		client,
 		100,
 	)
-	f.Start(stopCh)
-	f.WaitForCacheSync(stopCh)
+	f.StartWithContext(tCtx)
+	f.WaitForCacheSyncWithContext(tCtx)
 	fakePodControl := controller.FakePodControl{}
 	manager.podControl = &fakePodControl
 

--- a/pkg/controller/replication/conversion.go
+++ b/pkg/controller/replication/conversion.go
@@ -45,6 +45,7 @@ import (
 	appslisters "k8s.io/client-go/listers/apps/v1"
 	v1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 	appsinternal "k8s.io/kubernetes/pkg/apis/apps"
 	appsconversion "k8s.io/kubernetes/pkg/apis/apps/v1"
 	apiv1 "k8s.io/kubernetes/pkg/apis/core/v1"
@@ -58,7 +59,7 @@ type informerAdapter struct {
 }
 
 func (i informerAdapter) Informer() cache.SharedIndexInformer {
-	return conversionInformer{i.rcInformer.Informer()}
+	return conversionInformer{SharedIndexInformer: i.rcInformer.Informer(), logger: klog.Background()}
 }
 
 func (i informerAdapter) Lister() appslisters.ReplicaSetLister {
@@ -67,14 +68,22 @@ func (i informerAdapter) Lister() appslisters.ReplicaSetLister {
 
 type conversionInformer struct {
 	cache.SharedIndexInformer
+	logger klog.Logger
+}
+
+func (i conversionInformer) AddEventHandlerWithOptions(handler cache.ResourceEventHandler, options cache.HandlerOptions) (cache.ResourceEventHandlerRegistration, error) {
+	if options.Logger == nil {
+		options.Logger = &i.logger
+	}
+	return i.SharedIndexInformer.AddEventHandlerWithOptions(conversionEventHandler{handler}, options)
 }
 
 func (i conversionInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
-	return i.SharedIndexInformer.AddEventHandler(conversionEventHandler{handler})
+	return i.AddEventHandlerWithOptions(handler, cache.HandlerOptions{Logger: &i.logger})
 }
 
 func (i conversionInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (cache.ResourceEventHandlerRegistration, error) {
-	return i.SharedIndexInformer.AddEventHandlerWithResyncPeriod(conversionEventHandler{handler}, resyncPeriod)
+	return i.AddEventHandlerWithOptions(handler, cache.HandlerOptions{Logger: &i.logger, ResyncPeriod: &resyncPeriod})
 }
 
 type conversionLister struct {

--- a/pkg/controller/replication/replication_controller.go
+++ b/pkg/controller/replication/replication_controller.go
@@ -33,7 +33,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/replicaset"
 	consistencyutil "k8s.io/kubernetes/pkg/controller/util/consistency"
@@ -52,10 +51,9 @@ type ReplicationManager struct {
 
 // NewReplicationManager configures a replication manager with the specified event recorder
 func NewReplicationManager(ctx context.Context, podInformer coreinformers.PodInformer, rcInformer coreinformers.ReplicationControllerInformer, kubeClient clientset.Interface, burstReplicas int) *ReplicationManager {
-	logger := klog.FromContext(ctx)
 	eventBroadcaster := record.NewBroadcaster(record.WithContext(ctx))
 	return &ReplicationManager{
-		*replicaset.NewBaseController(logger, informerAdapter{rcInformer}, podInformer, clientsetAdapter{kubeClient}, burstReplicas,
+		*replicaset.NewBaseController(ctx, informerAdapter{rcInformer}, podInformer, clientsetAdapter{kubeClient}, burstReplicas,
 			v1.SchemeGroupVersion.WithKind("ReplicationController"),
 			"replication_controller",
 			"replicationmanager",

--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -237,7 +237,10 @@ func newControllerWithFeatures(
 		templatesSynced: templateInformer.Informer().HasSynced,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "resource_claim"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "resource_claim",
+			},
 		),
 		deletedObjects: newUIDCache(maxUIDCacheEntries),
 	}

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -163,12 +163,12 @@ func TestCreateClaimDoesNotMutateTemplate(t *testing.T) {
 				tCtx.Fatalf("error creating controller: %v", err)
 			}
 
-			informerFactory.Start(tCtx.Done())
+			informerFactory.StartWithContext(tCtx)
 			defer func() {
 				tCtx.Cancel("stopping informers")
 				informerFactory.Shutdown()
 			}()
-			informerFactory.WaitForCacheSync(tCtx.Done())
+			informerFactory.WaitForCacheSyncWithContext(tCtx)
 
 			// cachedTemplate is the object the controller reads from the shared informer
 			// cache; snapshot it so any in-place mutation is detectable.
@@ -1106,13 +1106,13 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			}
 
 			// Ensure informers are up-to-date.
-			informerFactory.Start(tCtx.Done())
+			informerFactory.StartWithContext(tCtx)
 			stopInformers := func() {
 				tCtx.Cancel("stopping informers")
 				informerFactory.Shutdown()
 			}
 			defer stopInformers()
-			informerFactory.WaitForCacheSync(tCtx.Done())
+			informerFactory.WaitForCacheSyncWithContext(tCtx)
 
 			// Add claims that only exist in the mutation cache.
 			for _, claim := range tc.claimsInCache {
@@ -1283,13 +1283,13 @@ func testClaimExists(tCtx ktesting.TContext) {
 			tCtx.ExpectNoError(err, "creating controller")
 
 			// Ensure informers are up-to-date.
-			informerFactory.Start(tCtx.Done())
+			informerFactory.StartWithContext(tCtx)
 			stopInformers := func() {
 				tCtx.Cancel("stopping informers")
 				informerFactory.Shutdown()
 			}
 			defer stopInformers()
-			informerFactory.WaitForCacheSync(tCtx.Done())
+			informerFactory.WaitForCacheSyncWithContext(tCtx)
 
 			// Add claims that only exist in the mutation cache.
 			if claim := tc.claimInMutationCache; claim != nil {
@@ -1654,7 +1654,7 @@ func testEventHandlers(tCtx ktesting.TContext) {
 			tCtx.ExpectNoError(err, "creating ephemeral controller")
 			tCtx.Cleanup(ec.queue.ShutDown)
 
-			informerFactory.Start(tCtx.Done())
+			informerFactory.StartWithContext(tCtx)
 			stopInformers := func() {
 				tCtx.Cancel("stopping informers")
 				informerFactory.Shutdown()

--- a/pkg/controller/resourcepoolstatusrequest/controller.go
+++ b/pkg/controller/resourcepoolstatusrequest/controller.go
@@ -116,7 +116,13 @@ func NewController(
 		requestSynced: requestInformer.Informer().HasSynced,
 		sliceSynced:   sliceInformer.Informer().HasSynced,
 		claimSynced:   claimInformer.Informer().HasSynced,
-		workqueue:     workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+		workqueue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "resourcepoolstatusrequest",
+			},
+		),
 	}
 
 	// Only consume the DeviceTaintRule informer when the gate is enabled, so
@@ -148,7 +154,7 @@ func NewController(
 
 // Run starts the controller workers.
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting ResourcePoolStatusRequest controller")

--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -104,6 +104,8 @@ type Controller struct {
 
 // NewController creates a quota controller with specified options
 func NewController(ctx context.Context, options *ControllerOptions) (*Controller, error) {
+	logger := klog.FromContext(ctx)
+
 	// build the resource quota controller
 	rq := &Controller{
 		rqClient:            options.QuotaClient,
@@ -111,11 +113,17 @@ func NewController(ctx context.Context, options *ControllerOptions) (*Controller
 		informerSyncedFuncs: []cache.InformerSynced{options.ResourceQuotaInformer.Informer().HasSynced},
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "resourcequota_primary"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "resourcequota_primary",
+			},
 		),
 		missingUsageQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "resourcequota_priority"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "resourcequota_priority",
+			},
 		),
 		resyncPeriod: options.ResyncPeriod,
 		registry:     options.Registry,
@@ -123,9 +131,8 @@ func NewController(ctx context.Context, options *ControllerOptions) (*Controller
 	// set the synchronization handler
 	rq.syncHandler = rq.syncResourceQuotaFromKey
 
-	logger := klog.FromContext(ctx)
-
-	options.ResourceQuotaInformer.Informer().AddEventHandlerWithResyncPeriod(
+	resyncPeriod := rq.resyncPeriod()
+	_, _ = options.ResourceQuotaInformer.Informer().AddEventHandlerWithOptions(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				rq.addQuota(logger, obj)
@@ -153,11 +160,15 @@ func NewController(ctx context.Context, options *ControllerOptions) (*Controller
 				rq.enqueueResourceQuota(logger, obj)
 			},
 		},
-		rq.resyncPeriod(),
+		cache.HandlerOptions{
+			Logger:       &logger,
+			ResyncPeriod: &resyncPeriod,
+		},
 	)
 
 	if options.DiscoveryFunc != nil {
 		qm := NewMonitor(
+			logger,
 			options.InformersStarted,
 			options.InformerFactory,
 			options.IgnoredResourcesFunc(),

--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -168,7 +168,7 @@ func NewController(ctx context.Context, options *ControllerOptions) (*Controller
 
 	if options.DiscoveryFunc != nil {
 		qm := NewMonitor(
-			logger,
+			ctx,
 			options.InformersStarted,
 			options.InformerFactory,
 			options.IgnoredResourcesFunc(),

--- a/pkg/controller/resourcequota/resource_quota_controller_test.go
+++ b/pkg/controller/resourcequota/resource_quota_controller_test.go
@@ -134,7 +134,7 @@ func setupQuotaController(t *testing.T, kubeClient kubernetes.Interface, lister 
 		t.Fatal(err)
 	}
 	stop := make(chan struct{})
-	informerFactory.Start(stop)
+	informerFactory.StartWithContext(ctx)
 	return quotaController{qc, stop}
 }
 

--- a/pkg/controller/resourcequota/resource_quota_monitor.go
+++ b/pkg/controller/resourcequota/resource_quota_monitor.go
@@ -106,14 +106,17 @@ type QuotaMonitor struct {
 }
 
 // NewMonitor creates a new instance of a QuotaMonitor
-func NewMonitor(informersStarted <-chan struct{}, informerFactory informerfactory.InformerFactory, ignoredResources map[schema.GroupResource]struct{}, resyncPeriod controller.ResyncPeriodFunc, replenishmentFunc ReplenishmentFunc, registry quota.Registry, updateFilter UpdateFilter) *QuotaMonitor {
+func NewMonitor(logger klog.Logger, informersStarted <-chan struct{}, informerFactory informerfactory.InformerFactory, ignoredResources map[schema.GroupResource]struct{}, resyncPeriod controller.ResyncPeriodFunc, replenishmentFunc ReplenishmentFunc, registry quota.Registry, updateFilter UpdateFilter) *QuotaMonitor {
 	return &QuotaMonitor{
 		informersStarted: informersStarted,
 		informerFactory:  informerFactory,
 		ignoredResources: ignoredResources,
 		resourceChanges: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[*event](),
-			workqueue.TypedRateLimitingQueueConfig[*event]{Name: "resource_quota_controller_resource_changes"},
+			workqueue.TypedRateLimitingQueueConfig[*event]{
+				Logger: &logger,
+				Name:   "resource_quota_controller_resource_changes",
+			},
 		),
 		resyncPeriod:      resyncPeriod,
 		replenishmentFunc: replenishmentFunc,
@@ -134,7 +137,7 @@ type monitor struct {
 // Run is intended to be called in a goroutine. Multiple calls of this is an
 // error.
 func (m *monitor) Run() {
-	m.controller.Run(m.stopCh)
+	m.controller.RunWithContext(wait.ContextForChannel(m.stopCh))
 }
 
 type monitors map[schema.GroupVersionResource]*monitor
@@ -173,7 +176,11 @@ func (qm *QuotaMonitor) controllerFor(ctx context.Context, resource schema.Group
 	shared, err := qm.informerFactory.ForResource(resource)
 	if err == nil {
 		logger.V(4).Info("QuotaMonitor using a shared informer", "resource", resource.String())
-		shared.Informer().AddEventHandlerWithResyncPeriod(handlers, qm.resyncPeriod())
+		resyncPeriod := qm.resyncPeriod()
+		_, _ = shared.Informer().AddEventHandlerWithOptions(handlers, cache.HandlerOptions{
+			Logger:       &logger,
+			ResyncPeriod: &resyncPeriod,
+		})
 		return shared.Informer().GetController(), nil
 	}
 	logger.V(4).Info("QuotaMonitor unable to use a shared informer", "resource", resource.String(), "err", err)

--- a/pkg/controller/resourcequota/resource_quota_monitor.go
+++ b/pkg/controller/resourcequota/resource_quota_monitor.go
@@ -106,7 +106,8 @@ type QuotaMonitor struct {
 }
 
 // NewMonitor creates a new instance of a QuotaMonitor
-func NewMonitor(logger klog.Logger, informersStarted <-chan struct{}, informerFactory informerfactory.InformerFactory, ignoredResources map[schema.GroupResource]struct{}, resyncPeriod controller.ResyncPeriodFunc, replenishmentFunc ReplenishmentFunc, registry quota.Registry, updateFilter UpdateFilter) *QuotaMonitor {
+func NewMonitor(ctx context.Context, informersStarted <-chan struct{}, informerFactory informerfactory.InformerFactory, ignoredResources map[schema.GroupResource]struct{}, resyncPeriod controller.ResyncPeriodFunc, replenishmentFunc ReplenishmentFunc, registry quota.Registry, updateFilter UpdateFilter) *QuotaMonitor {
+	logger := klog.FromContext(ctx)
 	return &QuotaMonitor{
 		informersStarted: informersStarted,
 		informerFactory:  informerFactory,

--- a/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller.go
+++ b/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller.go
@@ -80,7 +80,10 @@ func NewPodGroupProtectionController(
 		podSynced:      podInformer.Informer().HasSynced,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "podgroupprotection"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "podgroupprotection",
+			},
 		),
 	}
 
@@ -139,7 +142,7 @@ func addActivePodSchedulingGroupIndexer(indexer cache.Indexer) error {
 
 // Run runs the controller goroutines.
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting PodGroup protection controller")

--- a/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
+++ b/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
@@ -260,7 +260,7 @@ func TestHandlePodChange(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			c := &Controller{
-				queue: workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+				queue: workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()), //nolint:logcheck // Intentionally testing old API here.
 			}
 			defer c.queue.ShutDown()
 			c.handlePodChange(logger, tc.old, tc.new)
@@ -381,8 +381,8 @@ func TestPodGroupProtectionController(t *testing.T) {
 				t.Fatalf("unexpected error creating controller: %v", err)
 			}
 
-			informerFactory.Start(ctx.Done())
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.StartWithContext(ctx)
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 			go ctrl.Run(ctx, 1)
 
 			// In order to reduce test flakiness, make sure that the pod-to-delete is visible in the client set. Create a dummy pod to "warm up" the watch pipe.
@@ -555,7 +555,7 @@ func TestHandlePodGroupUpdate(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			c := &Controller{
-				queue: workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+				queue: workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()), //nolint:logcheck // Intentionally testing old API here.
 			}
 			defer c.queue.ShutDown()
 			c.handlePodGroupUpdate(logger, tc.pg)

--- a/pkg/controller/serviceaccount/serviceaccounts_controller.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller.go
@@ -68,22 +68,31 @@ func NewServiceAccountsController(logger klog.Logger, saInformer coreinformers.S
 		serviceAccountsToEnsure: options.ServiceAccounts,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "serviceaccount"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "serviceaccount",
+			},
 		),
 	}
 
-	saHandler, _ := saInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
+	saHandler, _ := saInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: func(obj interface{}) {
 			e.serviceAccountDeleted(logger, obj)
 		},
-	}, options.ServiceAccountResync)
+	}, cache.HandlerOptions{
+		Logger:       &logger,
+		ResyncPeriod: &options.ServiceAccountResync,
+	})
 	e.saLister = saInformer.Lister()
 	e.saListerSynced = saHandler.HasSynced
 
-	nsHandler, _ := nsInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
+	nsHandler, _ := nsInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    e.namespaceAdded,
 		UpdateFunc: e.namespaceUpdated,
-	}, options.NamespaceResync)
+	}, cache.HandlerOptions{
+		Logger:       &logger,
+		ResyncPeriod: &options.NamespaceResync,
+	})
 	e.nsLister = nsInformer.Lister()
 	e.nsListerSynced = nsHandler.HasSynced
 

--- a/pkg/controller/serviceaccount/serviceaccounts_controller.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller.go
@@ -62,7 +62,8 @@ func DefaultServiceAccountsControllerOptions() ServiceAccountsControllerOptions 
 }
 
 // NewServiceAccountsController returns a new *ServiceAccountsController.
-func NewServiceAccountsController(logger klog.Logger, saInformer coreinformers.ServiceAccountInformer, nsInformer coreinformers.NamespaceInformer, cl clientset.Interface, options ServiceAccountsControllerOptions) (*ServiceAccountsController, error) {
+func NewServiceAccountsController(ctx context.Context, saInformer coreinformers.ServiceAccountInformer, nsInformer coreinformers.NamespaceInformer, cl clientset.Interface, options ServiceAccountsControllerOptions) (*ServiceAccountsController, error) {
+	logger := klog.FromContext(ctx)
 	e := &ServiceAccountsController{
 		client:                  cl,
 		serviceAccountsToEnsure: options.ServiceAccounts,

--- a/pkg/controller/serviceaccount/serviceaccounts_controller_test.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller_test.go
@@ -173,7 +173,7 @@ func TestServiceAccountCreation(t *testing.T) {
 			defer tCtx.Cancel("test case terminating")
 
 			controller, err := NewServiceAccountsController(
-				logger,
+				tCtx,
 				saInformer,
 				nsInformer,
 				client,

--- a/pkg/controller/serviceaccount/tokens_controller.go
+++ b/pkg/controller/serviceaccount/tokens_controller.go
@@ -84,11 +84,17 @@ func NewTokensController(logger klog.Logger, serviceAccounts informers.ServiceAc
 
 		syncServiceAccountQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[serviceAccountQueueKey](),
-			workqueue.TypedRateLimitingQueueConfig[serviceAccountQueueKey]{Name: "serviceaccount_tokens_service"},
+			workqueue.TypedRateLimitingQueueConfig[serviceAccountQueueKey]{
+				Logger: &logger,
+				Name:   "serviceaccount_tokens_service",
+			},
 		),
 		syncSecretQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[secretQueueKey](),
-			workqueue.TypedRateLimitingQueueConfig[secretQueueKey]{Name: "serviceaccount_tokens_service"},
+			workqueue.TypedRateLimitingQueueConfig[secretQueueKey]{
+				Logger: &logger,
+				Name:   "serviceaccount_tokens_service",
+			},
 		),
 
 		maxRetries: maxRetries,
@@ -96,13 +102,16 @@ func NewTokensController(logger klog.Logger, serviceAccounts informers.ServiceAc
 
 	e.serviceAccounts = serviceAccounts.Lister()
 	e.serviceAccountSynced = serviceAccounts.Informer().HasSynced
-	serviceAccounts.Informer().AddEventHandlerWithResyncPeriod(
+	_, _ = serviceAccounts.Informer().AddEventHandlerWithOptions(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    e.queueServiceAccountSync,
 			UpdateFunc: e.queueServiceAccountUpdateSync,
 			DeleteFunc: e.queueServiceAccountSync,
 		},
-		options.ServiceAccountResync,
+		cache.HandlerOptions{
+			Logger:       &logger,
+			ResyncPeriod: &options.ServiceAccountResync,
+		},
 	)
 
 	e.secrets = secrets.Lister()

--- a/pkg/controller/serviceaccount/tokens_controller.go
+++ b/pkg/controller/serviceaccount/tokens_controller.go
@@ -71,7 +71,8 @@ type TokensControllerOptions struct {
 }
 
 // NewTokensController returns a new *TokensController.
-func NewTokensController(logger klog.Logger, serviceAccounts informers.ServiceAccountInformer, secrets informers.SecretInformer, cl clientset.Interface, options TokensControllerOptions) (*TokensController, error) {
+func NewTokensController(ctx context.Context, serviceAccounts informers.ServiceAccountInformer, secrets informers.SecretInformer, cl clientset.Interface, options TokensControllerOptions) (*TokensController, error) {
+	logger := klog.FromContext(ctx)
 	maxRetries := options.MaxRetries
 	if maxRetries == 0 {
 		maxRetries = 10

--- a/pkg/controller/serviceaccount/tokens_controller_test.go
+++ b/pkg/controller/serviceaccount/tokens_controller_test.go
@@ -433,7 +433,7 @@ func TestTokenCreation(t *testing.T) {
 
 	for k, tc := range testcases {
 		t.Run(k, func(t *testing.T) {
-			logger, ctx := ktesting.NewTestContext(t)
+			_, ctx := ktesting.NewTestContext(t)
 
 			// Re-seed to reset name generation
 			utilrand.Seed(1)
@@ -448,7 +448,7 @@ func TestTokenCreation(t *testing.T) {
 			secretInformer := informers.Core().V1().Secrets().Informer()
 			secrets := secretInformer.GetStore()
 			serviceAccounts := informers.Core().V1().ServiceAccounts().Informer().GetStore()
-			controller, err := NewTokensController(logger, informers.Core().V1().ServiceAccounts(), informers.Core().V1().Secrets(), client, TokensControllerOptions{TokenGenerator: generator, RootCA: []byte("CA Data"), MaxRetries: tc.MaxRetries})
+			controller, err := NewTokensController(ctx, informers.Core().V1().ServiceAccounts(), informers.Core().V1().Secrets(), client, TokensControllerOptions{TokenGenerator: generator, RootCA: []byte("CA Data"), MaxRetries: tc.MaxRetries})
 			if err != nil {
 				t.Fatalf("error creating Tokens controller: %v", err)
 			}
@@ -554,7 +554,7 @@ func TestTokenCreation(t *testing.T) {
 }
 
 func TestQueueServiceAccountSync_Tombstone(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	_, ctx := ktesting.NewTestContext(t)
 	sa := serviceAccount(emptySecretReferences())
 	tombstone := cache.DeletedFinalStateUnknown{
 		Key: "default/default",
@@ -563,7 +563,7 @@ func TestQueueServiceAccountSync_Tombstone(t *testing.T) {
 
 	client := fake.NewClientset(sa)
 	informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
-	tokenController, err := NewTokensController(logger, informerFactory.Core().V1().ServiceAccounts(), informerFactory.Core().V1().Secrets(), client, TokensControllerOptions{})
+	tokenController, err := NewTokensController(ctx, informerFactory.Core().V1().ServiceAccounts(), informerFactory.Core().V1().Secrets(), client, TokensControllerOptions{})
 	if err != nil {
 		t.Fatalf("error creating Tokens controller: %v", err)
 	}

--- a/pkg/controller/servicecidrs/servicecidrs_controller.go
+++ b/pkg/controller/servicecidrs/servicecidrs_controller.go
@@ -74,28 +74,36 @@ func NewController(
 	ipAddressInformer networkinginformers.IPAddressInformer,
 	client clientset.Interface,
 ) *Controller {
+	logger := klog.FromContext(ctx)
 	broadcaster := record.NewBroadcaster(record.WithContext(ctx))
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: controllerName})
 	c := &Controller{
 		client: client,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "ipaddresses"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "ipaddresses",
+			},
 		),
 		workerLoopPeriod: time.Second,
 	}
 
-	_, _ = serviceCIDRInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = serviceCIDRInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addServiceCIDR,
 		UpdateFunc: c.updateServiceCIDR,
 		DeleteFunc: c.deleteServiceCIDR,
+	}, cache.HandlerOptions{
+		Logger: &logger,
 	})
 	c.serviceCIDRLister = serviceCIDRInformer.Lister()
 	c.serviceCIDRsSynced = serviceCIDRInformer.Informer().HasSynced
 
-	_, _ = ipAddressInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = ipAddressInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addIPAddress,
 		DeleteFunc: c.deleteIPAddress,
+	}, cache.HandlerOptions{
+		Logger: &logger,
 	})
 
 	c.ipAddressLister = ipAddressInformer.Lister()

--- a/pkg/controller/statefulset/stateful_set.go
+++ b/pkg/controller/statefulset/stateful_set.go
@@ -169,7 +169,10 @@ func NewStatefulSetController(
 		revListerSynced: revInformer.Informer().HasSynced,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "statefulset"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "statefulset",
+			},
 		),
 		podControl: controller.RealPodControl{KubeClient: kubeClient, Recorder: recorder, OnWrite: podWriteCallback},
 
@@ -178,7 +181,7 @@ func NewStatefulSetController(
 		consistencyStore: consistencyStore,
 	}
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		// lookup the statefulset and enqueue
 		AddFunc: func(obj interface{}) {
 			ssc.addPod(logger, obj)
@@ -191,12 +194,14 @@ func NewStatefulSetController(
 		DeleteFunc: func(obj interface{}) {
 			ssc.deletePod(logger, obj)
 		},
+	}, cache.HandlerOptions{
+		Logger: &logger,
 	})
 	ssc.podLister = podInformer.Lister()
 	ssc.podListerSynced = podInformer.Informer().HasSynced
 	controller.AddPodControllerIndexer(podInformer.Informer())
 	ssc.podIndexer = podInformer.Informer().GetIndexer()
-	setInformer.Informer().AddEventHandler(
+	_, _ = setInformer.Informer().AddEventHandlerWithOptions(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				ssc.enqueueStatefulSet(logger, obj)
@@ -213,6 +218,7 @@ func NewStatefulSetController(
 				ssc.enqueueStatefulSet(logger, obj)
 			},
 		},
+		cache.HandlerOptions{Logger: &logger},
 	)
 	ssc.setLister = setInformer.Lister()
 	ssc.setListerSynced = setInformer.Informer().HasSynced

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	appsinformers "k8s.io/client-go/informers/apps/v1"
@@ -994,7 +995,7 @@ func TestStatefulSetControl_getSetRevisions(t *testing.T) {
 
 				stop := make(chan struct{})
 				defer close(stop)
-				informerFactory.Start(stop)
+				informerFactory.StartWithContext(wait.ContextForChannel(stop))
 				cache.WaitForCacheSync(
 					stop,
 					informerFactory.Apps().V1().StatefulSets().Informer().HasSynced,

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -43,7 +43,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	appsinformers "k8s.io/client-go/informers/apps/v1"
@@ -59,6 +58,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller/history"
 	"k8s.io/kubernetes/pkg/controller/statefulset/metrics"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	testingclock "k8s.io/utils/clock/testing"
 )
 
@@ -940,7 +940,7 @@ func TestStatefulSetControl_getSetRevisions(t *testing.T) {
 			set2.Status.CurrentRevision = rev0.Name
 			set2.Status.CollisionCount = new(int32)
 			rev2 := newRevisionOrDie(set2, 3)
-			tests := []struct {
+			type testcase struct {
 				name            string
 				existing        []*apps.ControllerRevision
 				set             *apps.StatefulSet
@@ -948,7 +948,8 @@ func TestStatefulSetControl_getSetRevisions(t *testing.T) {
 				expectedCurrent *apps.ControllerRevision
 				expectedUpdate  *apps.ControllerRevision
 				err             bool
-			}{
+			}
+			tests := []testcase{
 				{
 					name:            "creates initial revision",
 					existing:        nil,
@@ -986,18 +987,19 @@ func TestStatefulSetControl_getSetRevisions(t *testing.T) {
 					err:             false,
 				},
 			}
-			for _, test := range tests {
+			run := func(tCtx ktesting.TContext, test testcase) {
 				client := fake.NewSimpleClientset()
 				informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 				spc := NewStatefulPodControlFromManager(newFakeObjectManager(informerFactory), &noopRecorder{})
 				ssu := newFakeStatefulSetStatusUpdater(informerFactory.Apps().V1().StatefulSets())
 				ssc := defaultStatefulSetControl{spc, ssu, history.NewFakeHistory(informerFactory.Apps().V1().ControllerRevisions()), lru.New(maxRevisionEqualityCacheEntries)}
 
-				stop := make(chan struct{})
-				defer close(stop)
-				informerFactory.StartWithContext(wait.ContextForChannel(stop))
+				informerFactory.StartWithContext(tCtx)
+				tCtx.Cleanup(func() {
+					informerFactory.Shutdown()
+				})
 				cache.WaitForCacheSync(
-					stop,
+					tCtx.Done(),
 					informerFactory.Apps().V1().StatefulSets().Informer().HasSynced,
 					informerFactory.Core().V1().Pods().Informer().HasSynced,
 					informerFactory.Apps().V1().ControllerRevisions().Informer().HasSynced,
@@ -1008,34 +1010,37 @@ func TestStatefulSetControl_getSetRevisions(t *testing.T) {
 				}
 				revisions, err := ssc.ListRevisions(test.set)
 				if err != nil {
-					t.Fatal(err)
+					tCtx.Fatal(err)
 				}
 				current, update, _, err := ssc.getStatefulSetRevisions(test.set, revisions)
 				if err != nil {
-					t.Fatalf("error getting statefulset revisions:%v", err)
+					tCtx.Fatalf("error getting statefulset revisions:%v", err)
 				}
 				revisions, err = ssc.ListRevisions(test.set)
 				if err != nil {
-					t.Fatal(err)
+					tCtx.Fatal(err)
 				}
 				if len(revisions) != test.expectedCount {
-					t.Errorf("%s: want %d revisions got %d", test.name, test.expectedCount, len(revisions))
+					tCtx.Errorf("want %d revisions got %d", test.expectedCount, len(revisions))
 				}
 				if test.err {
-					t.Errorf("%s: expected error", test.name)
+					tCtx.Errorf("expected error")
 				}
 				if !test.err && !history.EqualRevision(current, test.expectedCurrent) {
-					t.Errorf("%s: for current want %v got %v", test.name, test.expectedCurrent, current)
+					tCtx.Errorf("for current want %v got %v", test.expectedCurrent, current)
 				}
 				if !test.err && !history.EqualRevision(update, test.expectedUpdate) {
-					t.Errorf("%s: for update want %v got %v", test.name, test.expectedUpdate, update)
+					tCtx.Errorf("for update want %v got %v", test.expectedUpdate, update)
 				}
 				if !test.err && test.expectedCurrent != nil && current != nil && test.expectedCurrent.Revision != current.Revision {
-					t.Errorf("%s: for current revision want %d got %d", test.name, test.expectedCurrent.Revision, current.Revision)
+					tCtx.Errorf("for current revision want %d got %d", test.expectedCurrent.Revision, current.Revision)
 				}
 				if !test.err && test.expectedUpdate != nil && update != nil && test.expectedUpdate.Revision != update.Revision {
-					t.Errorf("%s: for update revision want %d got %d", test.name, test.expectedUpdate.Revision, update.Revision)
+					tCtx.Errorf("for update revision want %d got %d", test.expectedUpdate.Revision, update.Revision)
 				}
+			}
+			for _, test := range tests {
+				t.Run(test.name, func(t *testing.T) { run(ktesting.Init(t), test) })
 			}
 		})
 }

--- a/pkg/controller/storageversiongc/gc_controller.go
+++ b/pkg/controller/storageversiongc/gc_controller.go
@@ -65,11 +65,17 @@ func NewStorageVersionGC(ctx context.Context, clientset kubernetes.Interface, le
 		storageVersionSynced: storageVersionInformer.Informer().HasSynced,
 		leaseQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "storage_version_garbage_collector_leases"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "storage_version_garbage_collector_leases",
+			},
 		),
 		storageVersionQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "storage_version_garbage_collector_storageversions"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "storage_version_garbage_collector_storageversions",
+			},
 		),
 	}
 	logger := klog.FromContext(ctx)
@@ -95,7 +101,7 @@ func NewStorageVersionGC(ctx context.Context, clientset kubernetes.Interface, le
 
 // Run starts one worker.
 func (c *Controller) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting storage version garbage collector")

--- a/pkg/controller/storageversiongc/gc_controller_test.go
+++ b/pkg/controller/storageversiongc/gc_controller_test.go
@@ -42,7 +42,7 @@ func setupController(ctx context.Context, clientset kubernetes.Interface) {
 	storageVersionInformer := informerFactory.Internal().V1alpha1().StorageVersions()
 
 	controller := NewStorageVersionGC(ctx, clientset, leaseInformer, storageVersionInformer)
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	// Using this ensure informer caches are fully populated before starting the controller.
 	if !cache.WaitForCacheSync(ctx.Done(), controller.leasesSynced, controller.storageVersionSynced) {
 		panic("timed out waiting for caches to sync")

--- a/pkg/controller/storageversionmigrator/migrationrunner.go
+++ b/pkg/controller/storageversionmigrator/migrationrunner.go
@@ -78,7 +78,10 @@ func NewCustomResourceController(
 		crdClient:  crdClient,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[metav1.GroupResource](),
-			workqueue.TypedRateLimitingQueueConfig[metav1.GroupResource]{Name: ResourceVersionControllerName},
+			workqueue.TypedRateLimitingQueueConfig[metav1.GroupResource]{
+				Logger: new(klog.FromContext(ctx)),
+				Name:   ResourceVersionControllerName,
+			},
 		),
 	}
 
@@ -134,7 +137,7 @@ func (crc *MigrationRunnerController) enqueue(svm *svmv1.StorageVersionMigration
 }
 
 func (crc *MigrationRunnerController) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting", "controller", MigrationRunnerControllerName)

--- a/pkg/controller/storageversionmigrator/migrationrunner_test.go
+++ b/pkg/controller/storageversionmigrator/migrationrunner_test.go
@@ -348,7 +348,7 @@ func TestCustomResourceController_Sync(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
+			logger, ctx := ktesting.NewTestContext(t)
 			var initialSVMs []runtime.Object
 			for _, svm := range tc.svms {
 				initialSVMs = append(initialSVMs, svm)
@@ -370,7 +370,7 @@ func TestCustomResourceController_Sync(t *testing.T) {
 
 			crdScheme := runtime.NewScheme()
 			_ = apiextensionsv1.AddToScheme(crdScheme)
-			crdTracker := k8stesting.NewObjectTracker(crdScheme, serializer.NewCodecFactory(crdScheme).UniversalDecoder())
+			crdTracker := k8stesting.NewObjectTrackerWithLogger(logger, crdScheme, serializer.NewCodecFactory(crdScheme).UniversalDecoder())
 
 			for _, obj := range initialCRDs {
 				_ = crdTracker.Add(obj)

--- a/pkg/controller/storageversionmigrator/resourceversion.go
+++ b/pkg/controller/storageversionmigrator/resourceversion.go
@@ -86,7 +86,10 @@ func NewResourceVersionController(
 		mapper:          mapper,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: ResourceVersionControllerName},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: new(klog.FromContext(ctx)),
+				Name:   ResourceVersionControllerName,
+			},
 		),
 	}
 
@@ -127,7 +130,7 @@ func (rv *ResourceVersionController) enqueue(svm *svmv1.StorageVersionMigration)
 }
 
 func (rv *ResourceVersionController) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting", "controller", ResourceVersionControllerName)

--- a/pkg/controller/storageversionmigrator/resourceversion_test.go
+++ b/pkg/controller/storageversionmigrator/resourceversion_test.go
@@ -488,6 +488,7 @@ type testRESTMapper struct {
 }
 
 func (m *testRESTMapper) Reset() {
+	//nolint:logcheck // Reset() has a fixed signature from meta.ResettableRESTMapper and cannot accept a context.
 	meta.MaybeResetRESTMapper(m.RESTMapper)
 }
 

--- a/pkg/controller/storageversionmigrator/storageversionmigrator.go
+++ b/pkg/controller/storageversionmigrator/storageversionmigrator.go
@@ -90,7 +90,10 @@ func NewSVMController(
 		dependencyGraphBuilder: dependencyGraphBuilder,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			rateLimiter,
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: controllerName},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: new(klog.FromContext(ctx)),
+				Name:   controllerName,
+			},
 		),
 		rateLimiter: rateLimiter,
 	}
@@ -136,7 +139,7 @@ func (svmc *SVMController) enqueue(svm *svmv1.StorageVersionMigration) {
 }
 
 func (svmc *SVMController) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting", "controller", svmc.controllerName)

--- a/pkg/controller/tainteviction/taint_eviction.go
+++ b/pkg/controller/tainteviction/taint_eviction.go
@@ -222,7 +222,7 @@ func New(ctx context.Context, c clientset.Interface, podInformer corev1informers
 	}
 	tm.taintEvictionQueue = CreateWorkerQueue(deletePodHandler(c, tm.emitPodDeletionEvent, tm.name))
 
-	_, err := podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			pod := obj.(*v1.Pod)
 			tm.PodUpdated(nil, pod)
@@ -249,12 +249,12 @@ func New(ctx context.Context, c clientset.Interface, podInformer corev1informers
 			}
 			tm.PodUpdated(pod, nil)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		return nil, fmt.Errorf("unable to add pod event handler: %w", err)
 	}
 
-	_, err = nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = nodeInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: controllerutil.CreateAddNodeHandler(func(node *v1.Node) error {
 			tm.NodeUpdated(nil, node)
 			return nil
@@ -267,7 +267,7 @@ func New(ctx context.Context, c clientset.Interface, podInformer corev1informers
 			tm.NodeUpdated(node, nil)
 			return nil
 		}),
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		return nil, fmt.Errorf("unable to add node event handler: %w", err)
 	}
@@ -277,7 +277,7 @@ func New(ctx context.Context, c clientset.Interface, podInformer corev1informers
 
 // Run starts the controller which will run in loop until `stopCh` is closed.
 func (tc *Controller) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting", "controller", tc.name)

--- a/pkg/controller/ttl/ttl_controller.go
+++ b/pkg/controller/ttl/ttl_controller.go
@@ -79,15 +79,18 @@ type Controller struct {
 
 // NewTTLController creates a new TTLController
 func NewTTLController(ctx context.Context, nodeInformer informers.NodeInformer, kubeClient clientset.Interface) *Controller {
+	logger := klog.FromContext(ctx)
 	ttlc := &Controller{
 		kubeClient: kubeClient,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "ttlcontroller"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "ttlcontroller",
+			},
 		),
 	}
-	logger := klog.FromContext(ctx)
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = nodeInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			ttlc.addNode(logger, obj)
 		},
@@ -97,6 +100,8 @@ func NewTTLController(ctx context.Context, nodeInformer informers.NodeInformer, 
 		DeleteFunc: func(obj interface{}) {
 			ttlc.deleteNode(logger, obj)
 		},
+	}, cache.HandlerOptions{
+		Logger: &logger,
 	})
 
 	ttlc.nodeStore = listers.NewNodeLister(nodeInformer.Informer().GetIndexer())
@@ -123,7 +128,7 @@ var (
 
 // Run begins watching and syncing.
 func (ttlc *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting TTL controller")

--- a/pkg/controller/ttl/ttl_controller_test.go
+++ b/pkg/controller/ttl/ttl_controller_test.go
@@ -231,7 +231,7 @@ func TestDesiredTTL(t *testing.T) {
 	for i, testCase := range testCases {
 		logger, _ := ktesting.NewTestContext(t)
 		ttlController := &Controller{
-			queue:             workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+			queue:             workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()), //nolint:logcheck // Intentionally testing old API here.
 			nodeCount:         testCase.nodeCount,
 			desiredTTLSeconds: testCase.desiredTTL,
 			boundaryStep:      testCase.boundaryStep,

--- a/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
+++ b/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
@@ -76,24 +76,29 @@ func New(ctx context.Context, jobInformer batchinformers.JobInformer, client cli
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: client.CoreV1().Events("")})
 
 	metrics.Register()
+	logger := klog.FromContext(ctx)
 
 	tc := &Controller{
 		client:   client,
 		recorder: eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "ttl-after-finished-controller"}),
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "ttl_jobs_to_delete"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "ttl_jobs_to_delete",
+			},
 		),
 	}
 
-	logger := klog.FromContext(ctx)
-	jobInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = jobInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			tc.addJob(logger, obj)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			tc.updateJob(logger, oldObj, newObj)
 		},
+	}, cache.HandlerOptions{
+		Logger: &logger,
 	})
 
 	tc.jLister = jobInformer.Lister()
@@ -106,7 +111,7 @@ func New(ctx context.Context, jobInformer batchinformers.JobInformer, client cli
 
 // Run starts the workers to clean up Jobs.
 func (tc *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting TTL after finished controller")

--- a/pkg/controller/validatingadmissionpolicystatus/controller.go
+++ b/pkg/controller/validatingadmissionpolicystatus/controller.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/api/admissionregistration/v1"
+	v1 "k8s.io/api/admissionregistration/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -33,6 +33,7 @@ import (
 	admissionregistrationv1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
 )
 
 // ControllerName has "Status" in it to differentiate this controller with the other that runs in API server.
@@ -53,7 +54,7 @@ type Controller struct {
 }
 
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	var wg sync.WaitGroup
 	defer func() {
@@ -73,24 +74,27 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	<-ctx.Done()
 }
 
-func NewController(policyInformer informerv1.ValidatingAdmissionPolicyInformer, policyClient admissionregistrationv1.ValidatingAdmissionPolicyInterface, typeChecker *validatingadmissionpolicy.TypeChecker) (*Controller, error) {
+func NewController(logger klog.Logger, policyInformer informerv1.ValidatingAdmissionPolicyInformer, policyClient admissionregistrationv1.ValidatingAdmissionPolicyInterface, typeChecker *validatingadmissionpolicy.TypeChecker) (*Controller, error) {
 	c := &Controller{
 		policyInformer: policyInformer,
 		policyQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: ControllerName},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   ControllerName,
+			},
 		),
 		policyClient: policyClient,
 		typeChecker:  typeChecker,
 	}
-	reg, err := policyInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	reg, err := policyInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			c.enqueuePolicy(obj)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			c.enqueuePolicy(newObj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/validatingadmissionpolicystatus/controller.go
+++ b/pkg/controller/validatingadmissionpolicystatus/controller.go
@@ -74,7 +74,8 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	<-ctx.Done()
 }
 
-func NewController(logger klog.Logger, policyInformer informerv1.ValidatingAdmissionPolicyInformer, policyClient admissionregistrationv1.ValidatingAdmissionPolicyInterface, typeChecker *validatingadmissionpolicy.TypeChecker) (*Controller, error) {
+func NewController(ctx context.Context, policyInformer informerv1.ValidatingAdmissionPolicyInformer, policyClient admissionregistrationv1.ValidatingAdmissionPolicyInterface, typeChecker *validatingadmissionpolicy.TypeChecker) (*Controller, error) {
+	logger := klog.FromContext(ctx)
 	c := &Controller{
 		policyInformer: policyInformer,
 		policyQueue: workqueue.NewTypedRateLimitingQueueWithConfig(

--- a/pkg/controller/validatingadmissionpolicystatus/controller_test.go
+++ b/pkg/controller/validatingadmissionpolicystatus/controller_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/kubernetes/pkg/generated/openapi"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func TestTypeChecking(t *testing.T) {
@@ -95,8 +96,7 @@ func TestTypeChecking(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-			defer cancel()
+			tCtx := ktesting.Init(t).WithTimeout(time.Minute, "test timed out")
 			policy := tc.policy.DeepCopy()
 			policy.ObjectMeta.Generation = 1 // fake storage does not do this automatically
 			client := fake.NewSimpleClientset(policy)
@@ -106,6 +106,7 @@ func TestTypeChecking(t *testing.T) {
 				RestMapper:     testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme),
 			}
 			controller, err := NewController(
+				tCtx.Logger(),
 				informerFactory.Admissionregistration().V1().ValidatingAdmissionPolicies(),
 				client.AdmissionregistrationV1().ValidatingAdmissionPolicies(),
 				typeChecker,
@@ -113,10 +114,10 @@ func TestTypeChecking(t *testing.T) {
 			if err != nil {
 				t.Fatalf("cannot create controller: %v", err)
 			}
-			informerFactory.Start(ctx.Done())
-			informerFactory.WaitForCacheSync(ctx.Done())
-			go controller.Run(ctx, 1)
-			err = wait.PollUntilContextCancel(ctx, time.Second, false, func(ctx context.Context) (done bool, err error) {
+			informerFactory.StartWithContext(tCtx)
+			informerFactory.WaitForCacheSyncWithContext(tCtx)
+			go controller.Run(tCtx, 1)
+			err = wait.PollUntilContextCancel(tCtx, time.Second, false, func(ctx context.Context) (done bool, err error) {
 				name := policy.Name
 				// wait until the typeChecking is set, which means the type checking
 				// is complete.

--- a/pkg/controller/validatingadmissionpolicystatus/controller_test.go
+++ b/pkg/controller/validatingadmissionpolicystatus/controller_test.go
@@ -106,7 +106,7 @@ func TestTypeChecking(t *testing.T) {
 				RestMapper:     testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme),
 			}
 			controller, err := NewController(
-				tCtx.Logger(),
+				tCtx,
 				informerFactory.Admissionregistration().V1().ValidatingAdmissionPolicies(),
 				client.AdmissionregistrationV1().ValidatingAdmissionPolicies(),
 				typeChecker,

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -132,7 +132,10 @@ func NewAttachDetachController(
 		nodesSynced: nodeInformer.Informer().HasSynced,
 		pvcQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "pvcs"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "pvcs",
+			},
 		),
 	}
 
@@ -332,7 +335,7 @@ type attachDetachController struct {
 }
 
 func (adc *attachDetachController) Run(ctx context.Context) {
-	defer runtime.HandleCrash()
+	defer runtime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	adc.broadcaster.StartStructuredLogging(3)

--- a/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
@@ -100,8 +100,8 @@ func Test_AttachDetachControllerStateOfWorldPopulators_Positive(t *testing.T) {
 	adc := createADC(t, tCtx, fakeKubeClient, informerFactory, plugins)
 
 	// Act
-	informerFactory.Start(tCtx.Done())
-	informerFactory.WaitForCacheSync(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
+	informerFactory.WaitForCacheSyncWithContext(tCtx)
 
 	err := adc.populateActualStateOfWorld(logger)
 	if err != nil {
@@ -209,8 +209,8 @@ func BenchmarkPopulateActualStateOfWorld(b *testing.B) {
 	adc := createADC(b, tCtx, fakeKubeClient, informerFactory, nil)
 
 	// Act
-	informerFactory.Start(tCtx.Done())
-	informerFactory.WaitForCacheSync(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
+	informerFactory.WaitForCacheSyncWithContext(tCtx)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -229,8 +229,8 @@ func BenchmarkNodeUpdate(b *testing.B) {
 	logger := tCtx.Logger()
 	adc := createADC(b, tCtx, fakeKubeClient, informerFactory, nil)
 
-	informerFactory.Start(tCtx.Done())
-	informerFactory.WaitForCacheSync(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
+	informerFactory.WaitForCacheSyncWithContext(tCtx)
 
 	err := adc.populateActualStateOfWorld(logger.V(2))
 	if err != nil {
@@ -351,7 +351,7 @@ func attachDetachRecoveryTestCase(t *testing.T, extraPods1 []*v1.Pod, extraPods2
 		_ = csiNodeInformer.GetIndexer().Add(&csiNode)
 	}
 
-	informerFactory.Start(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
 
 	if !kcache.WaitForNamedCacheSyncWithContext(tCtx,
 		informerFactory.Core().V1().Pods().Informer().HasSynced,
@@ -661,7 +661,7 @@ func volumeAttachmentRecoveryTestCase(t *testing.T, tc vaTest) {
 	}
 
 	// Makesure the informer cache is synced
-	informerFactory.Start(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
 
 	if !kcache.WaitForNamedCacheSyncWithContext(tCtx,
 		informerFactory.Core().V1().Pods().Informer().HasSynced,

--- a/pkg/controller/volume/ephemeral/controller.go
+++ b/pkg/controller/volume/ephemeral/controller.go
@@ -91,7 +91,10 @@ func NewController(
 		pvcsSynced: pvcInformer.Informer().HasSynced,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "ephemeral_volume"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "ephemeral_volume",
+			},
 		),
 	}
 
@@ -175,7 +178,7 @@ func (ec *ephemeralController) onPVCDelete(obj interface{}) {
 }
 
 func (ec *ephemeralController) Run(ctx context.Context, workers int) {
-	defer runtime.HandleCrash()
+	defer runtime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting ephemeral volume controller")

--- a/pkg/controller/volume/ephemeral/controller_test.go
+++ b/pkg/controller/volume/ephemeral/controller_test.go
@@ -152,8 +152,8 @@ func TestSyncHandler(t *testing.T) {
 			defer ec.queue.ShutDown()
 
 			// Ensure informers are up-to-date.
-			informerFactory.Start(ctx.Done())
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.StartWithContext(ctx)
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 			cache.WaitForCacheSync(ctx.Done(), podInformer.Informer().HasSynced, pvcInformer.Informer().HasSynced)
 
 			err = ec.syncHandler(context.TODO(), tc.podKey)

--- a/pkg/controller/volume/expand/expand_controller.go
+++ b/pkg/controller/volume/expand/expand_controller.go
@@ -111,7 +111,10 @@ func NewExpandController(
 		pvcsSynced: pvcInformer.Informer().HasSynced,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "volume_expand"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "volume_expand",
+			},
 		),
 		translator:               translator,
 		csiMigratedPluginManager: csiMigratedPluginManager,
@@ -326,7 +329,7 @@ func (expc *expandController) expand(logger klog.Logger, pvc *v1.PersistentVolum
 
 // TODO make concurrency configurable (workers argument). previously, nestedpendingoperations spawned unlimited goroutines
 func (expc *expandController) Run(ctx context.Context) {
-	defer runtime.HandleCrash()
+	defer runtime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting expand controller")

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -91,11 +91,17 @@ func NewController(ctx context.Context, p ControllerParameters) (*PersistentVolu
 		createProvisionedPVInterval:   createProvisionedPVInterval,
 		claimQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "claims"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "claims",
+			},
 		),
 		volumeQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "volumes"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "volumes",
+			},
 		),
 		resyncPeriod:        p.SyncPeriod,
 		operationTimestamps: metrics.NewOperationStartTimeCache(),
@@ -322,7 +328,7 @@ func (ctrl *PersistentVolumeController) deleteClaim(ctx context.Context, claim *
 
 // Run starts all of this controller's control loops
 func (ctrl *PersistentVolumeController) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	ctrl.eventBroadcaster.StartStructuredLogging(3)

--- a/pkg/controller/volume/persistentvolume/pv_controller_test.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_test.go
@@ -361,8 +361,8 @@ func TestControllerSync(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.TODO())
 		defer cancel()
 
-		informers.Start(ctx.Done())
-		informers.WaitForCacheSync(ctx.Done())
+		informers.StartWithContext(ctx)
+		informers.WaitForCacheSyncWithContext(ctx)
 
 		wg.Go(func() {
 			ctrl.Run(ctx)

--- a/pkg/controller/volume/persistentvolume/testing/testing.go
+++ b/pkg/controller/volume/persistentvolume/testing/testing.go
@@ -271,11 +271,11 @@ func (r *VolumeReactor) React(ctx context.Context, action core.Action) (handled 
 
 // Watch watches objects from the VolumeReactor. Watch returns a channel which
 // will push added / modified / deleted object.
-func (r *VolumeReactor) Watch(gvr schema.GroupVersionResource, ns string) (watch.Interface, error) {
+func (r *VolumeReactor) Watch(logger klog.Logger, gvr schema.GroupVersionResource, ns string) (watch.Interface, error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	fakewatcher := watch.NewRaceFreeFake()
+	fakewatcher := watch.NewRaceFreeFakeWithLogger(logger)
 
 	if _, exists := r.watchers[gvr]; !exists {
 		r.watchers[gvr] = make(map[string][]*watch.RaceFreeFakeWatcher)

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
@@ -127,7 +127,10 @@ func NewPVCProtectionController(logger klog.Logger, pvcInformer coreinformers.Pe
 		client: cl,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "pvcprotection"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "pvcprotection",
+			},
 		),
 		pvcProcessingStore: NewPVCProcessingStore(),
 	}
@@ -172,7 +175,7 @@ func NewPVCProtectionController(logger klog.Logger, pvcInformer coreinformers.Pe
 
 // Run runs the controller goroutines.
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting PVC protection controller")

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
@@ -122,7 +122,8 @@ var unusedSinceNowFunc = metav1.Now
 type podUsageCheckFunc func(logger klog.Logger, pod *v1.Pod, pvc *v1.PersistentVolumeClaim) bool
 
 // NewPVCProtectionController returns a new instance of PVCProtectionController.
-func NewPVCProtectionController(logger klog.Logger, pvcInformer coreinformers.PersistentVolumeClaimInformer, podInformer coreinformers.PodInformer, cl clientset.Interface) (*Controller, error) {
+func NewPVCProtectionController(ctx context.Context, pvcInformer coreinformers.PersistentVolumeClaimInformer, podInformer coreinformers.PodInformer, cl clientset.Interface) (*Controller, error) {
+	logger := klog.FromContext(ctx)
 	e := &Controller{
 		client: cl,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller_test.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller_test.go
@@ -736,8 +736,8 @@ func TestPVCProtectionController(t *testing.T) {
 		podInformer := informers.Core().V1().Pods()
 
 		// Create the controller
-		logger, _ := ktesting.NewTestContext(t)
-		ctrl, err := NewPVCProtectionController(logger, pvcInformer, podInformer, client)
+		logger, ctx := ktesting.NewTestContext(t)
+		ctrl, err := NewPVCProtectionController(ctx, pvcInformer, podInformer, client)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/pkg/controller/volume/pvprotection/pv_protection_controller.go
+++ b/pkg/controller/volume/pvprotection/pv_protection_controller.go
@@ -55,7 +55,10 @@ func NewPVProtectionController(logger klog.Logger, pvInformer coreinformers.Pers
 		client: cl,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "pvprotection"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "pvprotection",
+			},
 		),
 	}
 
@@ -78,7 +81,7 @@ func NewPVProtectionController(logger klog.Logger, pvInformer coreinformers.Pers
 
 // Run runs the controller goroutines.
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting PV protection controller")

--- a/pkg/controller/volume/pvprotection/pv_protection_controller.go
+++ b/pkg/controller/volume/pvprotection/pv_protection_controller.go
@@ -50,7 +50,8 @@ type Controller struct {
 }
 
 // NewPVProtectionController returns a new *Controller.
-func NewPVProtectionController(logger klog.Logger, pvInformer coreinformers.PersistentVolumeInformer, cl clientset.Interface) (*Controller, error) {
+func NewPVProtectionController(ctx context.Context, pvInformer coreinformers.PersistentVolumeInformer, cl clientset.Interface) (*Controller, error) {
+	logger := klog.FromContext(ctx)
 	e := &Controller{
 		client: cl,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(

--- a/pkg/controller/volume/pvprotection/pv_protection_controller_test.go
+++ b/pkg/controller/volume/pvprotection/pv_protection_controller_test.go
@@ -209,8 +209,8 @@ func TestPVProtectionController(t *testing.T) {
 		}
 
 		// Create the controller
-		logger, _ := ktesting.NewTestContext(t)
-		ctrl, err := NewPVProtectionController(logger, pvInformer, client)
+		logger, ctx := ktesting.NewTestContext(t)
+		ctrl, err := NewPVProtectionController(ctx, pvInformer, client)
 		if err != nil {
 			t.Fatalf("unexpected error constructing controller: %v", err)
 		}

--- a/pkg/controller/volume/selinuxwarning/selinux_warning_controller.go
+++ b/pkg/controller/volume/selinuxwarning/selinux_warning_controller.go
@@ -117,7 +117,8 @@ func NewController(
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig[cache.ObjectName](
 			workqueue.DefaultTypedControllerRateLimiter[cache.ObjectName](),
 			workqueue.TypedRateLimitingQueueConfig[cache.ObjectName]{
-				Name: "selinux_warning",
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "selinux_warning",
 			},
 		),
 		labelCache: volumecache.NewVolumeLabelCache(seLinuxTranslator),
@@ -355,7 +356,7 @@ func (c *Controller) enqueueAllPodsForCSIDriver(csiDriverName string) {
 }
 
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting SELinux warning controller")

--- a/pkg/controller/volume/selinuxwarning/selinux_warning_controller_test.go
+++ b/pkg/controller/volume/selinuxwarning/selinux_warning_controller_test.go
@@ -534,8 +534,8 @@ func TestSELinuxWarningController_Sync(t *testing.T) {
 			c.eventRecorder = fakeRecorder
 
 			// Start the informers
-			fakeInformerFactory.Start(ctx.Done())
-			fakeInformerFactory.WaitForCacheSync(ctx.Done())
+			fakeInformerFactory.StartWithContext(ctx)
+			fakeInformerFactory.WaitForCacheSyncWithContext(ctx)
 			// Start the controller
 			wg.Go(func() {
 				c.Run(ctx, 1)

--- a/pkg/controller/volume/vacprotection/vac_protection_controller.go
+++ b/pkg/controller/volume/vacprotection/vac_protection_controller.go
@@ -108,7 +108,8 @@ func NewVACProtectionController(logger klog.Logger,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "vacprotection",
+				Logger: &logger,
+				Name:   "vacprotection",
 			},
 		),
 	}
@@ -209,7 +210,7 @@ func NewVACProtectionController(logger klog.Logger,
 
 // Run runs the controller goroutines.
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting VAC protection controller")

--- a/pkg/controller/volume/vacprotection/vac_protection_controller.go
+++ b/pkg/controller/volume/vacprotection/vac_protection_controller.go
@@ -94,11 +94,12 @@ type Controller struct {
 }
 
 // NewVACProtectionController returns a new *Controller.
-func NewVACProtectionController(logger klog.Logger,
+func NewVACProtectionController(ctx context.Context,
 	client clientset.Interface,
 	pvcInformer coreinformers.PersistentVolumeClaimInformer,
 	pvInformer coreinformers.PersistentVolumeInformer,
 	vacInformer storageinformers.VolumeAttributesClassInformer) (*Controller, error) {
+	logger := klog.FromContext(ctx)
 	c := &Controller{
 		client:    client,
 		pvcSynced: pvcInformer.Informer().HasSynced,

--- a/pkg/controller/volume/vacprotection/vac_protection_controller_test.go
+++ b/pkg/controller/volume/vacprotection/vac_protection_controller_test.go
@@ -292,8 +292,8 @@ func TestVACProtectionController(t *testing.T) {
 		}
 
 		// Create the controller
-		logger, _ := ktesting.NewTestContext(t)
-		ctrl, err := NewVACProtectionController(logger, client, pvcInformer, pvInformer, vacInformer)
+		logger, ctx := ktesting.NewTestContext(t)
+		ctrl, err := NewVACProtectionController(ctx, client, pvcInformer, pvInformer, vacInformer)
 		require.NoError(t, err, "failed to create controller")
 
 		// Start the test by simulating an event

--- a/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
@@ -153,7 +153,7 @@ func newTestBinder(t *testing.T, ctx context.Context) *testEnv {
 	client.AddWatchReactor("*", func(action k8stesting.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
 		ns := action.GetNamespace()
-		watch, err := reactor.Watch(gvr, ns)
+		watch, err := reactor.Watch(logger, gvr, ns)
 		if err != nil {
 			return false, nil, err
 		}

--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -38,7 +38,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/util/keyutil"
-	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 	"k8s.io/kubernetes/pkg/controller"
 	serviceaccountcontroller "k8s.io/kubernetes/pkg/controller/serviceaccount"
@@ -401,7 +400,7 @@ func startServiceAccountTestServerAndWaitForCaches(ctx context.Context, t *testi
 		return rootClientset, clientConfig, stop, informers, err
 	}
 	tokenController, err := serviceaccountcontroller.NewTokensController(
-		klog.FromContext(ctx),
+		ctx,
 		informers.Core().V1().ServiceAccounts(),
 		informers.Core().V1().Secrets(),
 		rootClientset,
@@ -413,9 +412,8 @@ func startServiceAccountTestServerAndWaitForCaches(ctx context.Context, t *testi
 		return rootClientset, clientConfig, stop, informers, err
 	}
 	go tokenController.Run(ctx, 1)
-	logger := klog.FromContext(ctx)
 	serviceAccountController, err := serviceaccountcontroller.NewServiceAccountsController(
-		logger,
+		ctx,
 		informers.Core().V1().ServiceAccounts(),
 		informers.Core().V1().Namespaces(),
 		rootClientset,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Kubernetes 1.37 finished the introduction of context-aware client-go APIs. Components like kube-controller-manager which are meant to support contextual logging should use those new APIs.

This is not enforced yet because existing code must be updated first. Once that is done, enforcement of everything touched here can be enabled tree-wide.

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/pull/141647.

#### Special notes for your reviewer:

I could split this up further, for example into one PR or one commit per API type - please let me know what you prefer. I've not split up by controller because the changes are very similar, so it might be easier to see them all at once.

@soltysh @atiratree: is this something you can help with?

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
