### PR TITLE
validation-gen: fix nil member deref in the requiredness lint rule

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/generators/lint_rules.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/generators/lint_rules.go
@@ -277,8 +277,13 @@ func requiredAndOptional(extractor validators.ValidationExtractor, tagPrefix str
 		case types.Pointer:
 			hasVal, cycleBroken, err = hasTransitiveValidation(t.Elem, op)
 		case types.Struct:
-			for _, m := range t.Members {
-				mTags, err := extractor.ExtractTags(validators.Context{Scope: validators.ScopeField, Type: m.Type}, m.CommentLines)
+			for i := range t.Members {
+				m := &t.Members[i]
+				// A ScopeField context carries the struct member it describes.
+				// Validators such as requiredness read it to find the field's
+				// +default tag.
+				mCtx := validators.Context{Scope: validators.ScopeField, Type: m.Type, Member: m}
+				mTags, err := extractor.ExtractTags(mCtx, m.CommentLines)
 				if err != nil {
 					return false, false, err
 				}
@@ -286,10 +291,7 @@ func requiredAndOptional(extractor validators.ValidationExtractor, tagPrefix str
 					hasVal = true
 					break
 				}
-				fieldVals, err := extractor.ExtractValidations(
-					validators.Context{Scope: validators.ScopeField, Type: m.Type},
-					filterTags(mTags)...,
-				)
+				fieldVals, err := extractor.ExtractValidations(mCtx, filterTags(mTags)...)
 				if err != nil {
 					return false, false, err
 				}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/generators/lint_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/generators/lint_test.go
@@ -930,6 +930,29 @@ func TestLintRequiredness(t *testing.T) {
 			}),
 			wantError: "field Bar: field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden",
 		},
+		{
+			name: "transitive struct member with only +k8s:optional - no error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testPtr(
+					testStruct("Inner", []types.Member{
+						testField("Bar", testType("int"), "+k8s:optional"),
+					}),
+				)),
+			}),
+			wantError: "",
+		},
+		{
+			name: "transitive struct member with a validated sibling - error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testPtr(
+					testStruct("Inner", []types.Member{
+						testField("Bar", testType("int"), "+k8s:optional", "+default=1"),
+						testField("Baz", testType("int"), "+k8s:minimum=0"),
+					}),
+				)),
+			}),
+			wantError: "field Foo: field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden",
+		},
 	}
 
 	for _, tt := range tests {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
@@ -198,7 +198,13 @@ func (rtv *requirednessTagValidator) doOptional(context Context) (Validations, e
 // hasZeroDefault returns whether the field has a default value and whether
 // that default value is the zero value for the field's type.
 func (rtv *requirednessTagValidator) hasZeroDefault(context Context) (bool, bool, error) {
-	// This validator only applies to fields, so Member must be valid.
+	// This validator only applies to fields, and a field context carries the
+	// struct member it describes. Report a caller which does not honor that
+	// instead of dereferencing a nil member.
+	if context.Member == nil {
+		return false, false, fmt.Errorf("internal error: %s used on a field context with no member", rtv.mode)
+	}
+
 	tagsByName, err := gengo.ExtractFunctionStyleCommentTags("+", []string{defaultTagName}, context.Member.CommentLines)
 	if err != nil {
 		return false, false, fmt.Errorf("failed to read tags: %w", err)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validators
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/gengo/v2/codetags"
+	"k8s.io/gengo/v2/types"
+)
+
+// A field context is documented to carry the struct member it describes.
+// A caller which omits it must get an error, not a nil dereference.
+func TestRequirednessWithoutMember(t *testing.T) {
+	fieldType := &types.Type{Name: types.Name{Name: "int"}, Kind: types.Builtin}
+	tv := requirednessTagValidator{mode: requirednessOptional}
+	context := Context{Scope: ScopeField, Type: fieldType}
+
+	_, err := tv.GetValidations(context, codetags.Tag{Name: string(requirednessOptional)})
+	if err == nil {
+		t.Fatal("GetValidations() succeeded, want an error")
+	}
+	if !strings.Contains(err.Error(), "no member") {
+		t.Errorf("GetValidations() error = %v, want it to mention a missing member", err)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

`validation-gen` panics with a nil pointer dereference instead of producing a lint diagnostic, whenever the linter walks a struct member whose only known validation tag is `+k8s:optional`:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x103334f04]

goroutine 1 [running]:
k8s.io/code-generator/cmd/validation-gen/validators.requirednessTagValidator.hasZeroDefault(...)
	.../cmd/validation-gen/validators/required.go:190
k8s.io/code-generator/cmd/validation-gen/validators.requirednessTagValidator.doOptional(...)
	.../cmd/validation-gen/validators/required.go:148
k8s.io/code-generator/cmd/validation-gen/validators.requirednessTagValidator.GetValidations(...)
	.../cmd/validation-gen/validators/required.go:75
k8s.io/code-generator/cmd/validation-gen/validators.(*registry).ExtractTagValidations(...)
	.../cmd/validation-gen/validators/registry.go:143
k8s.io/code-generator/cmd/validation-gen/validators.(*registry).ExtractValidations(...)
	.../cmd/validation-gen/validators/registry.go:120
main.requiredAndOptional.func2(...)
	.../cmd/validation-gen/lint_rules.go:285
main.requiredAndOptional.func2(...)
	.../cmd/validation-gen/lint_rules.go:274
main.requiredAndOptional.func3(...)
	.../cmd/validation-gen/lint_rules.go:360
main.(*linter).lintComments(...)
	.../cmd/validation-gen/lint.go:149
main.(*linter).lintType(...)
	.../cmd/validation-gen/lint.go:98
main.GetTargets(...)
```

`validators.Context` documents the invariant:

https://github.com/kubernetes/kubernetes/blob/7ad706104313c1f57f52a151261d7e6bf8f99841/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go#L142-L144

The `requiredAndOptional` lint rule violates it. While deciding whether a field has transitive validation, it recurses into struct members and builds `ScopeField` contexts with `Member` unset:

https://github.com/kubernetes/kubernetes/blob/7ad706104313c1f57f52a151261d7e6bf8f99841/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_rules.go#L275-L288

The registry admits that context, because `ScopeField` is a valid scope for the requiredness validators

https://github.com/kubernetes/kubernetes/blob/7ad706104313c1f57f52a151261d7e6bf8f99841/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go#L64-L68

https://github.com/kubernetes/kubernetes/blob/7ad706104313c1f57f52a151261d7e6bf8f99841/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry.go#L137

and dispatches `requirednessTagValidator.GetValidations`

https://github.com/kubernetes/kubernetes/blob/7ad706104313c1f57f52a151261d7e6bf8f99841/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry.go#L143

For `+k8s:optional` that reaches `doOptional`, which calls `hasZeroDefault` unconditionally:

https://github.com/kubernetes/kubernetes/blob/7ad706104313c1f57f52a151261d7e6bf8f99841/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go#L148

which dereferences the missing member:

https://github.com/kubernetes/kubernetes/blob/7ad706104313c1f57f52a151261d7e6bf8f99841/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go#L186-L190

The trigger is narrow but very common in real API types: a field with no requiredness tag of its own, whose transitive closure contains a struct member whose only known validation tag is `+k8s:optional`. `+k8s:required` and `+k8s:forbidden` do not reach the dereference, because `hasNonOpaqueValidationTag` returns early for them, and `+k8s:optional` alone is the one case it deliberately skips:

https://github.com/kubernetes/kubernetes/blob/7ad706104313c1f57f52a151261d7e6bf8f99841/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_rules.go#L161-L178

It reproduces in a unit test too, without running the generator. Add to `TestLintRequiredness` in
`staging/src/k8s.io/code-generator/cmd/validation-gen/lint_test.go` (at `v1.37.0` tag):

```go
{
	name: "transitive struct member with only +k8s:optional - no error",
	typeToLint: testStruct("T", []types.Member{
		testField("Foo", testPtr(
			testStruct("Inner", []types.Member{
				testField("Bar", testType("int"), "+k8s:optional"),
			}),
		)),
	}),
	wantError: "",
},
```

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->

YES, Claude was used to help debugging and fixing. Test material was fully generated by it.
