### PR TITLE
e2e/network: add WithFeatureGate to LocalhostNodePorts tests

### DIFF
--- a/test/e2e/network/localhost_nodeports.go
+++ b/test/e2e/network/localhost_nodeports.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eendpointslice "k8s.io/kubernetes/test/e2e/framework/endpointslice"
@@ -41,7 +42,7 @@ var _ = common.SIGDescribe("LocalhostNodePorts", func() {
 	fr := framework.NewDefaultFramework("localhost-nodeports")
 	fr.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
-	framework.It("should proxy localhost NodePort traffic to backends across nodes", feature.LocalhostNodePorts, func(ctx context.Context) {
+	framework.It("should proxy localhost NodePort traffic to backends across nodes", feature.LocalhostNodePorts, framework.WithFeatureGate(features.KubeProxyNFTablesLocalhostNodePorts), func(ctx context.Context) {
 		cs := fr.ClientSet
 		ns := fr.Namespace.Name
 
@@ -104,7 +105,7 @@ var _ = common.SIGDescribe("LocalhostNodePorts", func() {
 		}
 	})
 
-	framework.It("should honor sessionAffinity=ClientIP for localhost NodePort", feature.LocalhostNodePorts, func(ctx context.Context) {
+	framework.It("should honor sessionAffinity=ClientIP for localhost NodePort", feature.LocalhostNodePorts, framework.WithFeatureGate(features.KubeProxyNFTablesLocalhostNodePorts), func(ctx context.Context) {
 		cs := fr.ClientSet
 		ns := fr.Namespace.Name
 
@@ -166,7 +167,7 @@ var _ = common.SIGDescribe("LocalhostNodePorts", func() {
 		}
 	})
 
-	framework.It("should let a node pull an image from a registry exposed via localhost NodePort", feature.LocalhostNodePorts, func(ctx context.Context) {
+	framework.It("should let a node pull an image from a registry exposed via localhost NodePort", feature.LocalhostNodePorts, framework.WithFeatureGate(features.KubeProxyNFTablesLocalhostNodePorts), func(ctx context.Context) {
 		cs := fr.ClientSet
 		ns := fr.Namespace.Name
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The LocalhostNodePorts e2e tests use `WithFeature("LocalhostNodePorts")` but do not reference the corresponding feature gate `KubeProxyNFTablesLocalhostNodePorts` via `WithFeatureGate`. This means the tests lack the `[Feature:OffByDefault]` and `[Alpha]` labels, causing them to run on clusters that do not enable the gate or use kube-proxy nftables.

This adds `framework.WithFeatureGate(features.KubeProxyNFTablesLocalhostNodePorts)` to all three test cases so the framework automatically applies the correct labels for CI filtering.

This is the same class of issue addressed by the carlory series of PRs (#129132, #129105, #129068, #129118) which systematically added missing `WithFeatureGate` annotations across e2e tests.

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/6032
Related: https://github.com/kubernetes/test-infra/issues/31666
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

The upstream convention (from `test/e2e/feature/feature.go`) states that "tests must be labeled with `framework.WithFeatureGate` to document their dependency on specific feature gates." Without `WithFeatureGate`, these tests run and fail on any cluster that doesn't run kube-proxy in nftables mode with the Alpha gate enabled (e.g. OVN-Kubernetes, Cilium, IPVS, iptables mode).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:
YES. Used Claude Code to research the labeling gap between WithFeature and WithFeatureGate, identify upstream precedents, and draft the PR description. All changes were reviewed and validated manually.

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
