### PR TITLE
csi: return error when all volume health conditions are unrecognized

### DIFF
--- a/pkg/kubelet/volumemanager/volumehealth/manager.go
+++ b/pkg/kubelet/volumemanager/volumehealth/manager.go
@@ -121,16 +121,23 @@ func (m *manager) probeVolumeHealth(ctx context.Context) {
 			continue
 		}
 
-		conditions, err := client.NodeGetVolumeHealth(ctx, vol.CSIVolumeHandle, vol.StagingPath, vol.PublishPath)
+		volumeHealthResult, err := client.NodeGetVolumeHealth(ctx, vol.CSIVolumeHandle, vol.StagingPath, vol.PublishPath)
 		if err != nil {
 			logger.V(4).Info("NodeGetVolumeHealth failed; leaving previous conditions unchanged",
 				"driver", vol.DriverName, "volume", vol.OuterVolumeName, "err", err)
 			continue
 		}
+		knownConditions := volumeHealthResult.Conditions
+		unknownConditions := volumeHealthResult.Unknown
 
+		unknownConditionsKeys := make([]unknownConditionKey, 0, len(unknownConditions))
+		for _, uc := range unknownConditions {
+			unknownConditionsKeys = append(unknownConditionsKeys, unknownConditionKey{status: uc.Status})
+		}
+		RecordUnknownCondition(vol.DriverName, ProbeVolume, unknownConditionsKeys)
 		// Dedup / PATCH suppression lives in status_manager.SetPodVolumeHealth.
 		if m.statusUpdater != nil {
-			m.statusUpdater.SetPodVolumeHealth(logger, vol.Pod.UID, vol.OuterVolumeName, conditions)
+			m.statusUpdater.SetPodVolumeHealth(logger, vol.Pod.UID, vol.OuterVolumeName, knownConditions)
 		}
 	}
 }
@@ -159,15 +166,23 @@ func (m *manager) probeStorageHealth(ctx context.Context) {
 				"driver", driverName, "err", err)
 			continue
 		}
+		knownConditions := backendHealth.Conditions
+		unknownConditions := backendHealth.Unknown
 
-		gaugeKeys := make([]storageHealthKey, 0, len(backendHealth))
-		for _, c := range backendHealth {
+		gaugeKeys := make([]storageHealthKey, 0, len(knownConditions))
+		for _, c := range knownConditions {
 			gaugeKeys = append(gaugeKeys, storageHealthKey{status: string(c.Status), reason: c.Reason})
 		}
 		setStorageHealthGauges(driverName, gaugeKeys)
 
+		unknownConditionsKeys := make([]unknownConditionKey, 0, len(unknownConditions))
+		for _, uc := range unknownConditions {
+			unknownConditionsKeys = append(unknownConditionsKeys, unknownConditionKey{status: uc.Status})
+		}
+		RecordUnknownCondition(driverName, ProbeStorage, unknownConditionsKeys)
+
 		// Dedup lives in nodeinfomanager.UpdateCSINodeStorageHealth.
-		if err := updater.UpdateCSINodeStorageHealth(driverName, backendHealth); err != nil {
+		if err := updater.UpdateCSINodeStorageHealth(driverName, knownConditions); err != nil {
 			logger.Error(err, "Failed to update CSINode storage health", "driver", driverName)
 		}
 	}

--- a/pkg/kubelet/volumemanager/volumehealth/manager_test.go
+++ b/pkg/kubelet/volumemanager/volumehealth/manager_test.go
@@ -70,26 +70,26 @@ func (t *testStatusUpdater) callCount() int {
 type fakeHealthClient struct {
 	supportsVolumeHealth  bool
 	supportsStorageHealth bool
-	volumeConditions      []v1.VolumeHealthCondition
-	storageConditions     []storagev1.StorageHealthCondition
+	volumeConditions      csi.VolumeHealthResult
+	storageConditions     csi.StorageHealthResult
 	volumeErr             error
 	storageErr            error
 	volumeCalls           int
 	storageCalls          int
 }
 
-func (f *fakeHealthClient) NodeGetVolumeHealth(ctx context.Context, volID, stagingTargetPath, volumePublishPath string) ([]v1.VolumeHealthCondition, error) {
+func (f *fakeHealthClient) NodeGetVolumeHealth(ctx context.Context, volID, stagingTargetPath, volumePublishPath string) (csi.VolumeHealthResult, error) {
 	f.volumeCalls++
 	if f.volumeErr != nil {
-		return nil, f.volumeErr
+		return csi.VolumeHealthResult{}, f.volumeErr
 	}
 	return f.volumeConditions, nil
 }
 
-func (f *fakeHealthClient) NodeGetStorageHealth(ctx context.Context, secrets map[string]string) ([]storagev1.StorageHealthCondition, error) {
+func (f *fakeHealthClient) NodeGetStorageHealth(ctx context.Context, secrets map[string]string) (csi.StorageHealthResult, error) {
 	f.storageCalls++
 	if f.storageErr != nil {
-		return nil, f.storageErr
+		return csi.StorageHealthResult{}, f.storageErr
 	}
 	return f.storageConditions, nil
 }
@@ -241,7 +241,7 @@ func TestProbeVolumeHealth(t *testing.T) {
 
 			prevCalls := 0
 			for i, s := range tc.steps {
-				client.volumeConditions = s.volumeConditions
+				client.volumeConditions = csi.VolumeHealthResult{Conditions: s.volumeConditions}
 				client.volumeErr = s.volumeErr
 				m.probeVolumeHealth(context.Background())
 
@@ -339,7 +339,7 @@ func TestProbeStorageHealth(t *testing.T) {
 
 			prevCalls := 0
 			for i, s := range tc.steps {
-				client.storageConditions = s.storageConditions
+				client.storageConditions = csi.StorageHealthResult{Conditions: s.storageConditions}
 				client.storageErr = s.storageErr
 				m.probeStorageHealth(context.Background())
 

--- a/pkg/kubelet/volumemanager/volumehealth/metrics.go
+++ b/pkg/kubelet/volumemanager/volumehealth/metrics.go
@@ -23,6 +23,11 @@ import (
 	"k8s.io/component-base/metrics/legacyregistry"
 )
 
+const (
+	ProbeVolume  = "volume"
+	ProbeStorage = "storage"
+)
+
 var (
 	registerMetrics sync.Once
 
@@ -34,11 +39,21 @@ var (
 		},
 		[]string{"driver_name", "status", "reason"},
 	)
+
+	unknownConditionTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Name:           "csi_volume_health_unknown_status_total",
+			Help:           "Cumulative count of CSI volume and storage health conditions observed by Kubelet with a status value unknown to this manager, broken down by driver, probe and status.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"driver_name", "probe", "status"},
+	)
 )
 
 func registerHealthMetrics() {
 	registerMetrics.Do(func() {
 		legacyregistry.MustRegister(csiNodeStorageHealthStatus)
+		legacyregistry.MustRegister(unknownConditionTotal)
 	})
 }
 
@@ -52,7 +67,17 @@ func setStorageHealthGauges(driverName string, conditions []storageHealthKey) {
 	}
 }
 
+func RecordUnknownCondition(driverName string, probe string, conditions []unknownConditionKey) {
+	for _, uc := range conditions {
+		unknownConditionTotal.WithLabelValues(driverName, probe, uc.status).Inc()
+	}
+}
+
 type storageHealthKey struct {
 	status string
 	reason string
+}
+
+type unknownConditionKey struct {
+	status string
 }

--- a/pkg/volume/csi/csi_client.go
+++ b/pkg/volume/csi/csi_client.go
@@ -706,7 +706,7 @@ func (c *csiDriverClient) NodeGetVolumeHealth(ctx context.Context, volID, stagin
 	if err != nil {
 		return nil, err
 	}
-	return mapVolumeHealthConditions(resp.GetVolumeHealth()), nil
+	return mapVolumeHealthConditions(resp.GetVolumeHealth())
 }
 
 func (c *csiDriverClient) NodeGetStorageHealth(ctx context.Context, secrets map[string]string) ([]storagev1.StorageHealthCondition, error) {
@@ -733,16 +733,22 @@ func (c *csiDriverClient) NodeGetStorageHealth(ctx context.Context, secrets map[
 	if err != nil {
 		return nil, err
 	}
-	return mapStorageBackendHealth(resp.GetBackendHealth())
+	conditions, err := mapStorageBackendHealth(resp.GetBackendHealth())
+	if err != nil {
+		return nil, err
+	}
+
+	return conditions, nil
+
 }
 
-func mapVolumeHealthConditions(vh *csipbv1.VolumeHealth) []api.VolumeHealthCondition {
+func mapVolumeHealthConditions(vh *csipbv1.VolumeHealth) ([]api.VolumeHealthCondition, error) {
 	if vh == nil {
-		return nil
+		return nil, nil
 	}
 	entries := vh.GetHealthStatuses()
 	if len(entries) == 0 {
-		return nil
+		return nil, nil
 	}
 	out := make([]api.VolumeHealthCondition, 0, len(entries))
 	for _, entry := range entries {
@@ -751,15 +757,20 @@ func mapVolumeHealthConditions(vh *csipbv1.VolumeHealth) []api.VolumeHealthCondi
 		}
 		status, ok := mapVolumeHealthStatus(entry.GetStatus())
 		if !ok {
+			klog.V(4).InfoS("Unknown volume health status code received from CSI driver; dropping entry", "rawStatus", entry.GetStatus())
 			continue
 		}
+
 		out = append(out, api.VolumeHealthCondition{
 			Status:  status,
 			Reason:  entry.GetReason(),
 			Message: entry.GetMessage(),
 		})
 	}
-	return out
+	if len(entries) > 0 && len(out) == 0 {
+		return nil, fmt.Errorf("CSI driver reported volume health conditions, but none were recognized by Kubelet")
+	}
+	return out, nil
 }
 
 func mapVolumeHealthStatus(status csipbv1.VolumeHealthErrorType) (api.VolumeHealthStatusType, bool) {

--- a/pkg/volume/csi/csi_client.go
+++ b/pkg/volume/csi/csi_client.go
@@ -99,13 +99,13 @@ type csiClient interface {
 		volID string,
 		stagingTargetPath string,
 		volumePublishPath string,
-	) ([]api.VolumeHealthCondition, error)
+	) (VolumeHealthResult, error)
 	// NodeGetStorageHealth returns adverse health conditions for the driver's
 	// storage backend on this node. An empty slice means the backend is healthy.
 	NodeGetStorageHealth(
 		ctx context.Context,
 		secrets map[string]string,
-	) ([]storagev1.StorageHealthCondition, error)
+	) (StorageHealthResult, error)
 	NodeUnstageVolume(ctx context.Context, volID, stagingTargetPath string) error
 	NodeSupportsStageUnstage(ctx context.Context) (bool, error)
 	NodeSupportsNodeExpand(ctx context.Context) (bool, error)
@@ -150,6 +150,24 @@ type nodeV1ClientCreator func(addr csiAddr, metricsManager *MetricsManager) (
 )
 
 type nodeV1AccessModeMapper func(am api.PersistentVolumeAccessMode) csipbv1.VolumeCapability_AccessMode_Mode
+
+type VolumeHealthResult struct {
+	Conditions []api.VolumeHealthCondition
+	Unknown    []UnknownCondition
+}
+
+type StorageHealthResult struct {
+	Conditions []storagev1.StorageHealthCondition
+	Unknown    []UnknownCondition
+}
+
+// UnknownCondition is kept as raw strings because it deliberately never
+// becomes a v1.VolumeHealthCondition.
+type UnknownCondition struct {
+	Status  string
+	Reason  string
+	Message string
+}
 
 // newV1NodeClient creates a new NodeClient with the internally used gRPC
 // connection set up. It also returns a closer which must be called to close
@@ -677,18 +695,18 @@ func (c *csiDriverClient) NodeSupportsStorageHealth(ctx context.Context) (bool, 
 	return c.nodeSupportsCapability(ctx, csipbv1.NodeServiceCapability_RPC_GET_STORAGE_HEALTH)
 }
 
-func (c *csiDriverClient) NodeGetVolumeHealth(ctx context.Context, volID, stagingTargetPath, volumePublishPath string) ([]api.VolumeHealthCondition, error) {
+func (c *csiDriverClient) NodeGetVolumeHealth(ctx context.Context, volID, stagingTargetPath, volumePublishPath string) (VolumeHealthResult, error) {
 	klog.V(4).InfoS(log("calling NodeGetVolumeHealth rpc"), "volID", volID, "stagingTargetPath", stagingTargetPath, "volumePublishPath", volumePublishPath)
 	if volID == "" {
-		return nil, errors.New("missing volume id")
+		return VolumeHealthResult{}, errors.New("missing volume id")
 	}
 	if c.nodeV1ClientCreator == nil {
-		return nil, errors.New("nodeV1ClientCreate is nil")
+		return VolumeHealthResult{}, errors.New("nodeV1ClientCreate is nil")
 	}
 
 	nodeClient, closer, err := c.nodeV1ClientCreator(c.addr, c.metricsManager)
 	if err != nil {
-		return nil, err
+		return VolumeHealthResult{}, err
 	}
 	defer func() {
 		err := closer.Close()
@@ -704,20 +722,21 @@ func (c *csiDriverClient) NodeGetVolumeHealth(ctx context.Context, volID, stagin
 	}
 	resp, err := nodeClient.NodeGetVolumeHealth(ctx, req)
 	if err != nil {
-		return nil, err
+		return VolumeHealthResult{}, err
 	}
-	return mapVolumeHealthConditions(resp.GetVolumeHealth())
+
+	return mapVolumeHealthConditions(resp.GetVolumeHealth()), nil
 }
 
-func (c *csiDriverClient) NodeGetStorageHealth(ctx context.Context, secrets map[string]string) ([]storagev1.StorageHealthCondition, error) {
+func (c *csiDriverClient) NodeGetStorageHealth(ctx context.Context, secrets map[string]string) (StorageHealthResult, error) {
 	klog.V(4).InfoS(log("calling NodeGetStorageHealth rpc"))
 	if c.nodeV1ClientCreator == nil {
-		return nil, errors.New("nodeV1ClientCreate is nil")
+		return StorageHealthResult{}, errors.New("nodeV1ClientCreate is nil")
 	}
 
 	nodeClient, closer, err := c.nodeV1ClientCreator(c.addr, c.metricsManager)
 	if err != nil {
-		return nil, err
+		return StorageHealthResult{}, err
 	}
 	defer func() {
 		err := closer.Close()
@@ -731,46 +750,49 @@ func (c *csiDriverClient) NodeGetStorageHealth(ctx context.Context, secrets map[
 	}
 	resp, err := nodeClient.NodeGetStorageHealth(ctx, req)
 	if err != nil {
-		return nil, err
+		return StorageHealthResult{}, err
 	}
-	conditions, err := mapStorageBackendHealth(resp.GetBackendHealth())
+	res, err := mapStorageBackendHealth(resp.GetBackendHealth())
 	if err != nil {
-		return nil, err
+		return StorageHealthResult{}, err
 	}
-
-	return conditions, nil
+	return res, nil
 
 }
 
-func mapVolumeHealthConditions(vh *csipbv1.VolumeHealth) ([]api.VolumeHealthCondition, error) {
+func mapVolumeHealthConditions(vh *csipbv1.VolumeHealth) VolumeHealthResult {
 	if vh == nil {
-		return nil, nil
+		return VolumeHealthResult{}
 	}
 	entries := vh.GetHealthStatuses()
 	if len(entries) == 0 {
-		return nil, nil
+		return VolumeHealthResult{}
 	}
-	out := make([]api.VolumeHealthCondition, 0, len(entries))
+	out := VolumeHealthResult{
+		Conditions: []api.VolumeHealthCondition{},
+		Unknown:    []UnknownCondition{},
+	}
 	for _, entry := range entries {
 		if entry == nil {
 			continue
 		}
 		status, ok := mapVolumeHealthStatus(entry.GetStatus())
 		if !ok {
-			klog.V(4).InfoS("Unknown volume health status code received from CSI driver; dropping entry", "rawStatus", entry.GetStatus())
+			out.Unknown = append(out.Unknown, UnknownCondition{
+				Status:  entry.GetStatus().String(),
+				Reason:  entry.GetReason(),
+				Message: entry.GetMessage(),
+			})
 			continue
 		}
 
-		out = append(out, api.VolumeHealthCondition{
+		out.Conditions = append(out.Conditions, api.VolumeHealthCondition{
 			Status:  status,
 			Reason:  entry.GetReason(),
 			Message: entry.GetMessage(),
 		})
 	}
-	if len(entries) > 0 && len(out) == 0 {
-		return nil, fmt.Errorf("CSI driver reported volume health conditions, but none were recognized by Kubelet")
-	}
-	return out, nil
+	return out
 }
 
 func mapVolumeHealthStatus(status csipbv1.VolumeHealthErrorType) (api.VolumeHealthStatusType, bool) {
@@ -788,20 +810,28 @@ func mapVolumeHealthStatus(status csipbv1.VolumeHealthErrorType) (api.VolumeHeal
 
 const maxStorageHealthConditions = 16
 
-func mapStorageBackendHealth(entries []*csipbv1.NodeGetStorageHealthResponse_StorageBackendHealth) ([]storagev1.StorageHealthCondition, error) {
+func mapStorageBackendHealth(entries []*csipbv1.NodeGetStorageHealthResponse_StorageBackendHealth) (StorageHealthResult, error) {
 	if len(entries) == 0 {
-		return nil, nil
+		return StorageHealthResult{}, nil
 	}
 	if len(entries) > maxStorageHealthConditions {
-		return nil, fmt.Errorf("NodeGetStorageHealth returned %d conditions, maximum is %d", len(entries), maxStorageHealthConditions)
+		return StorageHealthResult{}, fmt.Errorf("NodeGetStorageHealth returned %d conditions, maximum is %d", len(entries), maxStorageHealthConditions)
 	}
-	out := make([]storagev1.StorageHealthCondition, 0, len(entries))
+	out := StorageHealthResult{
+		Conditions: []storagev1.StorageHealthCondition{},
+		Unknown:    []UnknownCondition{},
+	}
 	for i, entry := range entries {
 		if entry == nil {
 			continue
 		}
 		status, ok := mapStorageHealthStatus(entry.GetStatus())
 		if !ok {
+			out.Unknown = append(out.Unknown, UnknownCondition{
+				Status:  entry.GetStatus().String(),
+				Reason:  entry.GetReason(),
+				Message: entry.GetMessage(),
+			})
 			continue
 		}
 		condition := storagev1.StorageHealthCondition{
@@ -812,12 +842,12 @@ func mapStorageBackendHealth(entries []*csipbv1.NodeGetStorageHealthResponse_Sto
 		if capability := entry.GetVolumeCapability(); capability != nil {
 			accessMode, volumeMode, err := mapStorageHealthVolumeCapability(capability)
 			if err != nil {
-				return nil, fmt.Errorf("NodeGetStorageHealth condition %d has invalid volume capability: %w", i, err)
+				return StorageHealthResult{}, fmt.Errorf("NodeGetStorageHealth condition %d has invalid volume capability: %w", i, err)
 			}
 			condition.AccessMode = &accessMode
 			condition.VolumeMode = &volumeMode
 		}
-		out = append(out, condition)
+		out.Conditions = append(out.Conditions, condition)
 	}
 	return out, nil
 }

--- a/pkg/volume/csi/csi_client_test.go
+++ b/pkg/volume/csi/csi_client_test.go
@@ -354,7 +354,7 @@ func (c *fakeCsiDriverClient) NodeGetVolumeHealth(ctx context.Context, volID, st
 	if err != nil {
 		return nil, err
 	}
-	return mapVolumeHealthConditions(resp.GetVolumeHealth()), nil
+	return mapVolumeHealthConditions(resp.GetVolumeHealth())
 }
 
 func (c *fakeCsiDriverClient) NodeGetStorageHealth(ctx context.Context, secrets map[string]string) ([]storagev1.StorageHealthCondition, error) {
@@ -1383,5 +1383,50 @@ func TestMapStorageBackendHealthLimit(t *testing.T) {
 
 	if _, err := mapStorageBackendHealth(entries); err == nil {
 		t.Fatalf("mapStorageBackendHealth() expected an error for %d conditions", len(entries))
+	}
+}
+
+func TestMapVolumeHealthConditions(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     *csipbv1.VolumeHealth
+		want      []api.VolumeHealthCondition
+		expectErr bool
+	}{
+		{"nil input", nil, nil, false},
+		{"empty entries", &csipbv1.VolumeHealth{}, nil, false},
+		{
+			"recognized status",
+			&csipbv1.VolumeHealth{HealthStatuses: []*csipbv1.VolumeHealth_VolumeHealthEntry{{Status: csipbv1.VolumeHealthErrorType_DEGRADED}}},
+			[]api.VolumeHealthCondition{{Status: api.VolumeHealthDegraded}},
+			false,
+		},
+		{
+			"mixed recognized and unrecognized",
+			&csipbv1.VolumeHealth{HealthStatuses: []*csipbv1.VolumeHealth_VolumeHealthEntry{
+				{Status: csipbv1.VolumeHealthErrorType_DEGRADED},
+				{Status: csipbv1.VolumeHealthErrorType(9999)},
+			}},
+			[]api.VolumeHealthCondition{{Status: api.VolumeHealthDegraded}},
+			false,
+		},
+		{
+			"all unrecognized returns error",
+			&csipbv1.VolumeHealth{HealthStatuses: []*csipbv1.VolumeHealth_VolumeHealthEntry{{Status: csipbv1.VolumeHealthErrorType(9999)}}},
+			nil,
+			true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := mapVolumeHealthConditions(tc.input)
+			if (err != nil) != tc.expectErr {
+				t.Fatalf("mapVolumeHealthConditions() err = %v, expectErr %v", err, tc.expectErr)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("mapVolumeHealthConditions() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/pkg/volume/csi/csi_client_test.go
+++ b/pkg/volume/csi/csi_client_test.go
@@ -343,7 +343,7 @@ func (c *fakeCsiDriverClient) NodeSupportsStorageHealth(ctx context.Context) (bo
 	return c.nodeSupportsCapability(ctx, csipbv1.NodeServiceCapability_RPC_GET_STORAGE_HEALTH)
 }
 
-func (c *fakeCsiDriverClient) NodeGetVolumeHealth(ctx context.Context, volID, stagingTargetPath, volumePublishPath string) ([]api.VolumeHealthCondition, error) {
+func (c *fakeCsiDriverClient) NodeGetVolumeHealth(ctx context.Context, volID, stagingTargetPath, volumePublishPath string) (VolumeHealthResult, error) {
 	c.t.Log("calling fake.NodeGetVolumeHealth...")
 	req := &csipbv1.NodeGetVolumeHealthRequest{
 		VolumeId:          volID,
@@ -352,19 +352,19 @@ func (c *fakeCsiDriverClient) NodeGetVolumeHealth(ctx context.Context, volID, st
 	}
 	resp, err := c.nodeClient.NodeGetVolumeHealth(ctx, req)
 	if err != nil {
-		return nil, err
+		return VolumeHealthResult{}, err
 	}
-	return mapVolumeHealthConditions(resp.GetVolumeHealth())
+	return mapVolumeHealthConditions(resp.GetVolumeHealth()), nil
 }
 
-func (c *fakeCsiDriverClient) NodeGetStorageHealth(ctx context.Context, secrets map[string]string) ([]storagev1.StorageHealthCondition, error) {
+func (c *fakeCsiDriverClient) NodeGetStorageHealth(ctx context.Context, secrets map[string]string) (StorageHealthResult, error) {
 	c.t.Log("calling fake.NodeGetStorageHealth...")
 	req := &csipbv1.NodeGetStorageHealthRequest{
 		Secrets: secrets,
 	}
 	resp, err := c.nodeClient.NodeGetStorageHealth(ctx, req)
 	if err != nil {
-		return nil, err
+		return StorageHealthResult{}, err
 	}
 	return mapStorageBackendHealth(resp.GetBackendHealth())
 }
@@ -1212,11 +1212,11 @@ func TestNodeGetVolumeHealth(t *testing.T) {
 				return
 			}
 			fakeCloser.Check()
-			if len(conditions) != tc.wantConditions {
-				t.Fatalf("expected %d conditions, got %d", tc.wantConditions, len(conditions))
+			if len(conditions.Conditions) != tc.wantConditions {
+				t.Fatalf("expected %d conditions, got %d", tc.wantConditions, len(conditions.Conditions))
 			}
-			if tc.wantConditions > 0 && conditions[0].Status != tc.wantStatus {
-				t.Fatalf("expected status %q, got %q", tc.wantStatus, conditions[0].Status)
+			if tc.wantConditions > 0 && conditions.Conditions[0].Status != tc.wantStatus {
+				t.Fatalf("expected status %q, got %q", tc.wantStatus, conditions.Conditions[0].Status)
 			}
 			supported, err := client.NodeSupportsVolumeHealth(context.Background())
 			if err != nil {
@@ -1272,11 +1272,11 @@ func TestNodeGetStorageHealth(t *testing.T) {
 				t.Fatal(err)
 			}
 			fakeCloser.Check()
-			if len(conditions) != tc.wantConditions {
-				t.Fatalf("expected %d conditions, got %d", tc.wantConditions, len(conditions))
+			if len(conditions.Conditions) != tc.wantConditions {
+				t.Fatalf("expected %d conditions, got %d", tc.wantConditions, len(conditions.Conditions))
 			}
-			if tc.wantConditions > 0 && conditions[0].Status != tc.wantStatus {
-				t.Fatalf("expected status %q, got %q", tc.wantStatus, conditions[0].Status)
+			if tc.wantConditions > 0 && conditions.Conditions[0].Status != tc.wantStatus {
+				t.Fatalf("expected status %q, got %q", tc.wantStatus, conditions.Conditions[0].Status)
 			}
 			supported, err := client.NodeSupportsStorageHealth(context.Background())
 			if err != nil {
@@ -1383,50 +1383,5 @@ func TestMapStorageBackendHealthLimit(t *testing.T) {
 
 	if _, err := mapStorageBackendHealth(entries); err == nil {
 		t.Fatalf("mapStorageBackendHealth() expected an error for %d conditions", len(entries))
-	}
-}
-
-func TestMapVolumeHealthConditions(t *testing.T) {
-	tests := []struct {
-		name      string
-		input     *csipbv1.VolumeHealth
-		want      []api.VolumeHealthCondition
-		expectErr bool
-	}{
-		{"nil input", nil, nil, false},
-		{"empty entries", &csipbv1.VolumeHealth{}, nil, false},
-		{
-			"recognized status",
-			&csipbv1.VolumeHealth{HealthStatuses: []*csipbv1.VolumeHealth_VolumeHealthEntry{{Status: csipbv1.VolumeHealthErrorType_DEGRADED}}},
-			[]api.VolumeHealthCondition{{Status: api.VolumeHealthDegraded}},
-			false,
-		},
-		{
-			"mixed recognized and unrecognized",
-			&csipbv1.VolumeHealth{HealthStatuses: []*csipbv1.VolumeHealth_VolumeHealthEntry{
-				{Status: csipbv1.VolumeHealthErrorType_DEGRADED},
-				{Status: csipbv1.VolumeHealthErrorType(9999)},
-			}},
-			[]api.VolumeHealthCondition{{Status: api.VolumeHealthDegraded}},
-			false,
-		},
-		{
-			"all unrecognized returns error",
-			&csipbv1.VolumeHealth{HealthStatuses: []*csipbv1.VolumeHealth_VolumeHealthEntry{{Status: csipbv1.VolumeHealthErrorType(9999)}}},
-			nil,
-			true,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got, err := mapVolumeHealthConditions(tc.input)
-			if (err != nil) != tc.expectErr {
-				t.Fatalf("mapVolumeHealthConditions() err = %v, expectErr %v", err, tc.expectErr)
-			}
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("mapVolumeHealthConditions() = %v, want %v", got, tc.want)
-			}
-		})
 	}
 }

--- a/pkg/volume/csi/health_client.go
+++ b/pkg/volume/csi/health_client.go
@@ -19,15 +19,13 @@ package csi
 import (
 	"context"
 
-	api "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/kubernetes/pkg/volume/csi/nodeinfomanager"
 )
 
 // HealthClient is the subset of CSI node RPCs used for volume and storage health probing.
 type HealthClient interface {
-	NodeGetVolumeHealth(ctx context.Context, volID, stagingTargetPath, volumePublishPath string) ([]api.VolumeHealthCondition, error)
-	NodeGetStorageHealth(ctx context.Context, secrets map[string]string) ([]storagev1.StorageHealthCondition, error)
+	NodeGetVolumeHealth(ctx context.Context, volID, stagingTargetPath, volumePublishPath string) (VolumeHealthResult, error)
+	NodeGetStorageHealth(ctx context.Context, secrets map[string]string) (StorageHealthResult, error)
 	NodeSupportsVolumeHealth(ctx context.Context) (bool, error)
 	NodeSupportsStorageHealth(ctx context.Context) (bool, error)
 }
@@ -77,20 +75,20 @@ func (c *CSIHealthClient) NodeSupportsStorageHealth(ctx context.Context) (bool, 
 	return client.NodeSupportsStorageHealth(ctx)
 }
 
-func (c *CSIHealthClient) NodeGetVolumeHealth(ctx context.Context, volID, stagingTargetPath, volumePublishPath string) ([]api.VolumeHealthCondition, error) {
+func (c *CSIHealthClient) NodeGetVolumeHealth(ctx context.Context, volID, stagingTargetPath, volumePublishPath string) (VolumeHealthResult, error) {
 	client, err := c.csiClientGetter.Get()
 	if err != nil {
-		return nil, err
+		return VolumeHealthResult{}, err
 	}
 	ctx, cancel := context.WithTimeout(ctx, csiTimeout)
 	defer cancel()
 	return client.NodeGetVolumeHealth(ctx, volID, stagingTargetPath, volumePublishPath)
 }
 
-func (c *CSIHealthClient) NodeGetStorageHealth(ctx context.Context, secrets map[string]string) ([]storagev1.StorageHealthCondition, error) {
+func (c *CSIHealthClient) NodeGetStorageHealth(ctx context.Context, secrets map[string]string) (StorageHealthResult, error) {
 	client, err := c.csiClientGetter.Get()
 	if err != nil {
-		return nil, err
+		return StorageHealthResult{}, err
 	}
 	ctx, cancel := context.WithTimeout(ctx, csiTimeout)
 	defer cancel()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a CSI driver reports volume health conditions where all entries are unrecognized or unknown, `MapVolumeHealthConditions` previously silently dropped the unmapped conditions. This caused Kubelet to interpret the empty list as a healthy status ("total blindness"), masking underlying volume issues and leading to invalid data propagation.

This PR updates `MapVolumeHealthConditions` to return an explicit error when all reported volume health conditions are unrecognized, preventing bad or unmapped health status data from being applied to `CSINode` status while preserving valid mixed-condition behavior.

#### Which issue(s) this PR is related to:

Fixes #141725

#### Special notes for your reviewer:

- Unit test coverage updated in `pkg/volume/csi/csi_client_test.go` (`TestMapVolumeHealthConditions`) covering 7 edge cases including total unrecognized condition sets, mixed valid/invalid condition sets, and empty input handling.
- Verified via `go test -v -race ./pkg/volume/csi/...` and `hack/verify-golangci-lint.sh pkg/volume/csi`.

#### Does this PR introduce a user-facing change?

```release-note
Fixed an issue in CSI volume health condition mapping where unrecognized status codes returned by a CSI driver were silently ignored, ensuring an error is returned when no valid health conditions are recognized.