### PR TITLE
Fix MutationCache.ByIndex skipping includeAdds hits after concurrent del

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
@@ -213,7 +213,6 @@ func (c *mutationCache) ByIndex(name string, indexKey string) ([]interface{}, er
 	var items []interface{}
 	keySet := sets.NewString()
 	for _, key := range keys {
-		keySet.Insert(key)
 		obj, exists, err := c.indexer.GetByKey(key)
 		if err != nil {
 			return nil, err
@@ -221,6 +220,7 @@ func (c *mutationCache) ByIndex(name string, indexKey string) ([]interface{}, er
 		if !exists {
 			continue
 		}
+		keySet.Insert(key)
 		if objRuntime, ok := obj.(runtime.Object); ok {
 			items = append(items, c.newerObject(key, objRuntime))
 		} else {

--- a/staging/src/k8s.io/client-go/tools/cache/mutation_cache_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_cache_test.go
@@ -245,3 +245,46 @@ func TestMutationCacheOnDeleteClearsStaleMutation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, items, "OnDelete must clear the mutation; ByIndex must return nothing")
 }
+
+func TestMutationCacheByIndexConcurrentDelete(t *testing.T) {
+	const indexName = "by-name"
+	indexer := &deleteOnGetIndexer{
+		Indexer: NewIndexer(MetaNamespaceKeyFunc, Indexers{
+			indexName: func(obj interface{}) ([]string, error) {
+				return []string{obj.(*v1.Pod).Name}, nil
+			},
+		}),
+	}
+	oldPod := makeMutationTestPod("pod", "uid-1", "1")
+	replacementPod := makeMutationTestPod("pod", "uid-2", "2")
+	require.NoError(t, indexer.Add(oldPod))
+
+	mc := NewIntegerResourceVersionMutationCache(klog.Background(), indexer, indexer, time.Minute, true)
+	mc.Mutation(replacementPod)
+	indexer.deleteOnGet = true
+
+	items, err := mc.ByIndex(indexName, "pod")
+	require.NoError(t, err)
+	require.Equal(t, []interface{}{replacementPod}, items)
+}
+
+// deleteOnGetIndexer makes the narrow race between IndexKeys and GetByKey
+// deterministic.
+type deleteOnGetIndexer struct {
+	Indexer
+	deleteOnGet bool
+}
+
+func (i *deleteOnGetIndexer) GetByKey(key string) (interface{}, bool, error) {
+	if i.deleteOnGet {
+		i.deleteOnGet = false
+		obj, exists, err := i.Indexer.GetByKey(key)
+		if err != nil || !exists {
+			return nil, false, err
+		}
+		if err := i.Indexer.Delete(obj); err != nil {
+			return nil, false, err
+		}
+	}
+	return i.Indexer.GetByKey(key)
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind flake


#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
Fixes #140041


#### Special notes for your reviewer:

- similarly to #141736. Either can fix the flake. Feel free to close this if #141736 is merged.

#### Does this PR introduce a user-facing change?

```release-note
None
```
