### PR TITLE
kubelet: sort containers by RestartCount

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -810,12 +810,17 @@ func ParsePodFullName(podFullName string) (string, string, error) {
 // completely optional settings.
 type Option func(Runtime)
 
-// SortContainerStatusesByCreationTime sorts the container statuses by creation time.
+// SortContainerStatusesByCreationTime sorts container statuses
+// by RestartCount first, then CreatedAt. This prevents clock-skew from causing
+// a container with a future CreatedAt to sort above the actually-newest one.
 type SortContainerStatusesByCreationTime []*Status
 
 func (s SortContainerStatusesByCreationTime) Len() int      { return len(s) }
 func (s SortContainerStatusesByCreationTime) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s SortContainerStatusesByCreationTime) Less(i, j int) bool {
+	if s[i].RestartCount != s[j].RestartCount {
+		return s[i].RestartCount < s[j].RestartCount
+	}
 	return s[i].CreatedAt.Before(s[j].CreatedAt)
 }
 

--- a/pkg/kubelet/container/runtime_test.go
+++ b/pkg/kubelet/container/runtime_test.go
@@ -768,9 +768,9 @@ func TestRuntimeFeaturesString(t *testing.T) {
 func TestSortContainerStatusesByCreationTime(t *testing.T) {
 	now := time.Now()
 	statuses := SortContainerStatusesByCreationTime{
-		{CreatedAt: now.Add(2 * time.Hour)},
-		{CreatedAt: now},
-		{CreatedAt: now.Add(1 * time.Hour)},
+		{RestartCount: 1, CreatedAt: now.Add(2 * time.Hour)},
+		{RestartCount: 1, CreatedAt: now},
+		{RestartCount: 1, CreatedAt: now.Add(1 * time.Hour)},
 	}
 
 	// Test Len
@@ -783,9 +783,17 @@ func TestSortContainerStatusesByCreationTime(t *testing.T) {
 	assert.Equal(t, original1, statuses[2], "Swap(0, 1) did not work correctly (0)")
 	assert.Equal(t, original2, statuses[1], "Swap(0, 1) did not work correctly (1)")
 
-	// Test Less
+	// Test Less: same RestartCount falls back to CreatedAt
 	assert.True(t, statuses.Less(1, 0), "Less(1, 0) should be true")
 	assert.False(t, statuses.Less(0, 1), "Less(0, 1) should be false")
+
+	// Test Less: higher RestartCount wins regardless of CreatedAt
+	skewed := SortContainerStatusesByCreationTime{
+		{RestartCount: 9, CreatedAt: now.Add(2 * time.Minute)},
+		{RestartCount: 10, CreatedAt: now},
+	}
+	assert.False(t, skewed.Less(1, 0), "higher RestartCount should not be Less")
+	assert.True(t, skewed.Less(0, 1), "lower RestartCount should be Less")
 }
 
 func TestNewCommandRunner(t *testing.T) {

--- a/pkg/kubelet/kuberuntime/helpers.go
+++ b/pkg/kubelet/kuberuntime/helpers.go
@@ -41,6 +41,9 @@ type containerByCreatedThenID []*runtimeapi.Container
 func (b containerByCreatedThenID) Len() int      { return len(b) }
 func (b containerByCreatedThenID) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
 func (b containerByCreatedThenID) Less(i, j int) bool {
+	if b[i].Metadata != nil && b[j].Metadata != nil && b[i].Metadata.Attempt != b[j].Metadata.Attempt {
+		return b[i].Metadata.Attempt > b[j].Metadata.Attempt
+	}
 	if b[i].CreatedAt != b[j].CreatedAt {
 		return b[i].CreatedAt > (b[j].CreatedAt)
 	}
@@ -62,11 +65,19 @@ func (p podSandboxByCreatedThenID) Less(i, j int) bool {
 	return p[i].Metadata.Attempt > p[j].Metadata.Attempt
 }
 
+// Sorts container statuses newest-first. RestartCount (attempt number) is the
+// primary key so that a clock-skew scenario cannot cause a terminated container
+// with a future CreatedAt to sort above the actually-newest running container.
 type containerStatusByCreated []*kubecontainer.Status
 
-func (c containerStatusByCreated) Len() int           { return len(c) }
-func (c containerStatusByCreated) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
-func (c containerStatusByCreated) Less(i, j int) bool { return c[i].CreatedAt.After(c[j].CreatedAt) }
+func (c containerStatusByCreated) Len() int      { return len(c) }
+func (c containerStatusByCreated) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c containerStatusByCreated) Less(i, j int) bool {
+	if c[i].RestartCount != c[j].RestartCount {
+		return c[i].RestartCount > c[j].RestartCount
+	}
+	return c[i].CreatedAt.After(c[j].CreatedAt)
+}
 
 // toKubeContainerState converts runtimeapi.ContainerState to kubecontainer.State.
 func toKubeContainerState(state runtimeapi.ContainerState) kubecontainer.State {

--- a/pkg/kubelet/kuberuntime/helpers_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_test.go
@@ -817,3 +817,66 @@ func TestPodSandboxByCreatedThenID(t *testing.T) {
 		})
 	}
 }
+
+func TestContainerStatusByCreated(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		input    []*kubecontainer.Status
+		expected []string
+	}{
+		{
+			name: "sort by CreatedAt when RestartCount is equal",
+			input: []*kubecontainer.Status{
+				{ID: kubecontainer.ContainerID{ID: "old"}, RestartCount: 3, CreatedAt: now.Add(-5 * time.Minute)},
+				{ID: kubecontainer.ContainerID{ID: "new"}, RestartCount: 3, CreatedAt: now},
+			},
+			expected: []string{"new", "old"},
+		},
+		{
+			name: "higher RestartCount wins even with older CreatedAt",
+			input: []*kubecontainer.Status{
+				{ID: kubecontainer.ContainerID{ID: "future-timestamp"}, RestartCount: 9, CreatedAt: now.Add(2 * time.Minute)},
+				{ID: kubecontainer.ContainerID{ID: "correct-timestamp"}, RestartCount: 10, CreatedAt: now},
+			},
+			expected: []string{"correct-timestamp", "future-timestamp"},
+		},
+		{
+			name: "clock skew: terminated container with future CreatedAt does not hide running one",
+			input: []*kubecontainer.Status{
+				{ID: kubecontainer.ContainerID{ID: "skewed-exited"}, RestartCount: 9, CreatedAt: now.Add(98 * time.Second)},
+				{ID: kubecontainer.ContainerID{ID: "actual-newest"}, RestartCount: 10, CreatedAt: now},
+			},
+			expected: []string{"actual-newest", "skewed-exited"},
+		},
+		{
+			name:     "empty slice",
+			input:    []*kubecontainer.Status{},
+			expected: []string{},
+		},
+		{
+			name: "single container",
+			input: []*kubecontainer.Status{
+				{ID: kubecontainer.ContainerID{ID: "only"}, RestartCount: 0, CreatedAt: now},
+			},
+			expected: []string{"only"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			statuses := make([]*kubecontainer.Status, len(tt.input))
+			copy(statuses, tt.input)
+
+			sort.Sort(containerStatusByCreated(statuses))
+
+			actualIDs := make([]string, len(statuses))
+			for i, s := range statuses {
+				actualIDs[i] = s.ID.ID
+			}
+
+			assert.Equal(t, tt.expected, actualIDs, "sorting order mismatch")
+		})
+	}
+}

--- a/pkg/kubelet/pod_container_deletor.go
+++ b/pkg/kubelet/pod_container_deletor.go
@@ -41,6 +41,9 @@ type podContainerDeletor struct {
 func (a containerStatusbyCreatedList) Len() int      { return len(a) }
 func (a containerStatusbyCreatedList) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a containerStatusbyCreatedList) Less(i, j int) bool {
+	if a[i].RestartCount != a[j].RestartCount {
+		return a[i].RestartCount > a[j].RestartCount
+	}
 	return a[i].CreatedAt.After(a[j].CreatedAt)
 }
 

--- a/pkg/kubelet/pod_container_deletor_test.go
+++ b/pkg/kubelet/pod_container_deletor_test.go
@@ -151,6 +151,37 @@ func TestGetContainersToDeleteInPod(t *testing.T) {
 	}
 }
 
+func TestGetContainersToDeleteInPodWithClockSkew(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	now := time.Now()
+	pod := kubecontainer.PodStatus{
+		ContainerStatuses: []*kubecontainer.Status{
+			{
+				ID:           kubecontainer.ContainerID{Type: "test", ID: "1"},
+				Name:         "bar",
+				CreatedAt:    now.Add(time.Hour),
+				RestartCount: 0,
+				State:        kubecontainer.ContainerStateExited,
+			},
+			{
+				ID:           kubecontainer.ContainerID{Type: "test", ID: "2"},
+				Name:         "bar",
+				CreatedAt:    now,
+				RestartCount: 1,
+				State:        kubecontainer.ContainerStateExited,
+			},
+		},
+	}
+
+	candidates := getContainersToDeleteInPod(logger, "", &pod, 1)
+	if len(candidates) != 1 {
+		t.Fatalf("expected 1 candidate, got %d", len(candidates))
+	}
+	if candidates[0].ID.ID != "1" {
+		t.Errorf("expected container 1 (lower RestartCount) to be deleted, got %s", candidates[0].ID.ID)
+	}
+}
+
 func TestGetContainersToDeleteInPodWithNoMatch(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	pod := kubecontainer.PodStatus{


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Currently containers in a pod sorted only by CreatedAt. When the system clock jumps backward, a terminated container with a future timestamp sorts above the running one, causing FindContainerStatusByName to return the wrong container and the kubelet to loop in RunContainerError.

Sort by RestartCount first, matching the existing podSandboxByCreatedThenID fix from #130551. 
This fixes the situation where a container with newer creationTime is picked up first even though there's another container with more RestartCount.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#83050

#### Special notes for your reviewer:

Reproducer: https://gist.github.com/bitoku/f0837677d37e8cdc93015128589469c6

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed kubelet container status misidentification after backward clock jumps.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:
YES for code generation
<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
