### PR TITLE
validation-gen: honor +k8s:validation-gen-input on --readonly-pkg

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/generators/targets.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/generators/targets.go
@@ -291,6 +291,32 @@ func DefaultNameSystem() string {
 	return "public"
 }
 
+// mapReadOnlyPkgs points each read-only types package at the package which
+// holds its validations. A read-only package never overrides a mapping made
+// for a package this run generates for. Among read-only packages, one which
+// names its input package is preferred over a types package standing for
+// itself, so that passing both a types package and the package holding its
+// validations works whichever order they are passed in.
+func mapReadOnlyPkgs(readOnlyPkgs []string, readOnlyInput map[string]string, inputToCanonicalPkg map[string]string) {
+	for _, extra := range readOnlyPkgs {
+		inputPath := readOnlyInput[extra]
+		if inputPath == extra {
+			continue
+		}
+		if _, ok := inputToCanonicalPkg[inputPath]; !ok {
+			inputToCanonicalPkg[inputPath] = extra
+		}
+	}
+	for _, extra := range readOnlyPkgs {
+		if readOnlyInput[extra] != extra {
+			continue
+		}
+		if _, ok := inputToCanonicalPkg[extra]; !ok {
+			inputToCanonicalPkg[extra] = extra
+		}
+	}
+}
+
 func GetTargets(context *generator.Context, args *args.Args) []generator.Target {
 	boilerplate, err := gengo.GoBoilerplate(args.GoHeaderFile, gengo.StdBuildTag, gengo.StdGeneratedBy)
 	if err != nil {
@@ -361,14 +387,37 @@ func GetTargets(context *generator.Context, args *args.Args) []generator.Target 
 	} else {
 		readOnlyPkgs = expanded // now in fully canonical form
 	}
-	for _, extra := range readOnlyPkgs {
-		inputPkgs = append(inputPkgs, extra)
-		pkgToInput[extra] = extra
-		// Don't let a read-only package override a generation mapping.
-		if _, ok := inputToCanonicalPkg[extra]; !ok {
-			inputToCanonicalPkg[extra] = extra
+	// FindPackages only canonicalizes paths, so the read-only packages must be
+	// loaded before their doc.go comments can be read below.
+	if len(readOnlyPkgs) > 0 {
+		if _, err := context.LoadPackages(readOnlyPkgs...); err != nil {
+			klog.Fatalf("cannot load read-only packages: %v", err)
 		}
 	}
+	// A read-only package may itself carry +<prefix>validation-gen-input, naming
+	// the types package whose validators it holds. Honor that, as for
+	// generated inputs, so cross-package references to those types resolve to
+	// the package which actually holds the functions. Lint rules are not
+	// applied here: they govern the packages this run generates for.
+	readOnlyInput := make(map[string]string, len(readOnlyPkgs))
+	for _, extra := range readOnlyPkgs {
+		inputPath := extra
+		if pkg := context.Universe[extra]; pkg != nil {
+			info, err := apidefinitions.Identify(pkg, spec)
+			if err != nil {
+				klog.Fatal(err)
+			}
+			inputPath = info.ExternalTypes()
+		}
+		readOnlyInput[extra] = inputPath
+		inputPkgs = append(inputPkgs, extra)
+		pkgToInput[extra] = inputPath
+		if inputPath != extra {
+			klog.V(4).Infof("  read-only input pkg %v", inputPath)
+			inputPkgs = append(inputPkgs, inputPath)
+		}
+	}
+	mapReadOnlyPkgs(readOnlyPkgs, readOnlyInput, inputToCanonicalPkg)
 
 	if len(inputPkgs) > 0 {
 		if _, err := context.LoadPackages(inputPkgs...); err != nil {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/generators/targets_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/generators/targets_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generators
+
+import (
+	"maps"
+	"testing"
+)
+
+func TestMapReadOnlyPkgs(t *testing.T) {
+	const (
+		metav1     = "k8s.io/apimachinery/pkg/apis/meta/v1"
+		metav1val  = "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
+		quantity   = "k8s.io/apimachinery/pkg/api/resource"
+		generated  = "example.com/api/v1"
+		generating = "example.com/apis/v1"
+	)
+
+	tests := []struct {
+		name          string
+		readOnlyPkgs  []string
+		readOnlyInput map[string]string
+		existing      map[string]string
+		want          map[string]string
+	}{
+		{
+			name:          "package with no input tag stands for itself",
+			readOnlyPkgs:  []string{quantity},
+			readOnlyInput: map[string]string{quantity: quantity},
+			want:          map[string]string{quantity: quantity},
+		},
+		{
+			name:          "package with an input tag maps its types package",
+			readOnlyPkgs:  []string{metav1val},
+			readOnlyInput: map[string]string{metav1val: metav1},
+			want:          map[string]string{metav1: metav1val},
+		},
+		{
+			name:          "types package listed before the package holding its validations",
+			readOnlyPkgs:  []string{metav1, metav1val},
+			readOnlyInput: map[string]string{metav1: metav1, metav1val: metav1},
+			want:          map[string]string{metav1: metav1val},
+		},
+		{
+			name:          "types package listed after the package holding its validations",
+			readOnlyPkgs:  []string{metav1val, metav1},
+			readOnlyInput: map[string]string{metav1: metav1, metav1val: metav1},
+			want:          map[string]string{metav1: metav1val},
+		},
+		{
+			name:          "a generation mapping is not overridden",
+			readOnlyPkgs:  []string{metav1, metav1val},
+			readOnlyInput: map[string]string{metav1: metav1, metav1val: metav1},
+			existing:      map[string]string{metav1: generating},
+			want:          map[string]string{metav1: generating},
+		},
+		{
+			name:          "unrelated generation mappings are left alone",
+			readOnlyPkgs:  []string{quantity},
+			readOnlyInput: map[string]string{quantity: quantity},
+			existing:      map[string]string{generated: generating},
+			want:          map[string]string{generated: generating, quantity: quantity},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := map[string]string{}
+			maps.Copy(got, tt.existing)
+			mapReadOnlyPkgs(tt.readOnlyPkgs, tt.readOnlyInput, got)
+			if !maps.Equal(got, tt.want) {
+				t.Errorf("mapReadOnlyPkgs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/code-generator/kube_codegen.sh
+++ b/staging/src/k8s.io/code-generator/kube_codegen.sh
@@ -32,11 +32,15 @@ KUBE_CODEGEN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # resource.Quantity) live in the read-only Go module cache, so generators
 # must not attempt to write output files for them. These packages are passed
 # as --readonly-pkg to generators that support it (validation-gen, openapi-gen).
+# meta/v1/validation is listed alongside meta/v1 because it holds the
+# hand-written and generated validations for the meta/v1 types; validation-gen
+# needs it to resolve references such as Condition.lastTransitionTime.
 # NOTE: These must be passed as separate arguments using an array loop, not
 # via "$(printf ...)". Double-quoting a printf command substitution collapses
 # the output into a single argument, which silently breaks flag parsing.
 KUBE_CODEGEN_READONLY_PKGS=(
     k8s.io/apimachinery/pkg/apis/meta/v1
+    k8s.io/apimachinery/pkg/apis/meta/v1/validation
     k8s.io/apimachinery/pkg/api/resource
     k8s.io/apimachinery/pkg/runtime
     k8s.io/apimachinery/pkg/types


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

A package passed with `--readonly-pkg` maps to itself, so its own `+k8s:validation-gen-input` is discarded. Cross-package references to the types in that package then resolve to the types package rather than to the package which holds their validation functions.

This breaks out-of-tree API repos on 1.37.  `kube_codegen.sh` passes `k8s.io/apimachinery/pkg/apis/meta/v1` as a read-only package, and 1.37 added:

https://github.com/kubernetes/kubernetes/blob/7ad706104313c1f57f52a151261d7e6bf8f99841/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go#L1674-L1675

The validation function lives in `meta/v1/validation`:

https://github.com/kubernetes/kubernetes/blob/7ad706104313c1f57f52a151261d7e6bf8f99841/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go#L428


Any repo whose types embed `metav1.ObjectMeta` or use `metav1.Condition` aborts with:

```
expected hand-written function
k8s.io/apimachinery/pkg/apis/meta/v1.ValidateCustom_Condition_LastTransitionTime was not found
```

In-tree generation is unaffected because `hack/update-codegen.sh` generates `meta/v1/validation` as a regular input instead.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->

YES, Claude was used to help debugging and fixing. Test material was fully generated by it.
