### PR TITLE
Automated cherry pick of #140873: Revert e2e test IPVS session affinity timeout changes

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -88,10 +88,6 @@ const (
 	// affinity is enabled.
 	AffinityConfirmCount = 15
 
-	// SessionAffinityTimeout is the number of seconds to wait between requests for
-	// session affinity to timeout before trying a load-balancer request again
-	SessionAffinityTimeout = 125
-
 	// label define which is used to find kube-proxy and kube-apiserver pod
 	kubeProxyLabelName     = "kube-proxy"
 	clusterAddonLabelKey   = "k8s-app"
@@ -4201,7 +4197,7 @@ func execAffinityTestForSessionAffinityTimeout(ctx context.Context, f *framework
 	ginkgo.By("creating service in namespace " + ns)
 	serviceType := svc.Spec.Type
 	// set an affinity timeout equal to the number of connection requests
-	svcSessionAffinityTimeout := int32(SessionAffinityTimeout)
+	svcSessionAffinityTimeout := int32(AffinityConfirmCount)
 	svc.Spec.SessionAffinity = v1.ServiceAffinityClientIP
 	svc.Spec.SessionAffinityConfig = &v1.SessionAffinityConfig{
 		ClientIP: &v1.ClientIPConfig{TimeoutSeconds: &svcSessionAffinityTimeout},
@@ -4237,37 +4233,34 @@ func execAffinityTestForSessionAffinityTimeout(ctx context.Context, f *framework
 	err = jig.CheckServiceReachability(ctx, svc, execPod)
 	framework.ExpectNoError(err)
 
-	// the service should be sticky until the timeout expires
+	ginkgo.By("checking that affinity holds when making multiple connections separated by less than the affinity timeout")
 	if !checkAffinity(ctx, cs, execPod, svcIP, servicePort, true) {
 		framework.Failf("the service %s (%s:%d) should be sticky until the timeout expires", svc.Name, svcIP, servicePort)
 	}
-	// but it should return different hostnames after the timeout expires
-	// try several times to avoid the probability that we hit the same pod twice
+
+	ginkgo.By("checking that affinity DOES NOT hold when making connections separated by more than the affinity timeout")
 	hosts := sets.NewString()
 	cmd := fmt.Sprintf(`curl -q -s --connect-timeout 2 http://%s/`, net.JoinHostPort(svcIP, strconv.Itoa(servicePort)))
+	// Even if affinity times out correctly, there's no guarantee that we'll get a
+	// different endpoint the second time we connect, since the new random endpoint
+	// might happen to be the same as the old random endpoint. But if we retry enough
+	// times (and affinity actually is timing out) then we'll eventually get a
+	// different endpoint.
 	for range 10 {
 		hostname, err := e2eoutput.RunHostCmd(execPod.Namespace, execPod.Name, cmd)
-		if err == nil {
-			hosts.Insert(hostname)
-			if hosts.Len() > 1 {
-				return
-			}
-			// In some case, ipvs didn't deleted the persistent connection after timeout expired,
-			// use 'ipvsadm -lnc' command can found the expire time become '13171233:02' after '00:00'
-			//
-			// pro expire state       source             virtual            destination
-			// TCP 00:00  NONE        10.105.253.160:0   10.105.253.160:80  10.244.1.25:9376
-			//
-			// pro expire state       source             virtual            destination
-			// TCP 13171233:02 NONE        10.105.253.160:0   10.105.253.160:80  10.244.1.25:9376
-			//
-			// And 2 seconds later, the connection will be ensure deleted,
-			// so we sleep 'svcSessionAffinityTimeout+5' seconds to avoid this issue.
-			// TODO: figure out why the expired connection didn't be deleted and fix this issue in ipvs side.
-			time.Sleep(time.Duration(svcSessionAffinityTimeout+5) * time.Second)
+		framework.ExpectNoError(err)
+
+		hosts.Insert(hostname)
+		if hosts.Len() > 1 {
+			// Success: affinity was broken.
+			return
 		}
+
+		// The service is now pinned to hostname; wait for that to expire
+		// before trying again.
+		time.Sleep(time.Duration(svcSessionAffinityTimeout+5) * time.Second)
 	}
-	framework.Fail("Session is sticky after reaching the timeout")
+	framework.Failf("Session is still sticky after reaching the %ds timeout", svcSessionAffinityTimeout)
 }
 
 func execAffinityTestForNonLBServiceWithTransition(ctx context.Context, f *framework.Framework, cs clientset.Interface, svc *v1.Service) {


### PR DESCRIPTION
Cherry pick of #140873 on release-1.37.

#140873: Revert e2e test IPVS session affinity timeout changes

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup
/kind flake


```release-note
NONE
```