### PR TITLE
node: fg: remove DisableCPUQuotaWithExclusiveCPUs

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -364,22 +364,6 @@ const (
 	// both allocators. This feature gate disables the dual write on the new Cluster IP allocators.
 	DisableAllocatorDualWrite featuregate.Feature = "DisableAllocatorDualWrite"
 
-	// owner: @ffromani
-	// beta: v1.33
-	//
-	// Disables CPU Quota for containers which have exclusive CPUs allocated.
-	// Disables pod-Level CPU Quota for pods containing at least one container with exclusive CPUs allocated
-	// Exclusive CPUs for a container (init, application, sidecar) are allocated when:
-	// (1) cpumanager policy is static,
-	// (2) the pod has QoS Guaranteed,
-	// (3) the container has integer cpu request.
-	// The expected behavior is that CPU Quota for containers having exclusive CPUs allocated is disabled.
-	// Because this fix changes a long-established (but incorrect) behavior, users observing
-	// any regressions can use the DisableCPUQuotaWithExclusiveCPUs feature gate (default on) to
-	// restore the old behavior. Please file issues if you hit issues and have to use this Feature Gate.
-	// The Feature Gate will be locked to true and then removed in +2 releases (1.35) if there are no bug reported
-	DisableCPUQuotaWithExclusiveCPUs featuregate.Feature = "DisableCPUQuotaWithExclusiveCPUs"
-
 	// owner: @HirazawaUi
 	// kep: http://kep.k8s.io/4004
 	//
@@ -1550,12 +1534,6 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.35"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove after MultiCIDRServiceAllocator is GA
 	},
 
-	DisableCPUQuotaWithExclusiveCPUs: {
-		{Version: version.MustParse("1.33"), Default: true, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("1.36"), Default: true, PreRelease: featuregate.Deprecated},
-		{Version: version.MustParse("1.37"), Default: true, PreRelease: featuregate.Deprecated, LockToDefault: true}, // remove in 1.38
-	},
-
 	DisableNodeKubeProxyVersion: {
 		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Deprecated},
@@ -2601,8 +2579,6 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 	DeploymentReplicaSetTerminatingReplicas: {},
 
 	DisableAllocatorDualWrite: {MultiCIDRServiceAllocator},
-
-	DisableCPUQuotaWithExclusiveCPUs: {},
 
 	DisableNodeKubeProxyVersion: {},
 

--- a/pkg/kubelet/cm/pod_container_manager_linux.go
+++ b/pkg/kubelet/cm/pod_container_manager_linux.go
@@ -81,7 +81,7 @@ func (m *podContainerManagerImpl) EnsureExists(logger klog.Logger, pod *v1.Pod) 
 	alreadyExists := m.Exists(pod)
 	if !alreadyExists {
 		enforceCPULimits := m.enforceCPULimits
-		if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.DisableCPUQuotaWithExclusiveCPUs) && m.podContainerManager.PodHasExclusiveCPUs(logger, pod) {
+		if m.podContainerManager.PodHasExclusiveCPUs(logger, pod) {
 			logger.V(2).Info("Disabled CFS quota", "pod", klog.KObj(pod))
 			enforceCPULimits = false
 		}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -187,7 +187,7 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerResources(ctx context.
 
 	// If pod has exclusive cpu and the container in question has integer cpu requests
 	// the cfs quota will not be enforced
-	disableCPUQuota := utilfeature.DefaultFeatureGate.Enabled(kubefeatures.DisableCPUQuotaWithExclusiveCPUs) && m.containerManager.ContainerHasExclusiveCPUs(logger, pod, container)
+	disableCPUQuota := m.containerManager.ContainerHasExclusiveCPUs(logger, pod, container)
 	logger.V(5).Info("Enforcing CFS quota", "pod", klog.KObj(pod), "unlimited", disableCPUQuota)
 	lcr := m.calculateLinuxResources(cpuRequest, cpuLimit, memoryLimit, disableCPUQuota)
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -887,7 +887,7 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 	resizeResult := kubecontainer.NewSyncResult(kubecontainer.ResizePodInPlace, format.Pod(pod))
 	pcm := m.containerManager.NewPodContainerManager()
 	enforceCPULimits := m.cpuCFSQuota
-	if utilfeature.DefaultFeatureGate.Enabled(features.DisableCPUQuotaWithExclusiveCPUs) && m.containerManager.PodHasExclusiveCPUs(logger, pod) {
+	if m.containerManager.PodHasExclusiveCPUs(logger, pod) {
 		enforceCPULimits = false
 		logger.V(2).Info("Disabled CFS quota", "pod", klog.KObj(pod))
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux.go
@@ -60,7 +60,7 @@ func (m *kubeGenericRuntimeManager) calculateSandboxResources(ctx context.Contex
 	}
 
 	// If pod has exclusive cpu the sandbox will not have cfs quote enforced
-	disableCPUQuota := utilfeature.DefaultFeatureGate.Enabled(features.DisableCPUQuotaWithExclusiveCPUs) && m.containerManager.PodHasExclusiveCPUs(logger, pod)
+	disableCPUQuota := m.containerManager.PodHasExclusiveCPUs(logger, pod)
 
 	logger.V(5).Info("Enforcing CFS quota", "pod", klog.KObj(pod), "unlimited", disableCPUQuota)
 	return m.calculateLinuxResources(cpuRequest, lim.Cpu(), lim.Memory(), disableCPUQuota)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
The FG removal was planned for 1.38, so delete it

#### Which issue(s) this PR is related to:
Related to https://github.com/kubernetes/kubernetes/pull/127525

#### Special notes for your reviewer:
Do we need to obey to emulation support for kubelet-only FGs? see https://github.com/kubernetes/kubernetes/pull/141758#discussion_r3906685120

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A