### PR TITLE
Add apiserver storage correctness tests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/etcd3"
 	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
 	storagetesting "k8s.io/apiserver/pkg/storage/testing"
+	"k8s.io/apiserver/pkg/storage/testing/correctness"
 	"k8s.io/apiserver/pkg/storage/value"
 	"k8s.io/apiserver/pkg/storage/value/encrypt/identity"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -801,4 +802,10 @@ func BenchmarkStoreStats(b *testing.B) {
 		}
 	}
 	storagetesting.RunBenchmarkStoreStats(ctx, b, cacher)
+}
+
+func TestCorrectness(t *testing.T) {
+	ctx, cacher, terminate := testSetup(t)
+	t.Cleanup(terminate)
+	correctness.RunTestCorrectness(ctx, t, cacher, etcd3testing.PathPrefix())
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -54,6 +54,7 @@ import (
 	etcdfeature "k8s.io/apiserver/pkg/storage/feature"
 	storagemetrics "k8s.io/apiserver/pkg/storage/metrics"
 	storagetesting "k8s.io/apiserver/pkg/storage/testing"
+	"k8s.io/apiserver/pkg/storage/testing/correctness"
 	"k8s.io/apiserver/pkg/storage/value"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -1422,4 +1423,9 @@ func TestPrefixStats(t *testing.T) {
 
 		})
 	}
+}
+
+func TestCorrectness(t *testing.T) {
+	ctx, store, _ := testSetup(t)
+	correctness.RunTestCorrectness(ctx, t, store, "")
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/correctness/correctness.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/correctness/correctness.go
@@ -1,0 +1,322 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package correctness
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/apis/example"
+	"k8s.io/apiserver/pkg/storage"
+)
+
+type testStep struct {
+	Name             string
+	Request          Request
+	CorrectResponse  Response
+	InvalidResponses []Response
+}
+
+func correctnessTestSteps() []testStep {
+	pod1UID := types.UID("uid-1")
+	pod2UID := types.UID("uid-2")
+	wrongUID := types.UID("wrong-uid")
+	pod1 := newTestPod("pod1", "ns1", pod1UID, "")
+	pod2 := newTestPod("pod2", "ns1", pod2UID, "")
+	pod1Key := mustGetKey(pod1)
+	pod2Key := mustGetKey(pod2)
+	wrongRV := "99"
+	pod2RV := "3"
+	return []testStep{
+		{
+			Name: "1. Create pod1 returns success RV=2",
+			Request: Request{
+				Op:     OpCreate,
+				Key:    pod1Key,
+				Object: pod1,
+			},
+			CorrectResponse: Response{
+				Object: withRV(pod1, "2"),
+			},
+			InvalidResponses: []Response{
+				{Object: &example.Pod{}, Err: storage.NewKeyExistsError(pod1Key, 0)},
+				{Object: &example.Pod{}, Err: storage.NewKeyNotFoundError(pod1Key, 0)},
+				{Object: withRV(pod1, "1")},
+				{Object: withRV(pod1, "3")},
+				{Object: nil, Err: nil},
+			},
+		},
+		{
+			Name: "2. Create pod1 duplicate returns key exists error",
+			Request: Request{
+				Op:     OpCreate,
+				Key:    pod1Key,
+				Object: pod1,
+			},
+			CorrectResponse: Response{
+				Object: nil,
+				Err:    storage.NewKeyExistsError(pod1Key, 0),
+			},
+			InvalidResponses: []Response{
+				{Object: withRV(pod1, "2")},
+				{Object: withRV(pod1, "3")},
+				{Object: &example.Pod{}, Err: storage.NewKeyNotFoundError(pod1Key, 0)},
+				{Object: nil, Err: nil},
+			},
+		},
+		{
+			Name: "3. Get pod1 returns success RV=2",
+			Request: Request{
+				Op:  OpGet,
+				Key: pod1Key,
+			},
+			CorrectResponse: Response{
+				Object: withRV(pod1, "2"),
+			},
+			InvalidResponses: []Response{
+				{Object: &example.Pod{}, Err: storage.NewKeyNotFoundError(pod1Key, 0)},
+				{Object: withRV(pod1, "1")},
+				{Object: withRV(pod1, "3")},
+				{Object: withRV(pod1, "uid-2")},
+				{Object: nil, Err: nil},
+			},
+		},
+		{
+			Name: "4. Create pod2 returns success RV=3",
+			Request: Request{
+				Op:     OpCreate,
+				Key:    pod2Key,
+				Object: pod2,
+			},
+			CorrectResponse: Response{
+				Object: withRV(pod2, "3"),
+			},
+			InvalidResponses: []Response{
+				{Object: &example.Pod{}, Err: storage.NewKeyExistsError(pod2Key, 0)},
+				{Object: withRV(pod2, "2")},
+				{Object: withRV(pod2, "4")},
+				{Object: nil, Err: nil},
+			},
+		},
+		{
+			Name: "5. Get pod2 returns success RV=3",
+			Request: Request{
+				Op:  OpGet,
+				Key: pod2Key,
+			},
+			CorrectResponse: Response{
+				Object: withRV(pod2, "3"),
+			},
+			InvalidResponses: []Response{
+				{Object: &example.Pod{}, Err: storage.NewKeyNotFoundError(pod2Key, 0)},
+				{Object: withRV(pod2, "2")},
+				{Object: withRV(pod2, "4")},
+				{Object: nil, Err: nil},
+			},
+		},
+		{
+			Name: "6. Delete pod2 with mismatched UID precondition returns invalid obj error",
+			Request: Request{
+				Op:            OpDelete,
+				Key:           pod2Key,
+				Preconditions: &storage.Preconditions{UID: &wrongUID},
+			},
+			CorrectResponse: Response{
+				Object: nil,
+				Err:    (&storage.Preconditions{UID: &wrongUID}).Check(pod2Key, withRV(pod2, "3")),
+			},
+			InvalidResponses: []Response{
+				{Object: withRV(pod2, "4")},
+				{Object: nil, Err: nil},
+				{Object: nil, Err: storage.NewKeyNotFoundError(pod2Key, 0)},
+			},
+		},
+		{
+			Name: "7. Delete pod2 with mismatched ResourceVersion precondition returns invalid obj error",
+			Request: Request{
+				Op:            OpDelete,
+				Key:           pod2Key,
+				Preconditions: &storage.Preconditions{ResourceVersion: &wrongRV},
+			},
+			CorrectResponse: Response{
+				Object: nil,
+				Err:    (&storage.Preconditions{ResourceVersion: &wrongRV}).Check(pod2Key, withRV(pod2, "3")),
+			},
+			InvalidResponses: []Response{
+				{Object: withRV(pod2, "4")},
+				{Object: nil, Err: nil},
+				{Object: nil, Err: storage.NewKeyNotFoundError(pod2Key, 0)},
+			},
+		},
+		{
+			Name: "8. Delete pod1 with matching UID precondition returns success RV=4",
+			Request: Request{
+				Op:            OpDelete,
+				Key:           pod1Key,
+				Preconditions: &storage.Preconditions{UID: &pod1UID},
+			},
+			CorrectResponse: Response{
+				Object: withRV(pod1, "4"),
+			},
+			InvalidResponses: []Response{
+				{Object: &example.Pod{}, Err: storage.NewKeyNotFoundError(pod1Key, 0)},
+				{Object: withRV(pod1, "2")},
+				{Object: withRV(pod1, "3")},
+				{Object: withRV(pod1, "5")},
+				{Object: nil, Err: nil},
+			},
+		},
+		{
+			Name: "9. Delete pod1 duplicate returns NotFound",
+			Request: Request{
+				Op:  OpDelete,
+				Key: pod1Key,
+			},
+			CorrectResponse: Response{
+				Object: nil,
+				Err:    storage.NewKeyNotFoundError(pod1Key, 4),
+			},
+			InvalidResponses: []Response{
+				{Object: withRV(pod1, "4")},
+				{Object: withRV(pod1, "5")},
+				{Object: nil, Err: nil},
+			},
+		},
+		{
+			Name: "10. Get pod1 after delete returns NotFound",
+			Request: Request{
+				Op:  OpGet,
+				Key: pod1Key,
+			},
+			CorrectResponse: Response{
+				Object: nil,
+				Err:    storage.NewKeyNotFoundError(pod1Key, 0),
+			},
+			InvalidResponses: []Response{
+				{Object: withRV(pod1, "2")},
+				{Object: withRV(pod1, "4")},
+				{Object: nil, Err: nil},
+			},
+		},
+		{
+			Name: "11. Delete pod2 with matching UID and RV preconditions returns success RV=5",
+			Request: Request{
+				Op:            OpDelete,
+				Key:           pod2Key,
+				Preconditions: &storage.Preconditions{UID: &pod2UID, ResourceVersion: &pod2RV},
+			},
+			CorrectResponse: Response{
+				Object: withRV(pod2, "5"),
+			},
+			InvalidResponses: []Response{
+				{Object: &example.Pod{}, Err: storage.NewKeyNotFoundError(pod2Key, 0)},
+				{Object: withRV(pod2, "3")},
+				{Object: withRV(pod2, "4")},
+				{Object: withRV(pod2, "6")},
+				{Object: nil, Err: nil},
+			},
+		},
+		{
+			Name: "12. Get pod2 after delete returns NotFound",
+			Request: Request{
+				Op:  OpGet,
+				Key: pod2Key,
+			},
+			CorrectResponse: Response{
+				Object: nil,
+				Err:    storage.NewKeyNotFoundError(pod2Key, 0),
+			},
+			InvalidResponses: []Response{
+				{Object: withRV(pod2, "3")},
+				{Object: withRV(pod2, "5")},
+				{Object: nil, Err: nil},
+			},
+		},
+	}
+}
+
+// RunTestCorrectness executes the operations from the sequential storage model against real storage
+// and validates that every transition matches the StorageModel specification.
+func RunTestCorrectness(ctx context.Context, t *testing.T, store storage.Interface, storagePrefix string) {
+	model := NewEmptyModel(storagePrefix)
+
+	for _, step := range correctnessTestSteps() {
+		out := &example.Pod{}
+		var err error
+		switch step.Request.Op {
+		case OpCreate:
+			err = store.Create(ctx, step.Request.Key, step.Request.Object, out, 0)
+		case OpGet:
+			err = store.Get(ctx, step.Request.Key, step.Request.GetOptions, out)
+		case OpDelete:
+			err = store.Delete(ctx, step.Request.Key, out, step.Request.Preconditions, storage.ValidateAllObjectFunc, nil, storage.DeleteOptions{})
+		default:
+			t.Fatalf("unknown operation: %v", step.Request.Op)
+		}
+		var respObj runtime.Object
+		if err == nil {
+			respObj = out
+		}
+		resp := Response{Object: respObj, Err: err}
+		ok, next := model.Step(step.Request, resp)
+		if respObj != nil {
+			acc, _ := meta.Accessor(respObj)
+			t.Logf("Step: %s, State RV before: %d, Response RV: %s, Obj: %+v, err: %v", step.Name, model.ResourceVersion, acc.GetResourceVersion(), respObj, err)
+		} else {
+			t.Logf("Step: %s, State RV before: %d, Response Err: %v", step.Name, model.ResourceVersion, err)
+		}
+		require.True(t, ok, "step %s failed to match model state transition: req=%+v resp=%+v", step.Name, step.Request, resp)
+		model = next
+	}
+}
+
+func newTestPod(name, namespace string, uid types.UID, rv string) *example.Pod {
+	pod := &example.Pod{}
+	pod.Name = name
+	pod.Namespace = namespace
+	pod.UID = uid
+	pod.ResourceVersion = rv
+	return pod
+}
+
+func withRV(pod *example.Pod, rv string) *example.Pod {
+	new := pod.DeepCopy()
+	new.ResourceVersion = rv
+	return new
+}
+
+func mustGetKey(obj runtime.Object) string {
+	key, err := getKey(obj)
+	if err != nil {
+		panic(err)
+	}
+	return key
+}
+
+func getKey(obj runtime.Object) (string, error) {
+	pod, ok := obj.(*example.Pod)
+	if !ok {
+		return "", fmt.Errorf("object is not a pod: %T", obj)
+	}
+	return "/pods/" + pod.Namespace + "/" + pod.Name, nil
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/correctness/model.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/correctness/model.go
@@ -1,0 +1,146 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package correctness
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/storage"
+)
+
+// NewEmptyModel returns a new Model with no items.
+func NewEmptyModel(prefix string) *Model {
+	return &Model{
+		Prefix:          prefix,
+		ResourceVersion: 1,
+		Items:           make(map[string]runtime.Object),
+	}
+}
+
+// Model is a state machine that mimics kubernetes storage behavior. Used for Linarizability testing of storage.
+type Model struct {
+	Items           map[string]runtime.Object
+	ResourceVersion uint64
+	Prefix          string
+}
+
+func (s *Model) Clone() *Model {
+	clone := &Model{
+		Items:           make(map[string]runtime.Object, len(s.Items)),
+		ResourceVersion: s.ResourceVersion,
+		Prefix:          s.Prefix,
+	}
+	for k, v := range s.Items {
+		if v != nil {
+			clone.Items[k] = v.DeepCopyObject()
+		}
+	}
+	return clone
+}
+
+func (s *Model) Equal(other *Model) bool {
+	return reflect.DeepEqual(s, other)
+}
+
+// Step applies an operation to the sequential state machine.
+func (s *Model) Step(input Request, output Response) (ok bool, next *Model) {
+	next = s
+	var expected Response
+	switch input.Op {
+	case OpCreate:
+		next = s.Clone()
+		expected = next.create(input.Key, input.Object)
+	case OpDelete:
+		next = s.Clone()
+		expected = next.delete(context.Background(), input.Key, input.Preconditions, nil)
+	case OpGet:
+		expected = s.get(input.Key, input.GetOptions)
+	}
+	if !reflect.DeepEqual(expected, output) {
+		return false, s
+	}
+	return true, next
+}
+
+func (s *Model) create(key string, obj runtime.Object) Response {
+	if _, exists := s.Items[key]; exists {
+		return Response{Object: nil, Err: storage.NewKeyExistsError(s.Prefix+key, 0)}
+	}
+	s.ResourceVersion++
+	copied := obj.DeepCopyObject()
+	accessor, err := meta.Accessor(copied)
+	if err != nil {
+		return Response{Object: nil, Err: err}
+	}
+	accessor.SetResourceVersion(strconv.FormatUint(s.ResourceVersion, 10))
+	s.Items[key] = copied
+	return Response{Object: copied, Err: nil}
+}
+
+func (s *Model) get(key string, opts storage.GetOptions) Response {
+	stored, exists := s.Items[key]
+	if !exists {
+		if opts.IgnoreNotFound {
+			return Response{Object: nil, Err: nil}
+		}
+		return Response{Object: nil, Err: storage.NewKeyNotFoundError(s.Prefix+key, 0)}
+	}
+	return Response{Object: stored.DeepCopyObject(), Err: nil}
+}
+
+func (s *Model) delete(ctx context.Context, key string, preconditions *storage.Preconditions, validateDeletion storage.ValidateObjectFunc) Response {
+	stored, exists := s.Items[key]
+	if !exists {
+		return Response{Object: nil, Err: storage.NewKeyNotFoundError(s.Prefix+key, int64(s.ResourceVersion))}
+	}
+	if err := preconditions.Check(s.Prefix+key, stored); err != nil {
+		return Response{Object: nil, Err: err}
+	}
+	if validateDeletion != nil && stored != nil {
+		if err := validateDeletion(ctx, stored); err != nil {
+			return Response{Object: nil, Err: err}
+		}
+	}
+	s.ResourceVersion++
+	deletedObj := stored.DeepCopyObject()
+	accessor, err := meta.Accessor(deletedObj)
+	if err != nil {
+		return Response{Object: nil, Err: err}
+	}
+	accessor.SetResourceVersion(strconv.FormatUint(s.ResourceVersion, 10))
+	delete(s.Items, key)
+	return Response{Object: deletedObj, Err: nil}
+}
+
+func (s *Model) Describe() string {
+	items := []string{}
+	for key, item := range s.Items {
+		accessor, err := meta.Accessor(item)
+		if err != nil {
+			items = append(items, fmt.Sprintf("<p>%s: err: %v</p>", key, err))
+		} else {
+			items = append(items, fmt.Sprintf("<p>%s: %s, RV:%s</p>", key, accessor.GetUID(), accessor.GetResourceVersion()))
+		}
+	}
+	return fmt.Sprintf("RV: %d, Items: %s", s.ResourceVersion, strings.Join(items, ""))
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/correctness/model_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/correctness/model_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package correctness
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCorrectness(t *testing.T) {
+	model := NewEmptyModel("")
+
+	for _, step := range correctnessTestSteps() {
+		t.Run(step.Name, func(t *testing.T) {
+			for i, invalidResponse := range step.InvalidResponses {
+				ok, _ := model.Step(step.Request, invalidResponse)
+				require.False(t, ok, "alternative response #%d should return ok=false: req=%+v resp=%+v", i, step.Request, invalidResponse)
+			}
+
+			ok, next := model.Step(step.Request, step.CorrectResponse)
+			require.True(t, ok, "valid response should return ok=true: req=%+v resp=%+v", step.Request, step.CorrectResponse)
+			model = next
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/correctness/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/correctness/types.go
@@ -1,0 +1,111 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package correctness
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/storage"
+)
+
+// Operation represents a single operation recorded in a concurrent execution history.
+type Operation struct {
+	ClientID int
+	Request  Request
+	Response Response
+	Start    time.Time
+	End      time.Time
+}
+
+// Request represents an input invocation to the storage interface.
+type Request struct {
+	Op            OpType
+	Key           string
+	Object        runtime.Object
+	GetOptions    storage.GetOptions
+	Preconditions *storage.Preconditions
+}
+
+// Describe formats the operation for debugging and visualization.
+func (r Request) Describe(output Response) string {
+	if output.Err != nil {
+		switch {
+		case storage.IsNotFound(output.Err):
+			return fmt.Sprintf("%s(%s) -> Not Found", r.Op, r.Key)
+		case storage.IsExist(output.Err):
+			return fmt.Sprintf("%s(%s) -> Already Exists", r.Op, r.Key)
+		case storage.IsConflict(output.Err):
+			return fmt.Sprintf("%s(%s) -> Conflict", r.Op, r.Key)
+		case storage.IsUnreachable(output.Err):
+			return fmt.Sprintf("%s(%s) -> Unreachable", r.Op, r.Key)
+		case storage.IsRequestTimeout(output.Err):
+			return fmt.Sprintf("%s(%s) -> Timeout", r.Op, r.Key)
+		case storage.IsInvalidObj(output.Err):
+			errStr := output.Err.Error()
+			errParts := strings.Split(errStr, "Precondition failed:")
+			if len(errParts) > 1 {
+				errStr = errParts[1]
+			}
+			return fmt.Sprintf("%s(%s) -> Invalid %s", r.Op, r.Key, errStr)
+		case storage.IsCorruptObject(output.Err):
+			return fmt.Sprintf("%s(%s) -> Corrupt", r.Op, r.Key)
+		default:
+			return fmt.Sprintf("%s(%s) -> Unknown Error", r.Op, r.Key)
+		}
+	}
+	accessor, err := meta.Accessor(output.Object)
+	if err != nil {
+		panic(err)
+	}
+	switch r.Op {
+	case OpCreate:
+		return fmt.Sprintf("%s(%s) -> RV: %s, UID: %s", r.Op, r.Key, accessor.GetResourceVersion(), accessor.GetUID())
+	case OpDelete:
+		if r.Preconditions != nil {
+			if r.Preconditions.ResourceVersion != nil && *r.Preconditions.ResourceVersion != "" {
+				return fmt.Sprintf("%s(if RV(%s) ==%s) -> Deleted", r.Op, r.Key, *r.Preconditions.ResourceVersion)
+			}
+			if r.Preconditions.UID != nil && *r.Preconditions.UID != "" {
+				return fmt.Sprintf("%s(if UID(%s) == %s) -> Deleted", r.Op, r.Key, *r.Preconditions.UID)
+			}
+		}
+		return fmt.Sprintf("%s(%s) -> Deleted", r.Op, r.Key)
+	case OpGet:
+		return fmt.Sprintf("%s(%s) -> RV: %s, UID: %s", r.Op, r.Key, accessor.GetResourceVersion(), accessor.GetUID())
+	default:
+		return fmt.Sprintf("%s(%s) -> RV: %s", r.Op, r.Key, accessor.GetResourceVersion())
+	}
+}
+
+// OpType identifies the storage interface operation.
+type OpType string
+
+const (
+	OpCreate OpType = "Create"
+	OpDelete OpType = "Delete"
+	OpGet    OpType = "Get"
+)
+
+// Response represents the output/result from the storage interface invocation.
+type Response struct {
+	Object runtime.Object
+	Err    error
+}


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/141652

PR introduces a minimal model test based correctness suite using same approach like etcd robustness testing. For now we cover just Create,Delete,Get to as minimal example that works showing both etcd3 and cacher fulfill same contract.

Model is defined in storage testing, but to avoid dependency on linarization library the test itself is located in integration tests.

```release-note
NONE
```

/cc @liggitt 