### PR TITLE
client-go: fix MutationCache ByIndex delete race

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
@@ -213,7 +213,6 @@ func (c *mutationCache) ByIndex(name string, indexKey string) ([]interface{}, er
 	var items []interface{}
 	keySet := sets.NewString()
 	for _, key := range keys {
-		keySet.Insert(key)
 		obj, exists, err := c.indexer.GetByKey(key)
 		if err != nil {
 			return nil, err
@@ -221,6 +220,10 @@ func (c *mutationCache) ByIndex(name string, indexKey string) ([]interface{}, er
 		if !exists {
 			continue
 		}
+		// Because the indexer returned an object for this key,
+		// add it to keySet to prevent the mutation cache from
+		// adding the same key again in our if c.includeAdds logic below.
+		keySet.Insert(key)
 		if objRuntime, ok := obj.(runtime.Object); ok {
 			items = append(items, c.newerObject(key, objRuntime))
 		} else {

--- a/staging/src/k8s.io/client-go/tools/cache/mutation_cache_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_cache_test.go
@@ -245,3 +245,52 @@ func TestMutationCacheOnDeleteClearsStaleMutation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, items, "OnDelete must clear the mutation; ByIndex must return nothing")
 }
+
+// racingIndexer removes objects from the wrapped Indexer on the first GetByKey
+// call, simulating an informer that processes a delete event concurrently with
+// a ByIndex call. This is possible because processDeltas updates the indexer
+// before invoking the event handlers, so the indexer is not serialized against
+// the mutation cache lock held by ByIndex.
+type racingIndexer struct {
+	Indexer
+	deleteOnNextGet []interface{}
+}
+
+func (r *racingIndexer) GetByKey(key string) (interface{}, bool, error) {
+	for _, obj := range r.deleteOnNextGet {
+		if err := r.Indexer.Delete(obj); err != nil {
+			return nil, false, err
+		}
+	}
+	r.deleteOnNextGet = nil
+	return r.Indexer.GetByKey(key)
+}
+
+// TestMutationCacheByIndexConcurrentDelete verifies that ByIndex returns a
+// cached replacement when the indexed object with the same key disappears
+// between IndexKeys and GetByKey.
+func TestMutationCacheByIndexConcurrentDelete(t *testing.T) {
+	byNameIndex := "by-name"
+	indexer := NewIndexer(MetaNamespaceKeyFunc, Indexers{
+		byNameIndex: func(obj interface{}) ([]string, error) {
+			return []string{obj.(*v1.Pod).Name}, nil
+		},
+	})
+
+	// The informer still has the old instance when ByIndex starts.
+	oldPod := makeMutationTestPod("pod", "uid-1", "1")
+	require.NoError(t, indexer.Add(oldPod))
+
+	racer := &racingIndexer{Indexer: indexer}
+	mc := NewIntegerResourceVersionMutationCache(klog.Background(), NewStore(MetaNamespaceKeyFunc), racer, time.Minute, true /* includeAdds */)
+
+	// Simulate recreating the pod under the same name.
+	replacementPod := makeMutationTestPod("pod", "uid-2", "2")
+	mc.Mutation(replacementPod)
+
+	// Delete oldPod when ByIndex calls GetByKey, after IndexKeys returns its key.
+	racer.deleteOnNextGet = []interface{}{oldPod}
+	items, err := mc.ByIndex(byNameIndex, "pod")
+	require.NoError(t, err)
+	require.Equal(t, []interface{}{replacementPod}, items)
+}


### PR DESCRIPTION
Only mark indexer keys as seen after GetByKey confirms that the object still exists. This allows ByIndex to fall back to a cached replacement when an informer deletes an object between IndexKeys and GetByKey.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake
/kind bug

#### What this PR does / why we need it:

`MutationCache.ByIndex` first gets matching keys from the indexer and then
looks up each object with `GetByKey`. Those operations are individually
thread-safe, but they are not atomic: an informer may remove an object between
the two calls.

Previously, `ByIndex` marked the key as handled before confirming that
`GetByKey` still returned an object. If the object had disappeared, the later
mutation-cache pass would skip the same key. A recently created replacement in
the mutation cache could therefore be omitted from the result.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #140041

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a race in client-go MutationCache indexed lookups that could temporarily hide a recently created replacement object.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
