### PR TITLE
node: fg: remove KubeletPodResources{DynamicResources,Get}

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -641,11 +641,6 @@ const (
 
 	// owner: @moshe010
 	//
-	// Enable POD resources API to return resources allocated by Dynamic Resource Allocation
-	KubeletPodResourcesDynamicResources featuregate.Feature = "KubeletPodResourcesDynamicResources"
-
-	// owner: @moshe010
-	//
 	// Enable POD resources API with Get method
 	KubeletPodResourcesGet featuregate.Feature = "KubeletPodResourcesGet"
 
@@ -1760,12 +1755,6 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.36"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	},
 
-	KubeletPodResourcesDynamicResources: {
-		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("1.36"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.37
-	},
-
 	KubeletPodResourcesGet: {
 		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
@@ -2685,8 +2674,6 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 	KubeletInUserNamespace: {},
 
 	KubeletPSI: {},
-
-	KubeletPodResourcesDynamicResources: {},
 
 	KubeletPodResourcesGet: {},
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -639,11 +639,6 @@ const (
 	// kep: https://kep.k8s.io/4205
 	KubeletPSI featuregate.Feature = "KubeletPSI"
 
-	// owner: @moshe010
-	//
-	// Enable POD resources API with Get method
-	KubeletPodResourcesGet featuregate.Feature = "KubeletPodResourcesGet"
-
 	// owner: @ffromani
 	// Deprecated: v1.34
 	//
@@ -1755,12 +1750,6 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.36"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	},
 
-	KubeletPodResourcesGet: {
-		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("1.36"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.37
-	},
-
 	KubeletPodResourcesListUseActivePods: {
 		{Version: version.MustParse("1.0"), Default: false, PreRelease: featuregate.GA},
 		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Deprecated}, // lock to default in 1.38, remove in 1.39
@@ -2674,8 +2663,6 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 	KubeletInUserNamespace: {},
 
 	KubeletPSI: {},
-
-	KubeletPodResourcesGet: {},
 
 	KubeletPodResourcesListUseActivePods: {},
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -3415,23 +3415,21 @@ func (pp *kubeletPodsProvider) GetPodByName(namespace, name string) (*v1.Pod, bo
 
 // ListenAndServePodResources runs the kubelet podresources grpc service.
 func (kl *Kubelet) ListenAndServePodResources(ctx context.Context) {
-	if utilfeature.DefaultFeatureGate.Enabled(features.KubeletPodResourcesGet) {
-		endpoint, err := util.LocalEndpoint(kl.getPodResourcesDir(), podresources.Socket)
-		if err != nil {
-			klog.FromContext(ctx).V(2).Info("Failed to get local endpoint for PodResources endpoint", "err", err)
-			return
-		}
-
-		providers := podresources.PodResourcesProviders{
-			Pods:             &kubeletPodsProvider{kl: kl},
-			Devices:          kl.containerManager,
-			Cpus:             kl.containerManager,
-			Memory:           kl.containerManager,
-			DynamicResources: kl.containerManager,
-		}
-
-		server.ListenAndServePodResources(ctx, endpoint, providers)
+	endpoint, err := util.LocalEndpoint(kl.getPodResourcesDir(), podresources.Socket)
+	if err != nil {
+		klog.FromContext(ctx).V(2).Info("Failed to get local endpoint for PodResources endpoint", "err", err)
+		return
 	}
+
+	providers := podresources.PodResourcesProviders{
+		Pods:             &kubeletPodsProvider{kl: kl},
+		Devices:          kl.containerManager,
+		Cpus:             kl.containerManager,
+		Memory:           kl.containerManager,
+		DynamicResources: kl.containerManager,
+	}
+
+	server.ListenAndServePodResources(ctx, endpoint, providers)
 }
 
 // ListenAndServePod initializes an HTTP server to serve the Pod API.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Remove podresources-API related FGs which were slated for removal in 1.38

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
Do we need to obey to emulation support for kubelet-only FGs? see https://github.com/kubernetes/kubernetes/pull/141758#discussion_r3906685120

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A