### PR TITLE
WIP: serve watch cache write path compares from a lock-free latest snapshot

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
@@ -81,8 +81,8 @@ func (c *CacheDelegator) EnableResourceSizeEstimation(keys storage.KeysFunc) err
 func (c *CacheDelegator) Delete(ctx context.Context, key string, out runtime.Object, preconditions *storage.Preconditions, validateDeletion storage.ValidateObjectFunc, cachedExistingObject runtime.Object, opts storage.DeleteOptions) error {
 	// Ignore the suggestion and try to pass down the current version of the object
 	// read from cache.
-	if elem, exists, err := c.cacher.watchCache.storage.GetByKey(key); err != nil {
-		klog.Errorf("GetByKey returned error: %v", err)
+	if elem, exists, err := c.cacher.watchCache.storage.GetByKeyLatestSnapshot(key); err != nil {
+		klog.Errorf("GetByKeyLatestSnapshot returned error: %v", err)
 	} else if exists {
 		// DeepCopy the object since we modify resource version when serializing the
 		// current object.
@@ -193,8 +193,8 @@ func shouldDelegateListOnNotReadyCache(opts storage.ListOptions) bool {
 func (c *CacheDelegator) GuaranteedUpdate(ctx context.Context, key string, destination runtime.Object, ignoreNotFound bool, preconditions *storage.Preconditions, tryUpdate storage.UpdateFunc, cachedExistingObject runtime.Object) error {
 	// Ignore the suggestion and try to pass down the current version of the object
 	// read from cache.
-	if elem, exists, err := c.cacher.watchCache.storage.GetByKey(key); err != nil {
-		klog.Errorf("GetByKey returned error: %v", err)
+	if elem, exists, err := c.cacher.watchCache.storage.GetByKeyLatestSnapshot(key); err != nil {
+		klog.Errorf("GetByKeyLatestSnapshot returned error: %v", err)
 	} else if exists {
 		// DeepCopy the object since we modify resource version when serializing the
 		// current object.

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree.go
@@ -21,6 +21,7 @@ import (
 	"iter"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/third_party/forked/golang/btree"
@@ -465,6 +466,7 @@ type Snapshotter interface {
 type storeSnapshotter struct {
 	mux       sync.RWMutex
 	snapshots *btree.BTree[rvSnapshot]
+	latest    atomic.Pointer[rvSnapshot]
 }
 
 type rvSnapshot struct {
@@ -476,6 +478,7 @@ func (s *storeSnapshotter) Reset() {
 	s.mux.Lock()
 	defer s.mux.Unlock()
 	s.snapshots.Clear(false)
+	s.latest.Store(nil)
 }
 
 func (s *storeSnapshotter) GetLessOrEqual(rv uint64) (Snapshot, bool) {
@@ -494,20 +497,21 @@ func (s *storeSnapshotter) GetLessOrEqual(rv uint64) (Snapshot, bool) {
 }
 
 func (s *storeSnapshotter) Latest() (Snapshot, bool) {
-	s.mux.RLock()
-	defer s.mux.RUnlock()
-
-	max, ok := s.snapshots.Max()
-	if !ok {
+	latest := s.latest.Load()
+	if latest == nil {
 		return nil, false
 	}
-	return max.snapshot, true
+	return latest.snapshot, true
 }
 
 func (s *storeSnapshotter) Add(rv uint64, indexer Indexer) {
 	s.mux.Lock()
 	defer s.mux.Unlock()
-	s.snapshots.ReplaceOrInsert(rvSnapshot{resourceVersion: rv, snapshot: indexer.Clone()})
+	rvs := rvSnapshot{resourceVersion: rv, snapshot: indexer.Clone()}
+	s.snapshots.ReplaceOrInsert(rvs)
+	if latest := s.latest.Load(); latest == nil || latest.resourceVersion <= rv {
+		s.latest.Store(&rvs)
+	}
 }
 
 func (s *storeSnapshotter) RemoveLess(rv uint64) {
@@ -522,6 +526,9 @@ func (s *storeSnapshotter) RemoveLess(rv uint64) {
 			break
 		}
 		s.snapshots.DeleteMin()
+	}
+	if s.snapshots.Len() == 0 {
+		s.latest.Store(nil)
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/watch_cache_storage.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/watch_cache_storage.go
@@ -61,6 +61,13 @@ type WatchCacheStorage struct {
 	snapshottingEnabled atomic.Bool
 }
 
+func (w *WatchCacheStorage) GetByKeyLatestSnapshot(key string) (interface{}, bool, error) {
+	if snap, ok := w.LatestSnapshot(); ok {
+		return snap.GetByKey(key)
+	}
+	return w.store.GetByKey(key)
+}
+
 // StoreLocked returns the live store.
 // Unlike GetExactSnapshotLocked this is not an immutable point-in-time copy.
 // The caller must hold the lock for the duration of use.
@@ -100,7 +107,7 @@ func (w *WatchCacheStorage) MarkConsistent(consistent bool) {
 	}
 }
 
-func (w *WatchCacheStorage) LatestSnapshotLocked() (Snapshot, bool) {
+func (w *WatchCacheStorage) LatestSnapshot() (Snapshot, bool) {
 	if w.SnapshottingEnabled() {
 		return w.snapshots.Latest()
 	}
@@ -108,7 +115,7 @@ func (w *WatchCacheStorage) LatestSnapshotLocked() (Snapshot, bool) {
 }
 
 func (w *WatchCacheStorage) GetLatestSnapshotOrBuildLocked(key, continueKey string) (Snapshot, error) {
-	if snap, ok := w.LatestSnapshotLocked(); ok {
+	if snap, ok := w.LatestSnapshot(); ok {
 		// Snapshots are added in order as we update store, so the
 		// latest snapshot match latest store state and latest revision.
 		return snap, nil

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/watch_cache_storage_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/watch_cache_storage_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package store
 
 import (
+	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,7 +71,7 @@ func TestWatchCacheStorageMarkConsistent(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestLatestSnapshotLocked(t *testing.T) {
+func TestLatestSnapshot(t *testing.T) {
 	keyFunc := func(obj runtime.Object) (string, error) {
 		return obj.(*mockObject).key, nil
 	}
@@ -78,18 +80,84 @@ func TestLatestSnapshotLocked(t *testing.T) {
 	indexers := &cache.Indexers{}
 	s := NewWatchCacheStorage(keyFunc, indexers)
 
-	_, ok := s.LatestSnapshotLocked()
+	_, ok := s.LatestSnapshot()
 	assert.False(t, ok, "expected no snapshot before any writes")
 
 	elem := &Element{Key: "foo", Object: &mockObject{key: "foo", val: "100"}}
 	require.NoError(t, s.UpdateStoreLocked(watch.Added, elem, 100))
 
-	snap, ok := s.LatestSnapshotLocked()
+	snap, ok := s.LatestSnapshot()
 	require.True(t, ok, "expected snapshot after write")
 	items, err := snap.OrderedListPrefix("", "")
 	require.NoError(t, err)
 	assert.Len(t, items, 1)
 	assert.Equal(t, &mockObject{key: "foo", val: "100"}, items[0].(*Element).Object)
+}
+
+func TestGetByKeyLatestSnapshot(t *testing.T) {
+	s := NewWatchCacheStorage(func(obj runtime.Object) (string, error) {
+		return obj.(*mockObject).key, nil
+	}, &cache.Indexers{})
+	update := func(et watch.EventType, key, val string, rv uint64) {
+		t.Helper()
+		require.NoError(t, s.UpdateStoreLocked(et, &Element{Key: key, Object: &mockObject{key: key, val: val}}, rv))
+	}
+
+	update(watch.Added, "a", "1", 100)
+	update(watch.Added, "b", "2", 101)
+	update(watch.Deleted, "a", "1", 102)
+
+	for _, key := range []string{"a", "b", "missing"} {
+		wantObj, wantOK, err := s.GetByKey(key)
+		require.NoError(t, err)
+		gotObj, gotOK, err := s.GetByKeyLatestSnapshot(key)
+		require.NoError(t, err)
+		require.Equal(t, wantOK, gotOK, "existence mismatch for %q", key)
+		if wantOK {
+			assert.Equal(t, wantObj.(*Element).Object, gotObj.(*Element).Object, "value mismatch for %q", key)
+		}
+	}
+
+	// Diverge the live store from the snapshot to prove which one is served.
+	require.NoError(t, s.store.Update(&Element{Key: "b", Object: &mockObject{key: "b", val: "999"}}))
+	got, ok, err := s.GetByKeyLatestSnapshot("b")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "2", got.(*Element).Object.(*mockObject).val, "expected the snapshot, not the live store")
+
+	// An inconsistent cache releases its snapshots while the store stays populated.
+	s.MarkConsistent(false)
+	update(watch.Modified, "b", "3", 103)
+	got, ok, err = s.GetByKeyLatestSnapshot("b")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "3", got.(*Element).Object.(*mockObject).val, "expected the live store")
+}
+
+func TestGetByKeyLatestSnapshotConcurrentWithIngest(t *testing.T) {
+	s := NewWatchCacheStorage(func(obj runtime.Object) (string, error) {
+		return obj.(*mockObject).key, nil
+	}, &cache.Indexers{})
+	require.NoError(t, s.UpdateStoreLocked(watch.Added, &Element{Key: "foo", Object: &mockObject{key: "foo", val: "0"}}, 100))
+
+	var wg sync.WaitGroup
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				if _, ok, err := s.GetByKeyLatestSnapshot("foo"); err != nil || !ok {
+					t.Errorf("GetByKeyLatestSnapshot(foo) = %v, %v; want found, nil", ok, err)
+					return
+				}
+			}
+		}()
+	}
+	for rv := uint64(101); rv < 1101; rv++ {
+		elem := &Element{Key: "foo", Object: &mockObject{key: "foo", val: strconv.FormatUint(rv, 10)}}
+		require.NoError(t, s.UpdateStoreLocked(watch.Modified, elem, rv))
+	}
+	wg.Wait()
 }
 
 func TestWatchCacheStorageMatchExactResourceVersionFallback(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -677,7 +677,7 @@ func (w *watchCache) getIntervalFromStoreLocked(key string, matchesSingle bool) 
 	// When not matching a single key, an immutable snapshot lets us
 	// defer the O(N) interval build off the watchCache lock.
 	if !matchesSingle {
-		if snapshot, ok := w.storage.LatestSnapshotLocked(); ok {
+		if snapshot, ok := w.storage.LatestSnapshot(); ok {
 			return newCacheIntervalFromLazySnapshot(w.resourceVersion, snapshot), nil
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Make the watch cache's latest snapshot lock-free and serve the write path's optimistic concurrency compare from it, so seeding a compare no longer takes a lock that contends with the reflector.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```