### PR TITLE
kubelet: check sidecars during StopLivenessAndStartup

### DIFF
--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -246,7 +246,7 @@ func (m *manager) StopLivenessAndStartup(pod *v1.Pod) {
 	defer m.workerLock.RUnlock()
 
 	key := probeKey{podUID: pod.UID}
-	for _, c := range pod.Spec.Containers {
+	for _, c := range append(pod.Spec.Containers, getRestartableInitContainers(pod)...) {
 		key.containerName = c.Name
 		for _, probeType := range [...]probeType{liveness, startup} {
 			key.probeType = probeType

--- a/pkg/kubelet/prober/prober_manager_test.go
+++ b/pkg/kubelet/prober/prober_manager_test.go
@@ -281,6 +281,86 @@ func TestAddRemovePodsWithRestartableInitContainer(t *testing.T) {
 	}
 }
 
+func TestStopLivenessAndStartup(t *testing.T) {
+	ktesting.Init(t).SyncTest("", testStopLivenessAndStartup)
+}
+
+func testStopLivenessAndStartup(tCtx ktesting.TContext) {
+	t := tCtx.TB()
+	m := newTestManager()
+	defer cleanup(t, m)
+
+	restartPolicyAlways := v1.ContainerRestartPolicyAlways
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: "stop_probe_pod",
+		},
+		Spec: v1.PodSpec{
+			InitContainers: []v1.Container{
+				{
+					Name: "regular-init",
+				},
+				{
+					Name:           "sidecar",
+					RestartPolicy:  &restartPolicyAlways,
+					StartupProbe:   defaultProbe,
+					LivenessProbe:  defaultProbe,
+					ReadinessProbe: defaultProbe,
+				},
+			},
+			Containers: []v1.Container{
+				{
+					Name:           "main",
+					StartupProbe:   defaultProbe,
+					LivenessProbe:  defaultProbe,
+					ReadinessProbe: defaultProbe,
+				},
+			},
+		},
+	}
+
+	m.AddPod(tCtx, &pod)
+	allProbes := []probeKey{
+		{"stop_probe_pod", "sidecar", startup},
+		{"stop_probe_pod", "sidecar", liveness},
+		{"stop_probe_pod", "sidecar", readiness},
+		{"stop_probe_pod", "main", startup},
+		{"stop_probe_pod", "main", liveness},
+		{"stop_probe_pod", "main", readiness},
+	}
+	if err := expectProbes(m, allProbes); err != nil {
+		t.Fatal(err)
+	}
+
+	m.StopLivenessAndStartup(&pod)
+
+	stoppedProbes := []probeKey{
+		{"stop_probe_pod", "sidecar", startup},
+		{"stop_probe_pod", "sidecar", liveness},
+		{"stop_probe_pod", "main", startup},
+		{"stop_probe_pod", "main", liveness},
+	}
+	if err := waitForWorkerExit(t, m, stoppedProbes); err != nil {
+		t.Fatal(err)
+	}
+
+	remainingProbes := []probeKey{
+		{"stop_probe_pod", "sidecar", readiness},
+		{"stop_probe_pod", "main", readiness},
+	}
+	if err := expectProbes(m, remainingProbes); err != nil {
+		t.Error(err)
+	}
+
+	m.RemovePod(&pod)
+	if err := waitForWorkerExit(t, m, remainingProbes); err != nil {
+		t.Fatal(err)
+	}
+	if err := expectProbes(m, nil); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestCleanupPods(t *testing.T) {
 	ktesting.Init(t).SyncTest("", testCleanupPods)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
`StopLivenessAndStartup` stops liveness and startup probes when a pod enters termination. Previously, it only iterated over `pod.Spec.Containers`, omitting restartable init containers. As a result, sidecar liveness and startup probe workers continued running throughout graceful termination until `RemovePod`.

This PR updates `StopLivenessAndStartup` to include `getRestartableInitContainers(pod)`, matching `AddPod` and `RemovePod`.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:
Yes, used Gemini to draft the fix and the unit test. I have verified all the changes.
