### PR TITLE
kubelet: stop logging HTTP probe headers

### DIFF
--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -170,8 +170,7 @@ func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe
 			host := req.URL.Hostname()
 			path := req.URL.Path
 			scheme := req.URL.Scheme
-			headers := p.HTTPGet.HTTPHeaders
-			loggerV4.Info("HTTP-Probe", "scheme", scheme, "host", host, "port", port, "path", path, "timeout", timeout, "headers", headers, "probeType", probeType)
+			loggerV4.Info("HTTP-Probe", "scheme", scheme, "host", host, "port", port, "path", path, "timeout", timeout, "probeType", probeType)
 		}
 		if p.HTTPGet.Protocol != nil && *p.HTTPGet.Protocol == v1.HTTPProtocolHTTP2 &&
 			utilfeature.DefaultFeatureGate.Enabled(features.H2CContainerProbe) {

--- a/pkg/kubelet/prober/prober_test.go
+++ b/pkg/kubelet/prober/prober_test.go
@@ -21,9 +21,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,6 +35,8 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/klog/v2"
+	klogtesting "k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -277,6 +281,52 @@ func TestProbe(t *testing.T) {
 			}
 		}
 	}
+}
+
+type fakeSuccessHTTPProber struct{}
+
+func (fakeSuccessHTTPProber) Probe(_ *http.Request, _ time.Duration) (probe.Result, string, error) {
+	return probe.Success, "", nil
+}
+
+func (fakeSuccessHTTPProber) ProbeH2C(_ *http.Request, _ time.Duration) (probe.Result, string, error) {
+	return probe.Success, "", nil
+}
+
+func TestRunProbeDoesNotLogHTTPHeaderValues(t *testing.T) {
+	const secretValue = "Bearer kubelet-probe-secret-token"
+
+	logger := klogtesting.NewLogger(t, klogtesting.NewConfig(klogtesting.BufferLogs(true), klogtesting.Verbosity(4)))
+	ctx := klog.NewContext(context.Background(), logger)
+	pb := &prober{http: fakeSuccessHTTPProber{}}
+	p := &v1.Probe{
+		ProbeHandler: v1.ProbeHandler{
+			HTTPGet: &v1.HTTPGetAction{
+				Path: "/healthz",
+				Port: intstr.FromInt32(8080),
+				HTTPHeaders: []v1.HTTPHeader{
+					{Name: "Authorization", Value: secretValue},
+				},
+			},
+		},
+	}
+
+	_, _, err := pb.runProbe(
+		ctx,
+		liveness,
+		p,
+		&v1.Pod{},
+		v1.PodStatus{PodIP: "127.0.0.1"},
+		v1.Container{Name: "app"},
+		kubecontainer.ContainerID{Type: "test", ID: "container"},
+	)
+	require.NoError(t, err)
+
+	underlier, ok := logger.GetSink().(klogtesting.Underlier)
+	require.True(t, ok, "expected ktesting log sink, got %T", logger.GetSink())
+	logs := underlier.GetBuffer().String()
+	require.Contains(t, logs, "HTTP-Probe", "expected HTTP probe debug log")
+	require.NotContains(t, logs, secretValue, "HTTP probe log must not contain header values")
 }
 
 func TestNewExecInContainer(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Kubelet currently includes the raw `HTTPGet.HTTPHeaders` field in the V(4) `HTTP-Probe` log entry. Because these values come directly from the PodSpec, probe credentials such as Authorization tokens, cookies, or API keys can be written to verbose kubelet logs.

This change removes the `headers` field from that debug log while preserving the remaining probe diagnostics (scheme, host, port, path, timeout, and probe type). The HTTP request itself is unchanged.

A regression test captures V(4) probe logs and verifies that a configured Authorization value is not emitted.

#### Which issue(s) this PR is related to:

Fixes #140174

#### Special notes for your reviewer:

There is an existing PR, #140196, which takes the alternative approach of constructing a slice containing only header names. Review discussion there raised a concern about allocating a sanitized header collection on every probe and suggested caching it, potentially in conjunction with #115939.

This PR instead uses the other behavior explicitly allowed by #140174: it omits the `headers` field entirely. That avoids exposing header values without adding a new per-probe allocation or depending on request/header caching work.

Validation performed locally:

- `go test ./pkg/kubelet/prober -run '^TestRunProbeDoesNotLogHTTPHeaderValues$' -count=1 -v`
- `go test ./pkg/kubelet/prober -count=1`
- `go test -race ./pkg/kubelet/prober -run '^TestRunProbeDoesNotLogHTTPHeaderValues$' -count=1`
- `make test WHAT=./pkg/kubelet/prober GOFLAGS='-count=1'`
- `hack/verify-gofmt.sh`
- `git diff --check`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```

#### AI usage disclosure:

YES. AI was used to inspect the issue and existing review context, help implement the focused code/test change, and run the local validation commands. The submitted change was reviewed against the repository contribution guidance and AGENTS.md requirements.
