### PR TITLE
pkg/volume/csi: pass context to nodeinfomanager methods

### DIFF
--- a/pkg/kubelet/volumemanager/volumehealth/manager.go
+++ b/pkg/kubelet/volumemanager/volumehealth/manager.go
@@ -37,7 +37,7 @@ type StatusUpdater interface {
 
 // CSINodeUpdater updates CSINode.Status.StorageHealth.
 type CSINodeUpdater interface {
-	UpdateCSINodeStorageHealth(driverName string, conditions []storagev1.StorageHealthCondition) error
+	UpdateCSINodeStorageHealth(ctx context.Context, driverName string, conditions []storagev1.StorageHealthCondition) error
 }
 
 // HealthClientFactory creates CSI health clients for registered drivers.
@@ -167,7 +167,7 @@ func (m *manager) probeStorageHealth(ctx context.Context) {
 		setStorageHealthGauges(driverName, gaugeKeys)
 
 		// Dedup lives in nodeinfomanager.UpdateCSINodeStorageHealth.
-		if err := updater.UpdateCSINodeStorageHealth(driverName, backendHealth); err != nil {
+		if err := updater.UpdateCSINodeStorageHealth(ctx, driverName, backendHealth); err != nil {
 			logger.Error(err, "Failed to update CSINode storage health", "driver", driverName)
 		}
 	}

--- a/pkg/kubelet/volumemanager/volumehealth/manager_test.go
+++ b/pkg/kubelet/volumemanager/volumehealth/manager_test.go
@@ -112,7 +112,7 @@ type storageCall struct {
 	conditions []storagev1.StorageHealthCondition
 }
 
-func (f *fakeCSINodeUpdater) UpdateCSINodeStorageHealth(driverName string, conditions []storagev1.StorageHealthCondition) error {
+func (f *fakeCSINodeUpdater) UpdateCSINodeStorageHealth(ctx context.Context, driverName string, conditions []storagev1.StorageHealthCondition) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.calls = append(f.calls, storageCall{

--- a/pkg/volume/csi/csi_plugin.go
+++ b/pkg/volume/csi/csi_plugin.go
@@ -148,15 +148,15 @@ func (h *RegistrationHandler) RegisterPlugin(ctx context.Context, pluginName str
 
 	driverNodeID, maxVolumePerNode, accessibleTopology, err := csi.NodeGetInfo(newCtx)
 	if err != nil {
-		if unregErr := unregisterDriver(pluginName); unregErr != nil {
+		if unregErr := unregisterDriver(ctx, pluginName); unregErr != nil {
 			klog.Error(log("registrationHandler.RegisterPlugin failed to unregister plugin due to previous error: %v", unregErr))
 		}
 		return err
 	}
 
-	err = nim.InstallCSIDriver(pluginName, driverNodeID, maxVolumePerNode, accessibleTopology)
+	err = nim.InstallCSIDriver(ctx, pluginName, driverNodeID, maxVolumePerNode, accessibleTopology)
 	if err != nil {
-		if unregErr := unregisterDriver(pluginName); unregErr != nil {
+		if unregErr := unregisterDriver(ctx, pluginName); unregErr != nil {
 			klog.Error(log("registrationHandler.RegisterPlugin failed to unregister plugin due to previous error: %v", unregErr))
 		}
 		return err
@@ -183,7 +183,7 @@ func updateCSIDriver(pluginName string) error {
 		return fmt.Errorf("failed to get NodeGetInfo from driver %q: %w", pluginName, err)
 	}
 
-	if err := nim.UpdateCSIDriver(pluginName, driverNodeID, maxVolumePerNode, accessibleTopology); err != nil {
+	if err := nim.UpdateCSIDriver(ctx, pluginName, driverNodeID, maxVolumePerNode, accessibleTopology); err != nil {
 		return fmt.Errorf("failed to update driver %q: %w", pluginName, err)
 	}
 	return nil
@@ -269,7 +269,7 @@ func (h *RegistrationHandler) validateVersions(callerName, pluginName string, en
 // it is no longer available
 func (h *RegistrationHandler) DeRegisterPlugin(ctx context.Context, pluginName, endpoint string) {
 	klog.Info(log("registrationHandler.DeRegisterPlugin request for plugin %s, endpoint %s", pluginName, endpoint))
-	if err := unregisterDriver(pluginName); err != nil {
+	if err := unregisterDriver(ctx, pluginName); err != nil {
 		klog.Error(log("registrationHandler.DeRegisterPlugin failed: %v", err))
 	}
 
@@ -393,7 +393,7 @@ func initializeCSINode(host volume.VolumeHost, csiDriverInformer cache.SharedInd
 		}
 		err = wait.ExponentialBackoff(initBackoff, func() (bool, error) {
 			klog.V(4).Infof("Initializing migrated drivers on CSINode")
-			err := nim.InitializeCSINodeWithAnnotation()
+			err := nim.InitializeCSINodeWithAnnotation(context.Background())
 			if err != nil {
 				kvh.SetKubeletError(fmt.Errorf("failed to initialize CSINode: %v", err))
 				klog.Errorf("Failed to initialize CSINode: %v", err)
@@ -959,10 +959,10 @@ func (p *csiPlugin) podInfoEnabled(driverName string) (bool, error) {
 	return true, nil
 }
 
-func unregisterDriver(driverName string) error {
+func unregisterDriver(ctx context.Context, driverName string) error {
 	csiDrivers.Delete(driverName)
 
-	if err := nim.UninstallCSIDriver(driverName); err != nil {
+	if err := nim.UninstallCSIDriver(ctx, driverName); err != nil {
 		return errors.New(log("Error uninstalling CSI driver: %v", err))
 	}
 

--- a/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go
+++ b/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go
@@ -76,28 +76,28 @@ type nodeUpdateFunc func(*v1.Node) (newNode *v1.Node, updated bool, err error)
 
 // Interface implements an interface for managing labels of a node
 type Interface interface {
-	CreateCSINode() (*storagev1.CSINode, error)
+	CreateCSINode(ctx context.Context) (*storagev1.CSINode, error)
 
 	// Updates or Creates the CSINode object with annotations for CSI Migration
-	InitializeCSINodeWithAnnotation() error
+	InitializeCSINodeWithAnnotation(ctx context.Context) error
 
 	// Record in the cluster the given node information from the CSI driver with the given name.
 	// Concurrent calls to InstallCSIDriver() is allowed, but they should not be intertwined with calls
 	// to other methods in this interface.
-	InstallCSIDriver(driverName string, driverNodeID string, maxVolumeLimit int64, topology map[string]string) error
+	InstallCSIDriver(ctx context.Context, driverName string, driverNodeID string, maxVolumeLimit int64, topology map[string]string) error
 
 	// UpdateCSIDriver updates CSIDrivers field in the CSINode object.
-	UpdateCSIDriver(driverName string, driverNodeID string, maxAttachLimit int64, topology map[string]string) error
+	UpdateCSIDriver(ctx context.Context, driverName string, driverNodeID string, maxAttachLimit int64, topology map[string]string) error
 
 	// Remove in the cluster node information from the CSI driver with the given name.
 	// Concurrent calls to UninstallCSIDriver() is allowed, but they should not be intertwined with calls
 	// to other methods in this interface.
-	UninstallCSIDriver(driverName string) error
+	UninstallCSIDriver(ctx context.Context, driverName string) error
 
 	// UpdateCSINodeStorageHealth updates CSINode.Status.StorageHealth for the given
 	// driver with the provided conditions. Other drivers' entries are preserved.
 	// No-ops if the condition identity set for this driver is unchanged.
-	UpdateCSINodeStorageHealth(driverName string, conditions []storagev1.StorageHealthCondition) error
+	UpdateCSINodeStorageHealth(ctx context.Context, driverName string, conditions []storagev1.StorageHealthCondition) error
 }
 
 // NewNodeInfoManager initializes nodeInfoManager
@@ -116,7 +116,7 @@ func NewNodeInfoManager(
 // CSINode object. If the CSINode object doesn't yet exist, it will be created.
 // If multiple calls to InstallCSIDriver() are made in parallel, some calls might receive Node or
 // CSINode update conflicts, which causes the function to retry the corresponding update.
-func (nim *nodeInfoManager) InstallCSIDriver(driverName string, driverNodeID string, maxAttachLimit int64, topology map[string]string) error {
+func (nim *nodeInfoManager) InstallCSIDriver(ctx context.Context, driverName string, driverNodeID string, maxAttachLimit int64, topology map[string]string) error {
 	if driverNodeID == "" {
 		return fmt.Errorf("error adding CSI driver node info: driverNodeID must not be empty")
 	}
@@ -126,12 +126,12 @@ func (nim *nodeInfoManager) InstallCSIDriver(driverName string, driverNodeID str
 		updateTopologyLabels(topology),
 	}
 
-	err := nim.updateNode(nodeUpdateFuncs...)
+	err := nim.updateNode(ctx, nodeUpdateFuncs...)
 	if err != nil {
 		return fmt.Errorf("error updating Node object with CSI driver node info: %v", err)
 	}
 
-	err = nim.updateCSINode(driverName, driverNodeID, maxAttachLimit, topology)
+	err = nim.updateCSINode(ctx, driverName, driverNodeID, maxAttachLimit, topology)
 	if err != nil {
 		return fmt.Errorf("error updating CSINode object with CSI driver node info: %v", err)
 	}
@@ -140,8 +140,8 @@ func (nim *nodeInfoManager) InstallCSIDriver(driverName string, driverNodeID str
 }
 
 // UpdateCSIDriver updates CSIDrivers field in the CSINode object.
-func (nim *nodeInfoManager) UpdateCSIDriver(driverName string, driverNodeID string, maxAttachLimit int64, topology map[string]string) error {
-	err := nim.updateCSINode(driverName, driverNodeID, maxAttachLimit, topology)
+func (nim *nodeInfoManager) UpdateCSIDriver(ctx context.Context, driverName string, driverNodeID string, maxAttachLimit int64, topology map[string]string) error {
+	err := nim.updateCSINode(ctx, driverName, driverNodeID, maxAttachLimit, topology)
 	if err != nil {
 		return fmt.Errorf("error updating CSINode object with CSI driver node info: %w", err)
 	}
@@ -152,13 +152,13 @@ func (nim *nodeInfoManager) UpdateCSIDriver(driverName string, driverNodeID stri
 // CSINode object. If the CSINodeInfo object contains no CSIDrivers, it will be deleted.
 // If multiple calls to UninstallCSIDriver() are made in parallel, some calls might receive Node or
 // CSINode update conflicts, which causes the function to retry the corresponding update.
-func (nim *nodeInfoManager) UninstallCSIDriver(driverName string) error {
-	err := nim.uninstallDriverFromCSINode(driverName)
+func (nim *nodeInfoManager) UninstallCSIDriver(ctx context.Context, driverName string) error {
+	err := nim.uninstallDriverFromCSINode(ctx, driverName)
 	if err != nil {
 		return fmt.Errorf("error uninstalling CSI driver from CSINode object %v", err)
 	}
 
-	err = nim.updateNode(
+	err = nim.updateNode(ctx,
 		removeNodeIDFromNode(driverName),
 	)
 	if err != nil {
@@ -167,10 +167,10 @@ func (nim *nodeInfoManager) UninstallCSIDriver(driverName string) error {
 	return nil
 }
 
-func (nim *nodeInfoManager) updateNode(updateFuncs ...nodeUpdateFunc) error {
+func (nim *nodeInfoManager) updateNode(ctx context.Context, updateFuncs ...nodeUpdateFunc) error {
 	var updateErrs []error
 	err := wait.ExponentialBackoff(updateBackoff, func() (bool, error) {
-		if err := nim.tryUpdateNode(updateFuncs...); err != nil {
+		if err := nim.tryUpdateNode(ctx, updateFuncs...); err != nil {
 			updateErrs = append(updateErrs, err)
 			return false, nil
 		}
@@ -187,7 +187,7 @@ func (nim *nodeInfoManager) updateNode(updateFuncs ...nodeUpdateFunc) error {
 // Because updateFuncs are applied sequentially, later updateFuncs should take into account
 // the effects of previous updateFuncs to avoid potential conflicts. For example, if multiple
 // functions update the same field, updates in the last function are persisted.
-func (nim *nodeInfoManager) tryUpdateNode(updateFuncs ...nodeUpdateFunc) error {
+func (nim *nodeInfoManager) tryUpdateNode(ctx context.Context, updateFuncs ...nodeUpdateFunc) error {
 	nim.lock.Lock()
 	defer nim.lock.Unlock()
 
@@ -200,7 +200,7 @@ func (nim *nodeInfoManager) tryUpdateNode(updateFuncs ...nodeUpdateFunc) error {
 	}
 
 	nodeClient := kubeClient.CoreV1().Nodes()
-	originalNode, err := nodeClient.Get(context.TODO(), string(nim.nodeName), metav1.GetOptions{})
+	originalNode, err := nodeClient.Get(ctx, string(nim.nodeName), metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -365,6 +365,7 @@ func updateTopologyLabels(topology map[string]string) nodeUpdateFunc {
 }
 
 func (nim *nodeInfoManager) updateCSINode(
+	ctx context.Context,
 	driverName string,
 	driverNodeID string,
 	maxAttachLimit int64,
@@ -377,7 +378,7 @@ func (nim *nodeInfoManager) updateCSINode(
 
 	var updateErrs []error
 	err := wait.ExponentialBackoff(updateBackoff, func() (bool, error) {
-		if err := nim.tryUpdateCSINode(csiKubeClient, driverName, driverNodeID, maxAttachLimit, topology); err != nil {
+		if err := nim.tryUpdateCSINode(ctx, csiKubeClient, driverName, driverNodeID, maxAttachLimit, topology); err != nil {
 			updateErrs = append(updateErrs, err)
 			return false, nil
 		}
@@ -390,6 +391,7 @@ func (nim *nodeInfoManager) updateCSINode(
 }
 
 func (nim *nodeInfoManager) tryUpdateCSINode(
+	ctx context.Context,
 	csiKubeClient clientset.Interface,
 	driverName string,
 	driverNodeID string,
@@ -399,22 +401,22 @@ func (nim *nodeInfoManager) tryUpdateCSINode(
 	nim.lock.Lock()
 	defer nim.lock.Unlock()
 
-	nodeInfo, err := csiKubeClient.StorageV1().CSINodes().Get(context.TODO(), string(nim.nodeName), metav1.GetOptions{})
+	nodeInfo, err := csiKubeClient.StorageV1().CSINodes().Get(ctx, string(nim.nodeName), metav1.GetOptions{})
 	if nodeInfo == nil || errors.IsNotFound(err) {
-		nodeInfo, err = nim.CreateCSINode()
+		nodeInfo, err = nim.CreateCSINode(ctx)
 	}
 	if err != nil {
 		return err
 	}
 
-	if err = nim.ensureNodeOwnsCSINode(nodeInfo); err != nil {
+	if err = nim.ensureNodeOwnsCSINode(ctx, nodeInfo); err != nil {
 		return err
 	}
 
-	return nim.installDriverToCSINode(nodeInfo, driverName, driverNodeID, maxAttachLimit, topology)
+	return nim.installDriverToCSINode(ctx, nodeInfo, driverName, driverNodeID, maxAttachLimit, topology)
 }
 
-func (nim *nodeInfoManager) InitializeCSINodeWithAnnotation() error {
+func (nim *nodeInfoManager) InitializeCSINodeWithAnnotation(ctx context.Context) error {
 	csiKubeClient := nim.volumeHost.GetKubeClient()
 	if csiKubeClient == nil {
 		return goerrors.New("error getting CSI client")
@@ -422,7 +424,7 @@ func (nim *nodeInfoManager) InitializeCSINodeWithAnnotation() error {
 
 	var lastErr error
 	err := wait.ExponentialBackoff(updateBackoff, func() (bool, error) {
-		if lastErr = nim.tryInitializeCSINodeWithAnnotation(csiKubeClient); lastErr != nil {
+		if lastErr = nim.tryInitializeCSINodeWithAnnotation(ctx, csiKubeClient); lastErr != nil {
 			klog.V(2).Infof("Failed to publish CSINode: %v", lastErr)
 			return false, nil
 		}
@@ -435,33 +437,33 @@ func (nim *nodeInfoManager) InitializeCSINodeWithAnnotation() error {
 	return nil
 }
 
-func (nim *nodeInfoManager) tryInitializeCSINodeWithAnnotation(csiKubeClient clientset.Interface) error {
+func (nim *nodeInfoManager) tryInitializeCSINodeWithAnnotation(ctx context.Context, csiKubeClient clientset.Interface) error {
 	nim.lock.Lock()
 	defer nim.lock.Unlock()
 
-	node, err := csiKubeClient.CoreV1().Nodes().Get(context.TODO(), string(nim.nodeName), metav1.GetOptions{})
+	node, err := csiKubeClient.CoreV1().Nodes().Get(ctx, string(nim.nodeName), metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
 	nim.nodeID = node.UID
 
-	nodeInfo, err := csiKubeClient.StorageV1().CSINodes().Get(context.TODO(), string(nim.nodeName), metav1.GetOptions{})
+	nodeInfo, err := csiKubeClient.StorageV1().CSINodes().Get(ctx, string(nim.nodeName), metav1.GetOptions{})
 	if nodeInfo == nil || errors.IsNotFound(err) {
 		// CreateCSINode will set the annotation
-		_, err = nim.CreateCSINode()
+		_, err = nim.CreateCSINode(ctx)
 		return err
 	} else if err != nil {
 		return err
 	}
 
-	if err = nim.ensureNodeOwnsCSINode(nodeInfo); err != nil {
+	if err = nim.ensureNodeOwnsCSINode(ctx, nodeInfo); err != nil {
 		return err
 	}
 
 	annotationModified := setMigrationAnnotation(nim.migratedPlugins, nodeInfo)
 
 	if annotationModified {
-		_, err := csiKubeClient.StorageV1().CSINodes().Update(context.TODO(), nodeInfo, metav1.UpdateOptions{})
+		_, err := csiKubeClient.StorageV1().CSINodes().Update(ctx, nodeInfo, metav1.UpdateOptions{})
 		return err
 	}
 	return nil
@@ -470,10 +472,10 @@ func (nim *nodeInfoManager) tryInitializeCSINodeWithAnnotation(csiKubeClient cli
 
 // ensureNodeOwnsCSINode will ensure that the current CSINode object is owned by the node represented by this nodeInfoManager.
 // If not, it will delete the existing CSINode object and return an error.
-func (nim *nodeInfoManager) ensureNodeOwnsCSINode(nodeInfo *storagev1.CSINode) error {
-	if ok, csiNodeOwnerID := nim.nodeOwnsCSINode(nodeInfo); !ok {
+func (nim *nodeInfoManager) ensureNodeOwnsCSINode(ctx context.Context, nodeInfo *storagev1.CSINode) error {
+	if ok, csiNodeOwnerID := nim.nodeOwnsCSINode(ctx, nodeInfo); !ok {
 		klog.V(2).Infof("existing CSINode %q is owned by different node (oldNodeID=%q, newNodeID=%q), cleaning up...", nodeInfo.Name, csiNodeOwnerID, nim.nodeID)
-		err := nim.DeleteCSINode()
+		err := nim.DeleteCSINode(ctx)
 		if err != nil {
 			return fmt.Errorf("error deleting existing CSINode %q: %w", nodeInfo.Name, err)
 		}
@@ -485,7 +487,7 @@ func (nim *nodeInfoManager) ensureNodeOwnsCSINode(nodeInfo *storagev1.CSINode) e
 
 // nodeOwnsCSINode checks if the CSINode object is owned by the node represented by this nodeInfoManager.
 // It also returns the current owner UID.
-func (nim *nodeInfoManager) nodeOwnsCSINode(nodeInfo *storagev1.CSINode) (bool, types.UID) {
+func (nim *nodeInfoManager) nodeOwnsCSINode(ctx context.Context, nodeInfo *storagev1.CSINode) (bool, types.UID) {
 	var csiNodeOwnerID types.UID
 	var found bool
 	for _, ownerRef := range nodeInfo.OwnerReferences {
@@ -506,7 +508,7 @@ func (nim *nodeInfoManager) nodeOwnsCSINode(nodeInfo *storagev1.CSINode) (bool, 
 	return found, csiNodeOwnerID
 }
 
-func (nim *nodeInfoManager) CreateCSINode() (*storagev1.CSINode, error) {
+func (nim *nodeInfoManager) CreateCSINode(ctx context.Context) (*storagev1.CSINode, error) {
 
 	csiKubeClient := nim.volumeHost.GetKubeClient()
 	if csiKubeClient == nil {
@@ -532,17 +534,17 @@ func (nim *nodeInfoManager) CreateCSINode() (*storagev1.CSINode, error) {
 
 	setMigrationAnnotation(nim.migratedPlugins, nodeInfo)
 
-	return csiKubeClient.StorageV1().CSINodes().Create(context.TODO(), nodeInfo, metav1.CreateOptions{})
+	return csiKubeClient.StorageV1().CSINodes().Create(ctx, nodeInfo, metav1.CreateOptions{})
 }
 
-func (nim *nodeInfoManager) DeleteCSINode() error {
+func (nim *nodeInfoManager) DeleteCSINode(ctx context.Context) error {
 
 	csiKubeClient := nim.volumeHost.GetKubeClient()
 	if csiKubeClient == nil {
 		return fmt.Errorf("error getting CSI client")
 	}
 
-	return csiKubeClient.StorageV1().CSINodes().Delete(context.TODO(), string(nim.nodeName), metav1.DeleteOptions{})
+	return csiKubeClient.StorageV1().CSINodes().Delete(ctx, string(nim.nodeName), metav1.DeleteOptions{})
 }
 
 func setMigrationAnnotation(migratedPlugins map[string](func() bool), nodeInfo *storagev1.CSINode) (modified bool) {
@@ -596,6 +598,7 @@ func keepAllocatableCount(driverInfoSpec storagev1.CSINodeDriver, maxAttachLimit
 }
 
 func (nim *nodeInfoManager) installDriverToCSINode(
+	ctx context.Context,
 	nodeInfo *storagev1.CSINode,
 	driverName string,
 	driverNodeID string,
@@ -652,11 +655,12 @@ func (nim *nodeInfoManager) installDriverToCSINode(
 	newDriverSpecs = append(newDriverSpecs, driverSpec)
 	nodeInfo.Spec.Drivers = newDriverSpecs
 
-	_, err := csiKubeClient.StorageV1().CSINodes().Update(context.TODO(), nodeInfo, metav1.UpdateOptions{})
+	_, err := csiKubeClient.StorageV1().CSINodes().Update(ctx, nodeInfo, metav1.UpdateOptions{})
 	return err
 }
 
 func (nim *nodeInfoManager) uninstallDriverFromCSINode(
+	ctx context.Context,
 	csiDriverName string) error {
 
 	csiKubeClient := nim.volumeHost.GetKubeClient()
@@ -666,7 +670,7 @@ func (nim *nodeInfoManager) uninstallDriverFromCSINode(
 
 	var updateErrs []error
 	err := wait.ExponentialBackoff(updateBackoff, func() (bool, error) {
-		if err := nim.tryUninstallDriverFromCSINode(csiKubeClient, csiDriverName); err != nil {
+		if err := nim.tryUninstallDriverFromCSINode(ctx, csiKubeClient, csiDriverName); err != nil {
 			updateErrs = append(updateErrs, err)
 			return false, nil
 		}
@@ -679,6 +683,7 @@ func (nim *nodeInfoManager) uninstallDriverFromCSINode(
 }
 
 func (nim *nodeInfoManager) tryUninstallDriverFromCSINode(
+	ctx context.Context,
 	csiKubeClient clientset.Interface,
 	csiDriverName string) error {
 
@@ -686,7 +691,7 @@ func (nim *nodeInfoManager) tryUninstallDriverFromCSINode(
 	defer nim.lock.Unlock()
 
 	nodeInfoClient := csiKubeClient.StorageV1().CSINodes()
-	nodeInfo, err := nodeInfoClient.Get(context.TODO(), string(nim.nodeName), metav1.GetOptions{})
+	nodeInfo, err := nodeInfoClient.Get(ctx, string(nim.nodeName), metav1.GetOptions{})
 	if err != nil && errors.IsNotFound(err) {
 		return nil
 	} else if err != nil {
@@ -712,7 +717,7 @@ func (nim *nodeInfoManager) tryUninstallDriverFromCSINode(
 	}
 	nodeInfo.Spec.Drivers = drivers
 
-	_, err = nodeInfoClient.Update(context.TODO(), nodeInfo, metav1.UpdateOptions{})
+	_, err = nodeInfoClient.Update(ctx, nodeInfo, metav1.UpdateOptions{})
 
 	return err // do not wrap error
 
@@ -722,7 +727,7 @@ func (nim *nodeInfoManager) tryUninstallDriverFromCSINode(
 // driver with the provided conditions. Other drivers' entries are preserved.
 // No-ops if the status, reason, and volume-capability identities for this driver
 // are unchanged.
-func (nim *nodeInfoManager) UpdateCSINodeStorageHealth(driverName string, conditions []storagev1.StorageHealthCondition) error {
+func (nim *nodeInfoManager) UpdateCSINodeStorageHealth(ctx context.Context, driverName string, conditions []storagev1.StorageHealthCondition) error {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.CSIVolumeHealth) {
 		return nil
 	}
@@ -734,7 +739,7 @@ func (nim *nodeInfoManager) UpdateCSINodeStorageHealth(driverName string, condit
 
 	var updateErrs []error
 	err := wait.ExponentialBackoff(updateBackoff, func() (bool, error) {
-		if err := nim.tryUpdateCSINodeStorageHealth(csiKubeClient, driverName, conditions); err != nil {
+		if err := nim.tryUpdateCSINodeStorageHealth(ctx, csiKubeClient, driverName, conditions); err != nil {
 			updateErrs = append(updateErrs, err)
 			return false, nil
 		}
@@ -747,6 +752,7 @@ func (nim *nodeInfoManager) UpdateCSINodeStorageHealth(driverName string, condit
 }
 
 func (nim *nodeInfoManager) tryUpdateCSINodeStorageHealth(
+	ctx context.Context,
 	csiKubeClient clientset.Interface,
 	driverName string,
 	conditions []storagev1.StorageHealthCondition) error {
@@ -754,12 +760,12 @@ func (nim *nodeInfoManager) tryUpdateCSINodeStorageHealth(
 	nim.lock.Lock()
 	defer nim.lock.Unlock()
 
-	nodeInfo, err := csiKubeClient.StorageV1().CSINodes().Get(context.TODO(), string(nim.nodeName), metav1.GetOptions{})
+	nodeInfo, err := csiKubeClient.StorageV1().CSINodes().Get(ctx, string(nim.nodeName), metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
 
-	if err = nim.ensureNodeOwnsCSINode(nodeInfo); err != nil {
+	if err = nim.ensureNodeOwnsCSINode(ctx, nodeInfo); err != nil {
 		return err
 	}
 
@@ -783,7 +789,7 @@ func (nim *nodeInfoManager) tryUpdateCSINodeStorageHealth(
 		combined = append(combined, storagev1.StorageHealth{Name: driverName, HealthConditions: conditions})
 	}
 	nodeInfo.Status.StorageHealth = combined
-	_, err = csiKubeClient.StorageV1().CSINodes().UpdateStatus(context.TODO(), nodeInfo, metav1.UpdateOptions{})
+	_, err = csiKubeClient.StorageV1().CSINodes().UpdateStatus(ctx, nodeInfo, metav1.UpdateOptions{})
 	return err
 }
 

--- a/pkg/volume/csi/nodeinfomanager/nodeinfomanager_test.go
+++ b/pkg/volume/csi/nodeinfomanager/nodeinfomanager_test.go
@@ -1019,12 +1019,12 @@ func TestInstallCSIDriverExistingAnnotation(t *testing.T) {
 		nim := NewNodeInfoManager(types.NodeName(nodeName), host, nil)
 
 		// Act
-		_, err = nim.CreateCSINode()
+		_, err = nim.CreateCSINode(t.Context())
 		if err != nil {
 			t.Errorf("expected no error from creating CSINodeinfo but got: %v", err)
 			continue
 		}
-		err = nim.InstallCSIDriver(driverName, nodeID, 0 /* maxVolumeLimit */, nil) // TODO test maxVolumeLimit
+		err = nim.InstallCSIDriver(t.Context(), driverName, nodeID, 0 /* maxVolumeLimit */, nil) // TODO test maxVolumeLimit
 		if err != nil {
 			t.Errorf("expected no error from InstallCSIDriver call but got: %v", err)
 			continue
@@ -1079,11 +1079,11 @@ func test(t *testing.T, addNodeInfo bool, testcases []testcase) {
 		nim := NewNodeInfoManager(types.NodeName(nodeName), host, tc.migratedPlugins)
 
 		//// Act
-		nim.CreateCSINode()
+		_, _ = nim.CreateCSINode(t.Context())
 		if addNodeInfo {
-			err = nim.InstallCSIDriver(tc.driverName, tc.inputNodeID, tc.inputVolumeLimit, tc.inputTopology)
+			err = nim.InstallCSIDriver(t.Context(), tc.driverName, tc.inputNodeID, tc.inputVolumeLimit, tc.inputTopology)
 		} else {
-			err = nim.UninstallCSIDriver(tc.driverName)
+			err = nim.UninstallCSIDriver(t.Context(), tc.driverName)
 		}
 
 		//// Assert
@@ -1419,7 +1419,7 @@ func TestUpdateCSINodeStorageHealth(t *testing.T) {
 			nim.nodeID = existingNode.UID
 
 			actionsBefore := len(client.Actions())
-			err = nim.UpdateCSINodeStorageHealth(tc.driverName, tc.conditions)
+			err = nim.UpdateCSINodeStorageHealth(t.Context(), tc.driverName, tc.conditions)
 			if err != nil {
 				t.Fatalf("UpdateCSINodeStorageHealth returned error: %v", err)
 			}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Passes `context.Context` through `nodeinfomanager.Interface` methods and propagates it down to client calls, eliminating internal `context.TODO()` usages. Also updates callers in `csi_plugin.go`, `volumehealth/manager.go`, and their respective unit tests.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```
#### AI usage disclosure:
YES: Used AI assistance for boilerplate refactoring, test updates, and linting. Didn't use AI agents.