### PR TITLE
client-go: context-aware APIs

### DIFF
--- a/staging/src/k8s.io/client-go/CHANGELOG.md
+++ b/staging/src/k8s.io/client-go/CHANGELOG.md
@@ -4,6 +4,19 @@ Go API changes are typically not included in the Kubernetes release notes, so
 noteworthy Go API changes *may* be documented here. This is currently not
 *required*, so consult the git history to see all changes.
 
+### Dynamic shared informer factory: add StartWithContext
+
+The same change was made earlier for the type informer factory:
+the new API supports contextual logging because a logger can
+be attached to the context.
+
+Mock implementations of the DynamicSharedInformerFactory have to add a
+StartWithContext implementation.
+
+```
+- ./dynamic/dynamicinformer.DynamicSharedInformerFactory.StartWithContext: added
+```
+
 ### sigs.k8s.io/structured-merge-diff/v7 upgrade
 
 The signature of csaupgrade.FindFieldsOwners changed from sigs.k8s.io/structured-merge-diff/v6 to sigs.k8s.io/structured-merge-diff/v7 types.

--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamiclister"
@@ -88,7 +89,14 @@ func (f *dynamicSharedInformerFactory) ForResource(gvr schema.GroupVersionResour
 }
 
 // Start initializes all requested informers.
+//
+// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
 func (f *dynamicSharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.StartWithContext(wait.ContextForChannel(stopCh))
+}
+
+// StartWithContext initializes all requested informers.
+func (f *dynamicSharedInformerFactory) StartWithContext(ctx context.Context) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -105,7 +113,7 @@ func (f *dynamicSharedInformerFactory) Start(stopCh <-chan struct{}) {
 			informer := informer.Informer()
 			go func() {
 				defer f.wg.Done()
-				informer.Run(stopCh)
+				informer.RunWithContext(ctx)
 			}()
 			f.startedInformers[informerType] = true
 		}

--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/interface.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/interface.go
@@ -17,6 +17,8 @@ limitations under the License.
 package dynamicinformer
 
 import (
+	"context"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/informers"
@@ -26,7 +28,13 @@ import (
 type DynamicSharedInformerFactory interface {
 	// Start initializes all requested informers. They are handled in goroutines
 	// which run until the stop channel gets closed.
+	//
+	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
+
+	// StartWithContext initializes all requested informers. They are handled in goroutines
+	// which run until the context gets canceled.
+	StartWithContext(ctx context.Context)
 
 	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(gvr schema.GroupVersionResource) informers.GenericInformer

--- a/staging/src/k8s.io/client-go/testing/fixture.go
+++ b/staging/src/k8s.io/client-go/testing/fixture.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/watch"
 	restclient "k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 )
 
 // ObjectTracker keeps track of objects. It is intended to be used to
@@ -288,6 +289,7 @@ func (o objectTrackerReact) Patch(action PatchActionImpl) (runtime.Object, error
 type tracker struct {
 	scheme  ObjectScheme
 	decoder runtime.Decoder
+	logger  klog.Logger
 	lock    sync.RWMutex
 	objects map[schema.GroupVersionResource]map[types.NamespacedName]versionedObject
 	// The value type of watchers is a map of which the key is either a namespace or
@@ -335,10 +337,19 @@ var _ ObjectTracker = &tracker{}
 
 // NewObjectTracker returns an ObjectTracker that can be used to keep track
 // of objects for the fake clientset. Mostly useful for unit tests.
+//
+// Contextual logging: NewObjectTrackerWithLogger should be used instead of NewObjectTracker in code which supports contextual logging.
 func NewObjectTracker(scheme ObjectScheme, decoder runtime.Decoder) ObjectTracker {
+	return NewObjectTrackerWithLogger(klog.Background(), scheme, decoder)
+}
+
+// NewObjectTrackerWithLogger is like NewObjectTracker, but supports passing
+// a logger for contextual logging instead of falling back to klog.Background.
+func NewObjectTrackerWithLogger(logger klog.Logger, scheme ObjectScheme, decoder runtime.Decoder) ObjectTracker {
 	return &tracker{
 		scheme:           scheme,
 		decoder:          decoder,
+		logger:           logger,
 		objects:          make(map[schema.GroupVersionResource]map[types.NamespacedName]versionedObject),
 		watchers:         make(map[schema.GroupVersionResource]map[string][]*watch.RaceFreeFakeWatcher),
 		resourceVersions: make(map[schema.GroupVersionResource]int64),
@@ -430,7 +441,7 @@ func (t *tracker) Watch(gvr schema.GroupVersionResource, ns string, opts ...meta
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
-	fakewatcher := watch.NewRaceFreeFake()
+	fakewatcher := watch.NewRaceFreeFakeWithLogger(t.logger)
 
 	if _, exists := t.watchers[gvr]; !exists {
 		t.watchers[gvr] = make(map[string][]*watch.RaceFreeFakeWatcher)
@@ -745,9 +756,17 @@ var _ ObjectTracker = &managedFieldObjectTracker{}
 
 // NewFieldManagedObjectTracker returns an ObjectTracker that can be used to keep track
 // of objects and managed fields for the fake clientset. Mostly useful for unit tests.
+//
+//logcheck:context // NewFieldManagedObjectTrackerWithLogger should be used instead of NewFieldManagedObjectTracker in code which supports contextual logging.
 func NewFieldManagedObjectTracker(scheme *runtime.Scheme, decoder runtime.Decoder, typeConverter managedfields.TypeConverter) ObjectTracker {
+	return NewFieldManagedObjectTrackerWithLogger(klog.Background(), scheme, decoder, typeConverter)
+}
+
+// NewFieldManagedObjectTrackerWithLogger is like NewFieldManagedObjectTracker, but supports passing
+// a logger for contextual logging instead of falling back to klog.Background.
+func NewFieldManagedObjectTrackerWithLogger(logger klog.Logger, scheme *runtime.Scheme, decoder runtime.Decoder, typeConverter managedfields.TypeConverter) ObjectTracker {
 	return &managedFieldObjectTracker{
-		ObjectTracker:   NewObjectTracker(scheme, decoder),
+		ObjectTracker:   NewObjectTrackerWithLogger(logger, scheme, decoder),
 		scheme:          scheme,
 		objectConverter: scheme,
 		mapper: func() meta.RESTMapper {

--- a/staging/src/k8s.io/client-go/testing/fixture_test.go
+++ b/staging/src/k8s.io/client-go/testing/fixture_test.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/util/watchlist"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/ptr"
 )
 
@@ -61,6 +62,7 @@ func getArbitraryResource(s schema.GroupVersionResource, name, namespace string)
 }
 
 func TestWatchCallNonNamespace(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	testResource := schema.GroupVersionResource{Group: "", Version: "test_version", Resource: "test_kind"}
 	testObj := getArbitraryResource(testResource, "test_name", "test_namespace")
 	accessor, err := meta.Accessor(testObj)
@@ -70,7 +72,7 @@ func TestWatchCallNonNamespace(t *testing.T) {
 	ns := accessor.GetNamespace()
 	scheme := runtime.NewScheme()
 	codecs := serializer.NewCodecFactory(scheme)
-	o := NewObjectTracker(scheme, codecs.UniversalDecoder())
+	o := NewObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder())
 	watch, err := o.Watch(testResource, ns)
 	if err != nil {
 		t.Fatalf("test resource watch failed in %s: %v ", ns, err)
@@ -86,6 +88,7 @@ func TestWatchCallNonNamespace(t *testing.T) {
 }
 
 func TestWatchCallAllNamespace(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	testResource := schema.GroupVersionResource{Group: "", Version: "test_version", Resource: "test_kind"}
 	testObj := getArbitraryResource(testResource, "test_name", "test_namespace")
 	accessor, err := meta.Accessor(testObj)
@@ -95,7 +98,7 @@ func TestWatchCallAllNamespace(t *testing.T) {
 	ns := accessor.GetNamespace()
 	scheme := runtime.NewScheme()
 	codecs := serializer.NewCodecFactory(scheme)
-	o := NewObjectTracker(scheme, codecs.UniversalDecoder())
+	o := NewObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder())
 	w, err := o.Watch(testResource, "test_namespace")
 	if err != nil {
 		t.Fatalf("test resource watch failed in test_namespace: %v", err)
@@ -137,6 +140,7 @@ func TestWatchCallAllNamespace(t *testing.T) {
 }
 
 func TestWatchCallMultipleInvocation(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	cases := []struct {
 		name string
 		op   watch.EventType
@@ -188,7 +192,7 @@ func TestWatchCallMultipleInvocation(t *testing.T) {
 	codecs := serializer.NewCodecFactory(scheme)
 	testResource := schema.GroupVersionResource{Group: "", Version: "test_version", Resource: "test_kind"}
 
-	o := NewObjectTracker(scheme, codecs.UniversalDecoder())
+	o := NewObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder())
 	watchNamespaces := []string{
 		"",
 		"",
@@ -239,6 +243,7 @@ func TestWatchCallMultipleInvocation(t *testing.T) {
 }
 
 func TestWatchAddAfterStop(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	testResource := schema.GroupVersionResource{Group: "", Version: "test_version", Resource: "test_kind"}
 	testObj := getArbitraryResource(testResource, "test_name", "test_namespace")
 	accessor, err := meta.Accessor(testObj)
@@ -249,7 +254,7 @@ func TestWatchAddAfterStop(t *testing.T) {
 	ns := accessor.GetNamespace()
 	scheme := runtime.NewScheme()
 	codecs := serializer.NewCodecFactory(scheme)
-	o := NewObjectTracker(scheme, codecs.UniversalDecoder())
+	o := NewObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder())
 	watch, err := o.Watch(testResource, ns)
 	if err != nil {
 		t.Errorf("watch creation failed: %v", err)
@@ -270,11 +275,12 @@ func TestWatchAddAfterStop(t *testing.T) {
 }
 
 func TestPatchWithMissingObject(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	nodesResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "nodes"}
 
 	scheme := runtime.NewScheme()
 	codecs := serializer.NewCodecFactory(scheme)
-	o := NewObjectTracker(scheme, codecs.UniversalDecoder())
+	o := NewObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder())
 	reaction := ObjectReaction(o)
 	action := NewRootPatchSubresourceAction(nodesResource, "node-1", types.StrategicMergePatchType, []byte(`{}`))
 	handled, node, err := reaction(action)
@@ -284,11 +290,12 @@ func TestPatchWithMissingObject(t *testing.T) {
 }
 
 func TestApplyCreate(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	cmResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configMaps"}
 	scheme := runtime.NewScheme()
 	scheme.AddKnownTypes(cmResource.GroupVersion(), &v1.ConfigMap{})
 	codecs := serializer.NewCodecFactory(scheme)
-	o := NewFieldManagedObjectTracker(scheme, codecs.UniversalDecoder(), configMapTypeConverter(scheme))
+	o := NewFieldManagedObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder(), configMapTypeConverter(scheme))
 
 	reaction := ObjectReaction(o)
 	patch := []byte(`{"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "cm-1"}, "data": {"k": "v"}}`)
@@ -304,11 +311,12 @@ func TestApplyCreate(t *testing.T) {
 }
 
 func TestApplyNoMeta(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	cmResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configMaps"}
 	scheme := runtime.NewScheme()
 	scheme.AddKnownTypes(cmResource.GroupVersion(), &v1.ConfigMap{})
 	codecs := serializer.NewCodecFactory(scheme)
-	o := NewFieldManagedObjectTracker(scheme, codecs.UniversalDecoder(), configMapTypeConverter(scheme))
+	o := NewFieldManagedObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder(), configMapTypeConverter(scheme))
 
 	reaction := ObjectReaction(o)
 	patch := []byte(`{"apiVersion": "v1", "kind": "ConfigMap", "data": {"k": "v"}}`)
@@ -325,11 +333,12 @@ func TestApplyNoMeta(t *testing.T) {
 }
 
 func TestApplyUpdateMultipleFieldManagers(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	cmResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configMaps"}
 	scheme := runtime.NewScheme()
 	scheme.AddKnownTypes(cmResource.GroupVersion(), &v1.ConfigMap{})
 	codecs := serializer.NewCodecFactory(scheme)
-	o := NewFieldManagedObjectTracker(scheme, codecs.UniversalDecoder(), configMapTypeConverter(scheme))
+	o := NewFieldManagedObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder(), configMapTypeConverter(scheme))
 
 	reaction := ObjectReaction(o)
 	action := NewCreateAction(cmResource, "default", &v1.ConfigMap{
@@ -436,6 +445,7 @@ func TestApplyUpdateMultipleFieldManagers(t *testing.T) {
 }
 
 func TestGetWithExactMatch(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	scheme := runtime.NewScheme()
 	codecs := serializer.NewCodecFactory(scheme)
 
@@ -449,7 +459,7 @@ func TestGetWithExactMatch(t *testing.T) {
 
 	var err error
 	// Object with empty namespace
-	o := NewObjectTracker(scheme, codecs.UniversalDecoder())
+	o := NewObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder())
 	nodeResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "node"}
 	node, gvr := constructObject(nodeResource, "node", "")
 
@@ -466,7 +476,7 @@ func TestGetWithExactMatch(t *testing.T) {
 	assert.EqualError(t, err, errNotFound.Error())
 
 	// Object with non-empty namespace
-	o = NewObjectTracker(scheme, codecs.UniversalDecoder())
+	o = NewObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder())
 	podResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pod"}
 	pod, gvr := constructObject(podResource, "pod", "default")
 	assert.NoError(t, o.Add(pod))
@@ -666,12 +676,13 @@ var configMapTypedSchema = typed.YAMLObject(`types:
 `)
 
 func TestManagedFieldsObjectTrackerReloadsScheme(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	cmResource := schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}
 	scheme := runtime.NewScheme()
 	codecs := serializer.NewCodecFactory(scheme)
 
 	// Create tracker without registered ConfigMap type
-	tracker := NewFieldManagedObjectTracker(scheme, codecs.UniversalDecoder(), configMapTypeConverter(scheme))
+	tracker := NewFieldManagedObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder(), configMapTypeConverter(scheme))
 
 	cm := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -688,13 +699,14 @@ func TestManagedFieldsObjectTrackerReloadsScheme(t *testing.T) {
 }
 
 func TestManagedFielsdObjectTrackerWithUnstructured(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	cmResource := schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}
 	cmGVK := schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}
 	scheme := runtime.NewScheme()
 	scheme.AddKnownTypeWithName(cmGVK, &unstructured.Unstructured{})
 	codecs := serializer.NewCodecFactory(scheme)
 
-	tracker := NewFieldManagedObjectTracker(scheme, codecs.UniversalDecoder(), managedfields.NewDeducedTypeConverter())
+	tracker := NewFieldManagedObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder(), managedfields.NewDeducedTypeConverter())
 
 	cm := &unstructured.Unstructured{}
 	cm.SetAPIVersion("v1")
@@ -743,10 +755,11 @@ func TestManagedFielsdObjectTrackerWithUnstructured(t *testing.T) {
 }
 
 func TestDoesClientSupportWatchListSemantics(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	scheme := runtime.NewScheme()
 	codecs := serializer.NewCodecFactory(scheme)
 
-	target := NewObjectTracker(scheme, codecs.UniversalDecoder())
+	target := NewObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder())
 
 	if !watchlist.DoesClientNotSupportWatchListSemantics(target) {
 		t.Fatalf("ObjectTracker should NOT support WatchList semantics")

--- a/staging/src/k8s.io/client-go/testing/internal/listandwatch_test.go
+++ b/staging/src/k8s.io/client-go/testing/internal/listandwatch_test.go
@@ -47,6 +47,8 @@ import (
 func TestListAndWatch(t *testing.T) { synctest.Test(t, testListAndWatch) }
 func testListAndWatch(t *testing.T) {
 	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	cm := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cm1",
@@ -54,8 +56,6 @@ func testListAndWatch(t *testing.T) {
 		},
 	}
 	client := fake.NewClientset(cm)
-	stopCh := make(chan struct{})
-	defer close(stopCh)
 	createDone := make(chan struct{})
 
 	f := informers.NewSharedInformerFactory(client, 0)
@@ -85,19 +85,19 @@ func testListAndWatch(t *testing.T) {
 	})
 
 	var adds, updates, deletes int
-	handle, err := configMapInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	handle, err := configMapInformer.AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(_ any) { adds++ },
 		UpdateFunc: func(_, _ any) { updates++ },
 		DeleteFunc: func(_ any) { deletes++ },
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		t.Fatalf("Unexpected error adding event handler: %v", err)
 	}
 	defer configMapInformer.RemoveEventHandler(handle)
 
 	configMapStore := configMapInformer.GetStore()
-	f.Start(stopCh)
-	f.WaitForCacheSync(stopCh)
+	f.StartWithContext(ctx)
+	f.WaitForCacheSyncWithContext(ctx)
 	logger.Info("Caches synced")
 
 	objs := configMapStore.List()

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leasecandidate.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leasecandidate.go
@@ -67,18 +67,57 @@ type LeaseCandidate struct {
 	strategy                        v1.CoordinatedLeaseStrategy
 }
 
+// CandidateConfig specifies optional configuration for NewCandidateWithConfig.
+type CandidateConfig struct {
+	// Logger is used for contextual logging. If unset, klog.Background() is used.
+	Logger *klog.Logger
+}
+
 // NewCandidate creates new LeaseCandidate controller that creates a
 // LeaseCandidate object if it does not exist and watches changes
 // to the corresponding object and renews if PingTime is set.
 // WARNING: This is an ALPHA feature. Ensure that the CoordinatedLeaderElection
 // feature gate is on.
-func NewCandidate(clientset kubernetes.Interface,
+//
+// Contextual logging: NewCandidateWithConfig and logger should be used instead of NewCandidate in code which supports contextual logging.
+func NewCandidate(
+	clientset kubernetes.Interface,
 	candidateNamespace string,
 	candidateName string,
 	targetLease string,
 	binaryVersion, emulationVersion string,
 	strategy v1.CoordinatedLeaseStrategy,
 ) (*LeaseCandidate, CacheSyncWaiter, error) {
+	//nolint:logcheck // Cannot provide Logger here, use NewCandidateWithConfig.
+	return NewCandidateWithConfig(
+		clientset,
+		candidateNamespace,
+		candidateName,
+		targetLease,
+		binaryVersion, emulationVersion,
+		strategy,
+		CandidateConfig{},
+	)
+}
+
+// NewCandidateWithConfig creates new LeaseCandidate controller that creates a
+// LeaseCandidate object if it does not exist and watches changes
+// to the corresponding object and renews if PingTime is set.
+// WARNING: This is an ALPHA feature. Ensure that the CoordinatedLeaderElection
+// feature gate is on.
+func NewCandidateWithConfig(
+	clientset kubernetes.Interface,
+	candidateNamespace string,
+	candidateName string,
+	targetLease string,
+	binaryVersion, emulationVersion string,
+	strategy v1.CoordinatedLeaseStrategy,
+	config CandidateConfig,
+) (*LeaseCandidate, CacheSyncWaiter, error) {
+	logger := klog.Background()
+	if config.Logger != nil {
+		logger = *config.Logger
+	}
 	fieldSelector := fields.OneTermEqualSelector("metadata.name", candidateName).String()
 	// A separate informer factory is required because this must start before informerFactories
 	// are started for leader elected components
@@ -105,9 +144,12 @@ func NewCandidate(clientset kubernetes.Interface,
 		emulationVersion:       emulationVersion,
 		strategy:               strategy,
 	}
-	lc.queue = workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[int](), workqueue.TypedRateLimitingQueueConfig[int]{Name: "leasecandidate"})
+	lc.queue = workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[int](), workqueue.TypedRateLimitingQueueConfig[int]{
+		Logger: &logger,
+		Name:   "leasecandidate",
+	})
 
-	h, err := leaseCandidateInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	h, err := leaseCandidateInformer.AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			if leasecandidate, ok := newObj.(*v1beta1.LeaseCandidate); ok {
 				if leasecandidate.Spec.PingTime != nil && leasecandidate.Spec.PingTime.After(leasecandidate.Spec.RenewTime.Time) {
@@ -115,7 +157,7 @@ func NewCandidate(clientset kubernetes.Interface,
 				}
 			}
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leasecandidate.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leasecandidate.go
@@ -18,6 +18,7 @@ package leaderelection
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"sync"
 	"time"
@@ -67,10 +68,32 @@ type LeaseCandidate struct {
 	strategy                        v1.CoordinatedLeaseStrategy
 }
 
-// CandidateConfig specifies optional configuration for NewCandidateWithConfig.
+// CandidateConfig specifies the configuration for NewCandidateWithConfig.
 type CandidateConfig struct {
 	// Logger is used for contextual logging. If unset, klog.Background() is used.
 	Logger *klog.Logger
+
+	// Clientset is used to interact with the LeaseCandidate API. Required.
+	Clientset kubernetes.Interface
+
+	// CandidateNamespace is the namespace to create the LeaseCandidate object in. Required.
+	CandidateNamespace string
+
+	// CandidateName is the name of the LeaseCandidate object. Required.
+	CandidateName string
+
+	// TargetLease is the name of the lease that this candidate is competing for. Required.
+	TargetLease string
+
+	// BinaryVersion is the binary version of the candidate. Required.
+	BinaryVersion string
+
+	// EmulationVersion is the emulation version of the candidate. Required when
+	// Strategy is v1.OldestEmulationVersion.
+	EmulationVersion string
+
+	// Strategy is the coordinated leader election strategy supported by the candidate. Required.
+	Strategy v1.CoordinatedLeaseStrategy
 }
 
 // NewCandidate creates new LeaseCandidate controller that creates a
@@ -89,15 +112,15 @@ func NewCandidate(
 	strategy v1.CoordinatedLeaseStrategy,
 ) (*LeaseCandidate, CacheSyncWaiter, error) {
 	//nolint:logcheck // Cannot provide Logger here, use NewCandidateWithConfig.
-	return NewCandidateWithConfig(
-		clientset,
-		candidateNamespace,
-		candidateName,
-		targetLease,
-		binaryVersion, emulationVersion,
-		strategy,
-		CandidateConfig{},
-	)
+	return NewCandidateWithConfig(CandidateConfig{
+		Clientset:          clientset,
+		CandidateNamespace: candidateNamespace,
+		CandidateName:      candidateName,
+		TargetLease:        targetLease,
+		BinaryVersion:      binaryVersion,
+		EmulationVersion:   emulationVersion,
+		Strategy:           strategy,
+	})
 }
 
 // NewCandidateWithConfig creates new LeaseCandidate controller that creates a
@@ -105,19 +128,36 @@ func NewCandidate(
 // to the corresponding object and renews if PingTime is set.
 // WARNING: This is an ALPHA feature. Ensure that the CoordinatedLeaderElection
 // feature gate is on.
-func NewCandidateWithConfig(
-	clientset kubernetes.Interface,
-	candidateNamespace string,
-	candidateName string,
-	targetLease string,
-	binaryVersion, emulationVersion string,
-	strategy v1.CoordinatedLeaseStrategy,
-	config CandidateConfig,
-) (*LeaseCandidate, CacheSyncWaiter, error) {
+func NewCandidateWithConfig(config CandidateConfig) (*LeaseCandidate, CacheSyncWaiter, error) {
+	if config.Clientset == nil {
+		return nil, nil, fmt.Errorf("required Clientset config parameter is unset")
+	}
+	if config.CandidateNamespace == "" {
+		return nil, nil, fmt.Errorf("required CandidateNamespace config parameter is unset")
+	}
+	if config.CandidateName == "" {
+		return nil, nil, fmt.Errorf("required CandidateName config parameter is unset")
+	}
+	if config.TargetLease == "" {
+		return nil, nil, fmt.Errorf("required TargetLease config parameter is unset")
+	}
+	if config.BinaryVersion == "" {
+		return nil, nil, fmt.Errorf("required BinaryVersion config parameter is unset")
+	}
+	if config.EmulationVersion == "" && config.Strategy == v1.OldestEmulationVersion {
+		return nil, nil, fmt.Errorf("required EmulationVersion config parameter is unset")
+	}
+	if config.Strategy == "" {
+		return nil, nil, fmt.Errorf("required Strategy config parameter is unset")
+	}
+
 	logger := klog.Background()
 	if config.Logger != nil {
 		logger = *config.Logger
 	}
+	clientset := config.Clientset
+	candidateNamespace := config.CandidateNamespace
+	candidateName := config.CandidateName
 	fieldSelector := fields.OneTermEqualSelector("metadata.name", candidateName).String()
 	// A separate informer factory is required because this must start before informerFactories
 	// are started for leader elected components
@@ -138,11 +178,11 @@ func NewCandidateWithConfig(
 		informerFactory:        informerFactory,
 		name:                   candidateName,
 		namespace:              candidateNamespace,
-		leaseName:              targetLease,
+		leaseName:              config.TargetLease,
 		clock:                  clock.RealClock{},
-		binaryVersion:          binaryVersion,
-		emulationVersion:       emulationVersion,
-		strategy:               strategy,
+		binaryVersion:          config.BinaryVersion,
+		emulationVersion:       config.EmulationVersion,
+		strategy:               config.Strategy,
 	}
 	lc.queue = workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[int](), workqueue.TypedRateLimitingQueueConfig[int]{
 		Logger: &logger,

--- a/staging/src/k8s.io/client-go/util/workqueue/rate_limiting_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/rate_limiting_queue.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package workqueue
 
-import "k8s.io/utils/clock"
+import (
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+)
 
 // RateLimitingInterface is an interface that rate limits items being added to the queue.
 //
@@ -46,6 +49,10 @@ type RateLimitingQueueConfig = TypedRateLimitingQueueConfig[any]
 
 // TypedRateLimitingQueueConfig specifies optional configurations to customize a TypedRateLimitingInterface.
 type TypedRateLimitingQueueConfig[T comparable] struct {
+	// An optional logger. The name of the queue does *not* get added to it, this should
+	// be done by the caller if desired.
+	Logger *klog.Logger
+
 	// Name for the queue. If unnamed, the metrics will not be registered.
 	Name string
 
@@ -97,6 +104,7 @@ func NewTypedRateLimitingQueueWithConfig[T comparable](rateLimiter TypedRateLimi
 
 	if config.DelayingQueue == nil {
 		config.DelayingQueue = NewTypedDelayingQueueWithConfig(TypedDelayingQueueConfig[T]{
+			Logger:          config.Logger,
 			Name:            config.Name,
 			MetricsProvider: config.MetricsProvider,
 			Clock:           config.Clock,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Enforcing the usage of all context-aware APIs revealed some more places in client-go itself which weren't context-aware. New variants are needed to let the caller supply a logger.

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/pull/141647.

#### Special notes for your reviewer:

Other PRs depend on this one because they need the new APIs.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
