### PR TITLE
Clarify PVC selector documentation

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -9886,7 +9886,7 @@
         },
         "selector": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
-          "description": "selector is a label query over volumes to consider for binding."
+          "description": "selector is a label query over volumes to consider for binding. A null or empty selector matches all volumes. This selector is ignored when volumeName is set."
         },
         "storageClassName": {
           "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",

--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -4602,7 +4602,7 @@
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
               }
             ],
-            "description": "selector is a label query over volumes to consider for binding."
+            "description": "selector is a label query over volumes to consider for binding. A null or empty selector matches all volumes. This selector is ignored when volumeName is set."
           },
           "storageClassName": {
             "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",

--- a/api/openapi-spec/v3/apis__apps__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apps__v1_openapi.json
@@ -3223,7 +3223,7 @@
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
               }
             ],
-            "description": "selector is a label query over volumes to consider for binding."
+            "description": "selector is a label query over volumes to consider for binding. A null or empty selector matches all volumes. This selector is ignored when volumeName is set."
           },
           "storageClassName": {
             "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -2556,7 +2556,7 @@
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
               }
             ],
-            "description": "selector is a label query over volumes to consider for binding."
+            "description": "selector is a label query over volumes to consider for binding. A null or empty selector matches all volumes. This selector is ignored when volumeName is set."
           },
           "storageClassName": {
             "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -506,8 +506,8 @@ type PersistentVolumeClaimSpec struct {
 	// Contains the types of access modes required
 	// +optional
 	AccessModes []PersistentVolumeAccessMode
-	// A label query over volumes to consider for binding. This selector is
-	// ignored when VolumeName is set
+	// A label query over volumes to consider for binding.
+	// A null or empty selector matches all volumes. This selector is ignored when VolumeName is set.
 	// +optional
 	Selector *metav1.LabelSelector
 	// Resources represents the minimum resources required

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -26921,7 +26921,7 @@ func schema_k8sio_api_core_v1_PersistentVolumeClaimSpec(ref common.ReferenceCall
 					},
 					"selector": {
 						SchemaProps: spec.SchemaProps{
-							Description: "selector is a label query over volumes to consider for binding.",
+							Description: "selector is a label query over volumes to consider for binding. A null or empty selector matches all volumes. This selector is ignored when volumeName is set.",
 							Ref:         ref(metav1.LabelSelector{}.OpenAPIModelName()),
 						},
 					},

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -555,6 +555,7 @@ type PersistentVolumeClaimSpec struct {
 	// +listType=atomic
 	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" protobuf:"bytes,1,rep,name=accessModes,casttype=PersistentVolumeAccessMode"`
 	// selector is a label query over volumes to consider for binding.
+	// A null or empty selector matches all volumes. This selector is ignored when volumeName is set.
 	// +optional
 	Selector *metav1.LabelSelector `json:"selector,omitempty" protobuf:"bytes,4,opt,name=selector"`
 	// resources represents the minimum resources the volume should have.

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -1557,7 +1557,7 @@ func (PersistentVolumeClaimList) SwaggerDoc() map[string]string {
 var map_PersistentVolumeClaimSpec = map[string]string{
 	"":                          "PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes",
 	"accessModes":               "accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
-	"selector":                  "selector is a label query over volumes to consider for binding.",
+	"selector":                  "selector is a label query over volumes to consider for binding. A null or empty selector matches all volumes. This selector is ignored when volumeName is set.",
 	"resources":                 "resources represents the minimum resources the volume should have. Users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
 	"volumeName":                "volumeName is the binding reference to the PersistentVolume backing this claim.",
 	"storageClassName":          "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",

--- a/staging/src/k8s.io/cli-runtime/artifacts/openapi/swagger-with-shared-parameters.json
+++ b/staging/src/k8s.io/cli-runtime/artifacts/openapi/swagger-with-shared-parameters.json
@@ -7475,7 +7475,7 @@
         },
         "selector": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
-          "description": "selector is a label query over volumes to consider for binding."
+          "description": "selector is a label query over volumes to consider for binding. A null or empty selector matches all volumes. This selector is ignored when volumeName is set."
         },
         "storageClassName": {
           "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",

--- a/staging/src/k8s.io/cli-runtime/artifacts/openapi/swagger.json
+++ b/staging/src/k8s.io/cli-runtime/artifacts/openapi/swagger.json
@@ -7917,7 +7917,7 @@
         },
         "selector": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
-          "description": "selector is a label query over volumes to consider for binding."
+          "description": "selector is a label query over volumes to consider for binding. A null or empty selector matches all volumes. This selector is ignored when volumeName is set."
         },
         "storageClassName": {
           "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaimspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaimspec.go
@@ -33,6 +33,7 @@ type PersistentVolumeClaimSpecApplyConfiguration struct {
 	// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
 	AccessModes []corev1.PersistentVolumeAccessMode `json:"accessModes,omitempty"`
 	// selector is a label query over volumes to consider for binding.
+	// A null or empty selector matches all volumes. This selector is ignored when volumeName is set.
 	Selector *metav1.LabelSelectorApplyConfiguration `json:"selector,omitempty"`
 	// resources represents the minimum resources the volume should have.
 	// Users are allowed to specify resource requirements

--- a/staging/src/k8s.io/client-go/openapi/openapitest/testdata/api__v1_openapi.json
+++ b/staging/src/k8s.io/client-go/openapi/openapitest/testdata/api__v1_openapi.json
@@ -4119,7 +4119,7 @@
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
               }
             ],
-            "description": "selector is a label query over volumes to consider for binding."
+            "description": "selector is a label query over volumes to consider for binding. A null or empty selector matches all volumes. This selector is ignored when volumeName is set."
           },
           "storageClassName": {
             "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",

--- a/staging/src/k8s.io/client-go/openapi/openapitest/testdata/apis__apps__v1_openapi.json
+++ b/staging/src/k8s.io/client-go/openapi/openapitest/testdata/apis__apps__v1_openapi.json
@@ -3012,7 +3012,7 @@
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
               }
             ],
-            "description": "selector is a label query over volumes to consider for binding."
+            "description": "selector is a label query over volumes to consider for binding. A null or empty selector matches all volumes. This selector is ignored when volumeName is set."
           },
           "storageClassName": {
             "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",

--- a/staging/src/k8s.io/client-go/openapi/openapitest/testdata/apis__batch__v1_openapi.json
+++ b/staging/src/k8s.io/client-go/openapi/openapitest/testdata/apis__batch__v1_openapi.json
@@ -2246,7 +2246,7 @@
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
               }
             ],
-            "description": "selector is a label query over volumes to consider for binding."
+            "description": "selector is a label query over volumes to consider for binding. A null or empty selector matches all volumes. This selector is ignored when volumeName is set."
           },
           "storageClassName": {
             "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/batch.k8s.io_v1.json
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/batch.k8s.io_v1.json
@@ -5900,7 +5900,7 @@
             ]
           },
           "selector": {
-            "description": "selector is a label query over volumes to consider for binding.",
+            "description": "selector is a label query over volumes to consider for binding. A null or empty selector matches all volumes. This selector is ignored when volumeName is set.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"

--- a/staging/src/k8s.io/kubectl/testdata/openapi/swagger.json
+++ b/staging/src/k8s.io/kubectl/testdata/openapi/swagger.json
@@ -8207,7 +8207,7 @@
         },
         "selector": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
-          "description": "A label query over volumes to consider for binding."
+          "description": "A label query over volumes to consider for binding. A null or empty selector matches all volumes. This selector is ignored when VolumeName is set."
         },
         "storageClassName": {
           "description": "Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",

--- a/staging/src/k8s.io/kubectl/testdata/openapi/v3/api/v1.json
+++ b/staging/src/k8s.io/kubectl/testdata/openapi/v3/api/v1.json
@@ -24124,7 +24124,7 @@
             ]
           },
           "selector": {
-            "description": "selector is a label query over volumes to consider for binding.",
+            "description": "selector is a label query over volumes to consider for binding. A null or empty selector matches all volumes. This selector is ignored when volumeName is set.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"

--- a/staging/src/k8s.io/kubectl/testdata/openapi/v3/apis/apps/v1.json
+++ b/staging/src/k8s.io/kubectl/testdata/openapi/v3/apis/apps/v1.json
@@ -3065,7 +3065,7 @@
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
               }
             ],
-            "description": "selector is a label query over volumes to consider for binding."
+            "description": "selector is a label query over volumes to consider for binding. A null or empty selector matches all volumes. This selector is ignored when volumeName is set."
           },
           "storageClassName": {
             "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Clarifies `PersistentVolumeClaimSpec.selector` API documentation so generated docs state that a null or empty selector matches all volumes, and that the selector is ignored when `volumeName` is set.

#### Which issue(s) this PR fixes:

Related to #25836

#### Special notes for your reviewer:

The documented behavior matches `FindMatchingVolume`: selector filtering is skipped when the selector is nil, an empty label selector matches all labels, and the `volumeName` binding path does not evaluate the selector.

This PR was prepared with assistance from OpenAI Codex. I reviewed the changes and am responsible for this contribution.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None
