### PR TITLE
kubectl edit: also print YAML syntax errors to stderr

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-syntax-error/test.yaml
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-syntax-error/test.yaml
@@ -5,6 +5,8 @@ args:
 namespace: default
 expectedStdout:
 - "service/kubernetes edited"
+expectedStderr:
+- "The edited file had a syntax error:"
 expectedExitCode: 0
 steps:
 - type: request

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
@@ -351,7 +351,9 @@ func (o *EditOptions) Run() error {
 			if err != nil {
 				// syntax error
 				containsError = true
-				results.header.reasons = append(results.header.reasons, editReason{head: fmt.Sprintf("The edited file had a syntax error: %v", err)})
+				reason := fmt.Sprintf("The edited file had a syntax error: %v", err)
+				results.header.reasons = append(results.header.reasons, editReason{head: reason})
+				fmt.Fprintln(o.ErrOut, reason)
 				continue
 			}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig cli
/area kubectl

#### What this PR does / why we need it:

`kubectl edit` reports the two "your edited file is broken" failure modes
inconsistently on the terminal:

- **Validation errors** are written to `o.ErrOut` (stderr) *and* added to the
  editor header before the editor is reopened.
- **YAML syntax errors** are only added to the editor header. Nothing is
  written to stderr.

So a user (or a script/CI job) watching stderr sees validation problems but
silently misses syntax problems, even though both cause the same
"reopen the editor and try again" flow.

This PR makes the syntax-error path also write the message to stderr, so the
two paths behave the same way on the terminal. The existing behavior is
otherwise unchanged: the error is still added to the editor header, the
user's edited content is still preserved, and the editor is still reopened
for correction.

The change is deliberately minimal — it extracts the already-existing
message string into a local variable and reuses it for both the header and
`fmt.Fprintln(o.ErrOut, ...)`.

#### Which issue(s) this PR fixes:

xref #26050

This does **not** fully resolve #26050 (a broad 2016 UX issue, much of which
has already been addressed over the years). It addresses one specific
remaining inconsistency: syntax errors not being surfaced on stderr the way
validation errors are.

#### Special notes for your reviewer:

- Scope: intentionally narrow. Happy to adjust or split further based on SIG
  CLI's preference given the age and breadth of the linked issue.
- Test: the existing fixture-driven test
  `staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-syntax-error`
  already exercises the full edit → syntax error → reopen → patch flow. This
  PR adds an `expectedStderr` assertion to it, which fails before the code
  change and passes after.
- Verified locally:
  - `go test ./staging/src/k8s.io/kubectl/pkg/cmd/edit/... -run TestEdit`
  - `go test ./staging/src/k8s.io/kubectl/pkg/cmd/util/editor/...`
  - `gofmt -l` clean on the changed file.

#### Does this PR introduce a user-facing change?

```release-note
kubectl edit: YAML syntax errors in the edited file are now also printed to stderr, consistent with how validation errors are already reported.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
