### PR TITLE
tainteviction: observe pod deletion latency in seconds

### DIFF
--- a/pkg/controller/tainteviction/taint_eviction.go
+++ b/pkg/controller/tainteviction/taint_eviction.go
@@ -117,7 +117,7 @@ func deletePodHandler(c clientset.Interface, emitEventFunc func(types.Namespaced
 			err = addConditionAndDeletePod(ctx, c, name, ns)
 			if err == nil {
 				metrics.PodDeletionsTotal.Inc()
-				metrics.PodDeletionsLatency.Observe(float64(time.Since(fireAt) * time.Second))
+				metrics.PodDeletionsLatency.Observe(time.Since(fireAt).Seconds())
 				break
 			}
 			time.Sleep(10 * time.Millisecond)

--- a/pkg/controller/tainteviction/taint_eviction_test.go
+++ b/pkg/controller/tainteviction/taint_eviction_test.go
@@ -37,6 +37,8 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/kubernetes/pkg/controller/tainteviction/metrics"
 	"k8s.io/kubernetes/pkg/controller/testutil"
 )
 
@@ -1001,4 +1003,57 @@ func TestPodDeletionEvent(t *testing.T) {
 			t.Errorf("emitPodDeletionEvent() returned data (-want,+got):\n%s", diff)
 		}
 	})
+}
+
+// podDeletionLatencySum returns the current sum of the pod deletion latency
+// histogram, or 0 if it has not been observed yet.
+func podDeletionLatencySum(t *testing.T) float64 {
+	t.Helper()
+	families, err := legacyregistry.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+	for _, family := range families {
+		if family.GetName() != "taint_eviction_controller_pod_deletion_duration_seconds" {
+			continue
+		}
+		if len(family.GetMetric()) == 0 {
+			break
+		}
+		return family.GetMetric()[0].GetHistogram().GetSampleSum()
+	}
+	return 0
+}
+
+func TestPodDeletionsLatencyObservedInSeconds(t *testing.T) {
+	metrics.Register()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "default"},
+		Spec:       corev1.PodSpec{NodeName: "node1"},
+	}
+	fakeClientset := fake.NewSimpleClientset(pod)
+
+	before := podDeletionLatencySum(t)
+
+	elapsed := 2 * time.Second
+	handler := deletePodHandler(fakeClientset, nil, "test")
+	args := &WorkArgs{Object: NamespacedObject{
+		NamespacedName: types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name},
+	}}
+	if err := handler(context.Background(), time.Now().Add(-elapsed), args); err != nil {
+		t.Fatalf("deletePodHandler failed: %v", err)
+	}
+
+	// The observation must be the elapsed time expressed in seconds. Multiplying a
+	// time.Duration by time.Second instead of calling Seconds() yields nanoseconds
+	// scaled by 1e9, which puts every sample in the +Inf bucket and overflows to a
+	// negative value once the latency exceeds roughly 9.2 seconds.
+	observed := podDeletionLatencySum(t) - before
+	if observed < 0 {
+		t.Errorf("observed latency is negative: %v", observed)
+	}
+	if diff := observed - elapsed.Seconds(); diff < -1 || diff > 1 {
+		t.Errorf("observed latency = %v seconds, want approximately %v", observed, elapsed.Seconds())
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig scheduling

#### What this PR does / why we need it:

`deletePodHandler` records the pod deletion latency with:

```go
metrics.PodDeletionsLatency.Observe(float64(time.Since(fireAt) * time.Second))
```

`time.Since` already returns a `time.Duration` in nanoseconds, so multiplying by
`time.Second` scales it by a further 1e9 instead of converting to seconds.

`taint_eviction_controller_pod_deletion_duration_seconds` is documented as
"Latency, in seconds, ..." and uses buckets from 0.005 to 240. With the current
code the observed values are:

| actual latency | observed | expected |
| :--- | :--- | :--- |
| 5ms | 5000000000000000 | 0.005 |
| 1s | 1000000000000000000 | 1 |
| 9s | 9000000000000000000 | 9 |
| 10s | -8446744073709551616 | 10 |
| 30s | -6893488147419103232 | 30 |

Every observation lands in the `+Inf` bucket, and once the latency exceeds
roughly 9.2s the multiplication overflows int64 and the histogram records a
negative value. `_sum` is meaningless in both cases.

`DeviceTaintEvictionController` already does this correctly in
`pkg/controller/devicetainteviction/device_taint_eviction.go`:

```go
tc.metrics.PodDeletionsLatency.Observe(float64(podDeletionLatency.Seconds()))
```

This PR makes `TaintEvictionController` do the same and adds the regression test
the package was missing, which is why this went unnoticed since the controller
was split out in KEP-3902.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The test drives `deletePodHandler` directly with a known `fireAt` and asserts the
gathered histogram sum is the elapsed time in seconds. It fails on master with:

```
observed latency = 2.003323596e+18 seconds, want approximately 2
```

Verified on linux/arm64: `go test ./pkg/controller/tainteviction/... -count=1`
passes, `go vet` and `gofmt` are clean.

The metric is ALPHA, so the corrected values are not a compatibility concern, but
anyone currently graphing or alerting on it will see the series change from
`+Inf`-only (or negative) to real values.

#### Does this PR introduce a user-facing change?

```release-note
Fixed the `taint_eviction_controller_pod_deletion_duration_seconds` metric, which recorded nanoseconds scaled by 1e9 rather than seconds. Every observation fell into the `+Inf` bucket and latencies above roughly 9.2 seconds were recorded as negative values.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

YES. I used Claude Code to help locate this bug (it surfaced while auditing
metric observation call sites), to draft the regression test, and to verify the
before/after behaviour in a linux container. I reviewed every line and am
responsible for the submitted changes.
