### PR TITLE
kubectl delete: stop waiting when list and watch are forbidden

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
@@ -24,15 +24,22 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
+	fakedynamic "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/rest/fake"
+	clienttesting "k8s.io/client-go/testing"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
@@ -299,6 +306,75 @@ func TestDeleteObject(t *testing.T) {
 	cmd.Run(cmd, []string{})
 
 	// uses the name from the file, not the response
+	if buf.String() != "replicationcontroller/redis-master\n" {
+		t.Errorf("unexpected output: %s", buf.String())
+	}
+}
+
+// TestDeleteObjectWaitForbidden verifies the end to end behaviour of the fix for
+// kubernetes/kubectl#1411: a caller allowed to delete a resource but not to list
+// or watch it must see delete succeed rather than hang. The wait cannot confirm
+// the removal, but the deletion itself was accepted.
+func TestDeleteObjectWaitForbidden(t *testing.T) {
+	cmdtesting.InitTestErrorHandler(t)
+	_, _, rc := cmdtesting.TestData()
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/namespaces/test/replicationcontrollers/redis-master" && m == "DELETE":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
+			default:
+				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+				return nil, nil
+			}
+		}),
+	}
+
+	gvr := schema.GroupVersionResource{Version: "v1", Resource: "replicationcontrollers"}
+	forbidden := errors.NewForbidden(gvr.GroupResource(), "redis-master",
+		fmt.Errorf("not allowed to list replicationcontrollers"))
+
+	fakeDynamic := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(
+		scheme.Scheme, map[schema.GroupVersionResource]string{gvr: "ReplicationControllerList"})
+	// The object is still present, as it would be while graceful deletion or a
+	// finalizer is in progress, so the wait has something to wait for.
+	fakeDynamic.PrependReactor("get", "replicationcontrollers", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ReplicationController",
+			"metadata":   map[string]interface{}{"namespace": "test", "name": "redis-master"},
+		}}, nil
+	})
+	fakeDynamic.PrependReactor("list", "replicationcontrollers", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, forbidden
+	})
+	fakeDynamic.PrependWatchReactor("replicationcontrollers", func(action clienttesting.Action) (bool, watch.Interface, error) {
+		return true, nil, forbidden
+	})
+	tf.FakeDynamicClient = fakeDynamic
+
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+	cmd := NewCmdDelete(tf, streams)
+	cmd.Flags().Set("filename", "../../../testdata/redis-master-controller.yaml")
+	cmd.Flags().Set("cascade", "false")
+	cmd.Flags().Set("output", "name")
+	cmd.Flags().Set("wait", "true")
+
+	start := time.Now()
+	cmd.Run(cmd, []string{})
+	elapsed := time.Since(start)
+
+	// Without the fix the wait retries the denied list until the timeout, which
+	// delete sets to a week when --timeout is not given.
+	if elapsed > 30*time.Second {
+		t.Fatalf("expected delete to return promptly, took %v", elapsed)
+	}
 	if buf.String() != "replicationcontroller/redis-master\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/delete.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -77,15 +78,43 @@ func IsDeleted(ctx context.Context, info *resource.Info, o *WaitOptions) (runtim
 		return info.Object, false, errWaitTimeoutWithName
 	}
 
+	intrCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// The reflector backing UntilWithSync treats list and watch failures as
+	// retryable, so a caller that may delete an object but may not list or watch
+	// it would otherwise retry until the timeout instead of returning. Record the
+	// first forbidden error and stop waiting, so the caller can decide what it
+	// means. Deletion itself has already succeeded at this point.
+	var (
+		forbiddenLock sync.Mutex
+		forbiddenErr  error
+	)
+	recordForbidden := func(err error) {
+		if !apierrors.IsForbidden(err) {
+			return
+		}
+		forbiddenLock.Lock()
+		defer forbiddenLock.Unlock()
+		if forbiddenErr == nil {
+			forbiddenErr = err
+			cancel()
+		}
+	}
+
 	fieldSelector := fields.OneTermEqualSelector("metadata.name", info.Name).String()
 	lw := cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			options.FieldSelector = fieldSelector
-			return o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).List(ctx, options)
+			list, err := o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).List(ctx, options)
+			recordForbidden(err)
+			return list, err
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			options.FieldSelector = fieldSelector
-			return o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).Watch(ctx, options)
+			w, err := o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).Watch(ctx, options)
+			recordForbidden(err)
+			return w, err
 		},
 	}, o.DynamicClient)
 
@@ -111,8 +140,6 @@ func IsDeleted(ctx context.Context, info *resource.Info, o *WaitOptions) (runtim
 		return false, nil
 	}
 
-	intrCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
 	intr := interrupt.New(nil, cancel)
 	err := intr.Run(func() error {
 		_, err := watchtools.UntilWithSync(intrCtx, lw, &unstructured.Unstructured{}, preconditionFunc, Wait{errOut: o.ErrOut}.IsDeleted)
@@ -121,6 +148,13 @@ func IsDeleted(ctx context.Context, info *resource.Info, o *WaitOptions) (runtim
 		}
 		return err
 	})
+	forbiddenLock.Lock()
+	stoppedByForbidden := forbiddenErr
+	forbiddenLock.Unlock()
+	if stoppedByForbidden != nil {
+		// Report the denial rather than the context cancellation it triggered.
+		return gottenObj, false, stoppedByForbidden
+	}
 	if err != nil {
 		if wait.Interrupted(err) { // nolint:staticcheck // SA1019
 			return gottenObj, false, errWaitTimeoutWithName

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/delete.go
@@ -148,14 +148,22 @@ func IsDeleted(ctx context.Context, info *resource.Info, o *WaitOptions) (runtim
 		}
 		return err
 	})
-	forbiddenLock.Lock()
-	stoppedByForbidden := forbiddenErr
-	forbiddenLock.Unlock()
-	if stoppedByForbidden != nil {
-		// Report the denial rather than the context cancellation it triggered.
-		return gottenObj, false, stoppedByForbidden
-	}
 	if err != nil {
+		// A recorded denial is the reason the wait stopped, so report it rather
+		// than the context cancellation it triggered. Only consult it once the
+		// wait has failed: if deletion was confirmed first, the confirmation stands.
+		forbiddenLock.Lock()
+		stoppedByForbidden := forbiddenErr
+		forbiddenLock.Unlock()
+		if stoppedByForbidden != nil {
+			// Cancelling the wait may have pre-empted a precondition that was
+			// about to be satisfied, so confirm through the get that already
+			// succeeded above before reporting the denial.
+			if _, getErr := o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).Get(ctx, info.Name, metav1.GetOptions{}); apierrors.IsNotFound(getErr) {
+				return info.Object, true, nil
+			}
+			return gottenObj, false, stoppedByForbidden
+		}
 		if wait.Interrupted(err) { // nolint:staticcheck // SA1019
 			return gottenObj, false, errWaitTimeoutWithName
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package wait
 
 import (
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -612,6 +613,58 @@ func TestWaitForDeletion(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestWaitForDeletionForbidden verifies that a caller allowed to delete an object
+// but not to list or watch it gets the forbidden error back promptly. The reflector
+// backing the wait treats list and watch failures as retryable, so without explicit
+// handling this retries until the timeout, which kubectl delete sets to a week.
+func TestWaitForDeletionForbidden(t *testing.T) {
+	scheme := runtime.NewScheme()
+	listMapping := map[schema.GroupVersionResource]string{
+		{Group: "group", Version: "version", Resource: "theresource"}: "TheKindList",
+	}
+	forbidden := apierrors.NewForbidden(
+		schema.GroupResource{Group: "group", Resource: "theresource"}, "name-foo",
+		fmt.Errorf("not allowed to list theresource"))
+
+	fakeClient := dynamicfakeclient.NewSimpleDynamicClientWithCustomListKinds(scheme, listMapping)
+	fakeClient.PrependReactor("get", "theresource", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, newUnstructured("group/version", "TheKind", "ns-foo", "name-foo"), nil
+	})
+	fakeClient.PrependReactor("list", "theresource", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, forbidden
+	})
+	fakeClient.PrependWatchReactor("theresource", func(action clienttesting.Action) (bool, watch.Interface, error) {
+		return true, nil, forbidden
+	})
+
+	o := &WaitOptions{
+		ResourceFinder: genericclioptions.NewSimpleFakeResourceFinder(&resource.Info{
+			Mapping: &meta.RESTMapping{
+				Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+			},
+			Name:      "name-foo",
+			Namespace: "ns-foo",
+		}),
+		DynamicClient: fakeClient,
+		Timeout:       time.Hour,
+
+		Printer:     printers.NewDiscardingPrinter(),
+		ConditionFn: []ConditionFunc{IsDeleted},
+		IOStreams:   genericiooptions.NewTestIOStreamsDiscard(),
+	}
+
+	start := time.Now()
+	err := o.RunWaitContext(t.Context())
+	elapsed := time.Since(start)
+
+	if !apierrors.IsForbidden(err) {
+		t.Fatalf("expected a forbidden error, got %v", err)
+	}
+	if elapsed > 30*time.Second {
+		t.Fatalf("expected to return without waiting for the timeout, took %v", elapsed)
 	}
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
@@ -668,6 +668,64 @@ func TestWaitForDeletionForbidden(t *testing.T) {
 	}
 }
 
+// TestWaitForDeletionForbiddenAfterDeletionConfirmed verifies that a denial racing
+// with a confirmed deletion does not mask the confirmation. Deletion is observed
+// normally while watch is denied, so the wait must still report success.
+func TestWaitForDeletionForbiddenAfterDeletionConfirmed(t *testing.T) {
+	scheme := runtime.NewScheme()
+	listMapping := map[schema.GroupVersionResource]string{
+		{Group: "group", Version: "version", Resource: "theresource"}: "TheKindList",
+	}
+	forbidden := apierrors.NewForbidden(
+		schema.GroupResource{Group: "group", Resource: "theresource"}, "name-foo",
+		fmt.Errorf("not allowed to watch theresource"))
+
+	fakeClient := dynamicfakeclient.NewSimpleDynamicClientWithCustomListKinds(scheme, listMapping)
+	// The object exists when the wait starts and is gone by the time the denial
+	// is reported, which is what makes the confirmation worth preserving.
+	getCount := 0
+	fakeClient.PrependReactor("get", "theresource", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		getCount++
+		if getCount == 1 {
+			return true, newUnstructured("group/version", "TheKind", "ns-foo", "name-foo"), nil
+		}
+		return true, nil, apierrors.NewNotFound(
+			schema.GroupResource{Group: "group", Resource: "theresource"}, "name-foo")
+	})
+	// The list succeeds and reports the object already gone, while watch is denied.
+	fakeClient.PrependReactor("list", "theresource", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, newUnstructuredList(), nil
+	})
+	fakeClient.PrependWatchReactor("theresource", func(action clienttesting.Action) (bool, watch.Interface, error) {
+		return true, nil, forbidden
+	})
+
+	o := &WaitOptions{
+		ResourceFinder: genericclioptions.NewSimpleFakeResourceFinder(&resource.Info{
+			Mapping: &meta.RESTMapping{
+				Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+			},
+			Name:      "name-foo",
+			Namespace: "ns-foo",
+		}),
+		DynamicClient: fakeClient,
+		Timeout:       time.Hour,
+
+		Printer:     printers.NewDiscardingPrinter(),
+		ConditionFn: []ConditionFunc{IsDeleted},
+		IOStreams:   genericiooptions.NewTestIOStreamsDiscard(),
+	}
+
+	start := time.Now()
+	err := o.RunWaitContext(t.Context())
+	if elapsed := time.Since(start); elapsed > 30*time.Second {
+		t.Fatalf("expected to return without waiting for the timeout, took %v", elapsed)
+	}
+	if err != nil {
+		t.Fatalf("expected the confirmed deletion to stand, got %v", err)
+	}
+}
+
 func TestWaitForCondition(t *testing.T) {
 	scheme := runtime.NewScheme()
 	listMapping := map[schema.GroupVersionResource]string{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

A caller granted `delete` but not `list` or `watch` on a resource never sees `kubectl delete` terminate. The delete itself succeeds, then the command spins:

```
$ kubectl delete pod -n my-ns my-pod
pod "my-pod" deleted
E0801 21:08:59.640755 reflector.go:147] Failed to watch *unstructured.Unstructured: unknown
E0801 21:09:00.891846 reflector.go:147] Failed to watch *unstructured.Unstructured: unknown
E0801 21:09:03.706254 reflector.go:147] Failed to watch *unstructured.Unstructured: unknown
...
```

This affects least privilege setups where `delete` is granted but `list`/`watch` are withheld so tenants cannot enumerate each other's objects. It has been reported against 1.25 and again on 1.28, including a CI pipeline permanently marked failed because the cleanup step never returns.

#### Root cause

`delete.go` already anticipates this and tolerates a forbidden error from the wait:

```go
err = waitOptions.RunWaitContext(context.Background())
if errors.IsForbidden(err) || errors.IsMethodNotSupported(err) {
	// if we're forbidden from waiting, we shouldn't fail.
	klog.V(1).Info(err)
	return nil
}
```

That branch is unreachable in this case. `IsDeleted` drives `watchtools.UntilWithSync`, which is backed by a reflector, and a reflector's contract is to treat list and watch failures as retryable. An RBAC denial is indistinguishable from a transient failure, so it is retried instead of returned and the error never reaches the check above.

The wait therefore runs until `effectiveTimeout`, which `delete.go` sets to 168 hours when `--timeout` is not given.

#### The fix

Wrap the list and watch functions so the first forbidden response is recorded and cancels the wait, then return that error once the watch unwinds. The pre-existing handling in `delete.go` then does the right thing and reports success, since the object was deleted and only the confirmation was denied.

Cancelling on a denial can pre-empt a precondition that was about to be satisfied, so the recorded denial is consulted only after the wait has actually failed, and the object is re-checked with the get that already succeeded before the denial is reported. If it is gone, the confirmation stands and the wait reports success. That costs one extra request, only on the denial path.

Deliberately scoped to `Forbidden`. `Unauthorized` was also reported on this issue, but it indicates broken or expired credentials rather than a deliberate permission boundary, so silently treating it as success would mask a real authentication failure. Happy to address it separately if reviewers disagree.

One reflector log line is still emitted before the cancellation takes effect, rather than an unbounded stream. Suppressing it entirely would mean a preflight permission check on every delete, which did not seem worth the extra round trip.

#### Which issue(s) this PR is related to:

Fixes kubernetes/kubectl#1411

#### Special notes for your reviewer:

**This also changes `kubectl wait --for=delete`,** which shares `IsDeleted`. That command has no forbidden tolerance of its own, so where it previously hung until the timeout it now exits non-zero with the forbidden error. That seems right, since it genuinely cannot confirm the deletion, but it is a second user-visible change and is called out in the release note.

Tests are regression guards rather than restatements of the implementation. Each was verified in both directions against unmodified master:

| Test | Without the fix | With the fix |
| --- | --- | --- |
| `TestWaitForDeletionForbidden` | hangs until the deadline | passes in 0.00s |
| `TestWaitForDeletionForbiddenAfterDeletionConfirmed` | fails, denial masks the confirmation | passes |
| `TestDeleteObjectWaitForbidden` | hangs until the deadline | passes in 0.5s |

`TestDeleteObjectWaitForbidden` covers the command end to end. The wait path previously had no coverage in the delete package at all, since no test set a dynamic client and the nil check short circuited before reaching it.

`go test -race` passes on both packages, since the recorded denial crosses goroutines between the reflector and the caller.

The issue is assigned to @mpuckett159 from the original 2023 triage. Happy to hand this over if you are already working on it.

#### Does this PR introduce a user-facing change?

```release-note
Fixed an issue where `kubectl delete` would not terminate, and repeatedly logged watch failures, when the user has permission to delete a resource but not to list or watch it. The delete now completes as soon as the server denies the confirmation watch. `kubectl wait --for=delete` is affected by the same fix and now reports the permission error instead of waiting until its timeout.
```
