### PR TITLE
use podutil.ContainerIter to iterate over containers and init containers

### DIFF
--- a/pkg/controller/podautoscaler/replica_calculator.go
+++ b/pkg/controller/podautoscaler/replica_calculator.go
@@ -521,15 +521,11 @@ func calculatePodLevelRequests(pod *v1.Pod, resource v1.ResourceName) (int64, er
 // resource by summing requests from all containers in the pod.
 // If a container name is specified, it uses only that container.
 func calculatePodRequestsFromContainers(pod *v1.Pod, container string, resource v1.ResourceName) (int64, error) {
-	containers := append([]v1.Container{}, pod.Spec.Containers...)
-	for _, c := range pod.Spec.InitContainers {
-		if c.RestartPolicy != nil && *c.RestartPolicy == v1.ContainerRestartPolicyAlways {
-			containers = append(containers, c)
-		}
-	}
-
 	request := int64(0)
-	for _, c := range containers {
+	for c, containerType := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
+		if containerType == podutil.InitContainers && !podutil.IsRestartableInitContainer(c) {
+			continue
+		}
 		if container == "" || container == c.Name {
 			containerRequest, ok := c.Resources.Requests[resource]
 			if !ok {

--- a/pkg/kubelet/allocation/handlers.go
+++ b/pkg/kubelet/allocation/handlers.go
@@ -136,11 +136,11 @@ func disallowResizeForSwappableContainers(runtime kubecontainer.Runtime, desired
 		}
 		return false
 	}
-	allocatedContainers := make(map[string]v1.Container)
-	for _, container := range append(allocatedPod.Spec.Containers, allocatedPod.Spec.InitContainers...) {
+	allocatedContainers := make(map[string]*v1.Container)
+	for container := range podutil.ContainerIter(&allocatedPod.Spec, podutil.InitContainers|podutil.Containers) {
 		allocatedContainers[container.Name] = container
 	}
-	for _, desiredContainer := range append(desiredPod.Spec.Containers, desiredPod.Spec.InitContainers...) {
+	for desiredContainer := range podutil.ContainerIter(&desiredPod.Spec, podutil.InitContainers|podutil.Containers) {
 		allocatedContainer, ok := allocatedContainers[desiredContainer.Name]
 		if !ok {
 			continue
@@ -148,8 +148,8 @@ func disallowResizeForSwappableContainers(runtime kubecontainer.Runtime, desired
 		origMemRequest := desiredContainer.Resources.Requests[v1.ResourceMemory]
 		newMemRequest := allocatedContainer.Resources.Requests[v1.ResourceMemory]
 		if !origMemRequest.Equal(newMemRequest) && !restartableMemoryResizePolicy(allocatedContainer.ResizePolicy) {
-			aSwapBehavior := runtime.GetContainerSwapBehavior(desiredPod, &desiredContainer)
-			bSwapBehavior := runtime.GetContainerSwapBehavior(allocatedPod, &allocatedContainer)
+			aSwapBehavior := runtime.GetContainerSwapBehavior(desiredPod, desiredContainer)
+			bSwapBehavior := runtime.GetContainerSwapBehavior(allocatedPod, allocatedContainer)
 			if aSwapBehavior != kubetypes.NoSwap || bSwapBehavior != kubetypes.NoSwap {
 				return true, "In-place resize of containers with swap is not supported."
 			}

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -48,6 +48,7 @@ import (
 	internalapi "k8s.io/cri-api/pkg/apis"
 	pluginwatcherapi "k8s.io/kubelet/pkg/apis/pluginregistration/v1"
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
@@ -420,8 +421,8 @@ func (cm *containerManagerImpl) NewPodContainerManager() PodContainerManager {
 
 func (cm *containerManagerImpl) PodHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod) bool {
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.PodLevelResourceManagers) && resourcehelper.IsPodLevelResourcesSet(pod) {
-		for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
-			if cm.cpuManager.GetResourceIsolationLevel(pod, &container) != cmqos.ResourceIsolationContainer {
+		for container := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
+			if cm.cpuManager.GetResourceIsolationLevel(pod, container) != cmqos.ResourceIsolationContainer {
 				return false
 			}
 		}

--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -30,6 +30,7 @@ import (
 	resourcehelper "k8s.io/component-helpers/resource"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
@@ -406,7 +407,7 @@ func (m *manager) removeStaleState(rootLogger klog.Logger) {
 	activeContainers := make(map[string]map[string]struct{})
 	for _, pod := range activePods {
 		activeContainers[string(pod.UID)] = make(map[string]struct{})
-		for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+		for container := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
 			activeContainers[string(pod.UID)][container.Name] = struct{}{}
 		}
 	}
@@ -462,9 +463,7 @@ func (m *manager) reconcileState(ctx context.Context) (success []reconciledConta
 			continue
 		}
 
-		allContainers := pod.Spec.InitContainers
-		allContainers = append(allContainers, pod.Spec.Containers...)
-		for _, container := range allContainers {
+		for container := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
 			logger := klog.LoggerWithValues(podLogger, "containerName", container.Name)
 
 			containerID, err := findContainerIDByName(&pstatus, container.Name)

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -427,7 +427,11 @@ func (p *staticPolicy) allocatePodForAdd(logger klog.Logger, s state.State, pod 
 	}
 
 	// 4. Allocate the entire CPU "bubble" for the pod using the hint from the Topology Manager.
-	hint := p.affinity.GetAffinity(logger, podUID, append(pod.Spec.InitContainers, pod.Spec.Containers...)[0].Name)
+	firstContainerName := pod.Spec.Containers[0].Name
+	if len(pod.Spec.InitContainers) > 0 {
+		firstContainerName = pod.Spec.InitContainers[0].Name
+	}
+	hint := p.affinity.GetAffinity(logger, podUID, firstContainerName)
 	podAllocation, err := p.allocateCPUs(logger, s, totalPodCPUs, hint.NUMANodeAffinity, cpuset.New())
 	if err != nil {
 		logger.Error(err, "Unable to allocate CPUs for pod", "totalPodCPUs", totalPodCPUs)
@@ -497,7 +501,7 @@ func (p *staticPolicy) allocatePodForAdd(logger klog.Logger, s state.State, pod 
 	logger.V(4).Info("Partitioned pod-level CPU allocation", "exclusiveCPUs", podCPUAllocationToString(exclusiveCPUs), "podSharedPool", podSharedPool)
 
 	// 6. Save all container assignments to the state.
-	for _, c := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+	for c := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
 		if cset, isExclusive := exclusiveCPUs[c.Name]; isExclusive {
 			s.SetCPUSet(podUID, c.Name, cset)
 		} else {
@@ -945,10 +949,10 @@ func (p *staticPolicy) getPodTopologyHintsForAdd(logger klog.Logger, s state.Sta
 	}
 
 	assignedCPUs := cpuset.New()
-	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+	for container := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
 		logger_ := klog.LoggerWithValues(logger, "containerName", container.Name)
 
-		requestedByContainer := p.guaranteedCPUs(logger, pod, &container)
+		requestedByContainer := p.guaranteedCPUs(logger, pod, container)
 		// Short circuit to regenerate the same hints if there are already
 		// guaranteed CPUs allocated to the Container. This might happen after a
 		// kubelet restart, for example.

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -33,6 +33,7 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/klog/v2"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	pkgfeatures "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cm/admission"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state"
@@ -831,8 +832,8 @@ func TestStaticPolicyReuseCPUs(t *testing.T) {
 		pod := testCase.pod
 
 		// allocate
-		for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
-			_ = policy.Allocate(logger, st, pod, &container, lifecycle.AddOperation)
+		for container := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
+			_ = policy.Allocate(logger, st, pod, container, lifecycle.AddOperation)
 		}
 		if !st.defaultCPUSet.Equals(testCase.expCSetAfterAlloc) {
 			t.Errorf("StaticPolicy Allocate() error (%v). expected default cpuset %s but got %s",
@@ -888,8 +889,8 @@ func TestStaticPolicyDoNotReuseCPUs(t *testing.T) {
 		pod := testCase.pod
 
 		// allocate
-		for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
-			err := policy.Allocate(logger, st, pod, &container, lifecycle.AddOperation)
+		for container := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
+			err := policy.Allocate(logger, st, pod, container, lifecycle.AddOperation)
 			if err != nil {
 				t.Errorf("StaticPolicy Allocate() error (%v). expected no error but got %v",
 					testCase.description, err)

--- a/pkg/kubelet/cm/memorymanager/memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager.go
@@ -376,7 +376,7 @@ func (m *manager) removeStaleState(logger klog.Logger) {
 	activeContainers := make(map[string]map[string]struct{})
 	for _, pod := range activePods {
 		activeContainers[string(pod.UID)] = make(map[string]struct{})
-		for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+		for container := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
 			activeContainers[string(pod.UID)][container.Name] = struct{}{}
 		}
 	}

--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -235,7 +235,11 @@ func (p *staticPolicy) AllocatePod(logger klog.Logger, s state.State, pod *v1.Po
 
 	// 3. Handle hints and NUMA alignment.
 	machineState := s.GetMachineState()
-	bestHint := p.affinity.GetAffinity(logger, podUID, append(pod.Spec.InitContainers, pod.Spec.Containers...)[0].Name)
+	firstContainerName := pod.Spec.Containers[0].Name
+	if len(pod.Spec.InitContainers) > 0 {
+		firstContainerName = pod.Spec.InitContainers[0].Name
+	}
+	bestHint := p.affinity.GetAffinity(logger, podUID, firstContainerName)
 	if bestHint.NUMANodeAffinity == nil {
 		defaultHint, err := p.getDefaultHint(machineState, pod, podTotalMemory)
 		if err != nil {
@@ -395,7 +399,7 @@ func (p *staticPolicy) AllocatePod(logger klog.Logger, s state.State, pod *v1.Po
 	logger.V(4).Info("Partitioned pod-level memory allocation", "exclusiveMemory", podMemoryAllocationToString(exclusiveMemory), "podSharedPool", memoryBlocksToString(podSharedPoolBlocks))
 
 	// 6. Save all container assignments to the state.
-	for _, c := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+	for c := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
 		if blocks, isExclusive := exclusiveMemory[c.Name]; isExclusive {
 			s.SetMemoryBlocks(podUID, c.Name, blocks)
 		} else {
@@ -845,13 +849,13 @@ func (p *staticPolicy) GetPodTopologyHints(logger klog.Logger, s state.State, po
 		return nil
 	}
 
-	for _, ctn := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+	for ctn := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
 		containerBlocks := s.GetMemoryBlocks(string(pod.UID), ctn.Name)
 		// Short circuit to regenerate the same hints if there are already
 		// memory allocated for the container. This might happen after a
 		// kubelet restart, for example.
 		if containerBlocks != nil {
-			return regenerateHints(logger, pod, &ctn, containerBlocks, reqRsrcs)
+			return regenerateHints(logger, pod, ctn, containerBlocks, reqRsrcs)
 		}
 	}
 

--- a/pkg/kubelet/cm/topologymanager/scope.go
+++ b/pkg/kubelet/cm/topologymanager/scope.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/kubelet/cm/admission"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
@@ -137,8 +138,8 @@ func (s *scope) RemoveContainer(logger klog.Logger, containerID string) error {
 }
 
 func (s *scope) admitPolicyNone(ctx context.Context, pod *v1.Pod, operation lifecycle.Operation) lifecycle.PodAdmitResult {
-	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
-		err := s.allocateAlignedResources(ctx, pod, &container, operation)
+	for container := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
+		err := s.allocateAlignedResources(ctx, pod, container, operation)
 		if err != nil {
 			return admission.GetPodAdmitResult(err)
 		}

--- a/pkg/kubelet/cm/topologymanager/scope_container.go
+++ b/pkg/kubelet/cm/topologymanager/scope_container.go
@@ -23,6 +23,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	resourcehelper "k8s.io/component-helpers/resource"
 	"k8s.io/klog/v2"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cm/admission"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
@@ -52,8 +53,8 @@ func NewContainerScope(policy Policy) Scope {
 func (s *containerScope) Admit(ctx context.Context, pod *v1.Pod, operation lifecycle.Operation) lifecycle.PodAdmitResult {
 	logger := klog.FromContext(ctx)
 
-	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
-		bestHint, admit := s.calculateAffinity(logger, pod, &container, operation)
+	for container := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
+		bestHint, admit := s.calculateAffinity(logger, pod, container, operation)
 		logger.Info("Best TopologyHint", "bestHint", bestHint, "pod", klog.KObj(pod), "containerName", container.Name, "operation", operation)
 
 		if !admit {
@@ -69,7 +70,7 @@ func (s *containerScope) Admit(ctx context.Context, pod *v1.Pod, operation lifec
 		logger.Info("Topology Affinity", "bestHint", bestHint, "pod", klog.KObj(pod), "containerName", container.Name, "operation", operation)
 		s.setTopologyHints(string(pod.UID), container.Name, bestHint)
 
-		err := s.allocateAlignedResources(ctx, pod, &container, operation)
+		err := s.allocateAlignedResources(ctx, pod, container, operation)
 		if err != nil {
 			metrics.TopologyManagerAdmissionErrorsTotal.Inc()
 			return admission.GetPodAdmitResult(err)

--- a/pkg/kubelet/cm/topologymanager/scope_pod.go
+++ b/pkg/kubelet/cm/topologymanager/scope_pod.go
@@ -23,6 +23,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	resourcehelper "k8s.io/component-helpers/resource"
 	"k8s.io/klog/v2"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cm/admission"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
@@ -67,11 +68,11 @@ func (s *podScope) admitUsingContainerResources(ctx context.Context, pod *v1.Pod
 		return admission.GetPodAdmitResult(NewTopologyAffinityError())
 	}
 
-	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+	for container := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
 		logger.Info("Topology Affinity", "bestHint", bestHint, "pod", klog.KObj(pod), "containerName", container.Name)
 		s.setTopologyHints(string(pod.UID), container.Name, bestHint)
 
-		err := s.allocateAlignedResources(ctx, pod, &container, operation)
+		err := s.allocateAlignedResources(ctx, pod, container, operation)
 		if err != nil {
 			metrics.TopologyManagerAdmissionErrorsTotal.Inc()
 			return admission.GetPodAdmitResult(err)
@@ -96,7 +97,7 @@ func (s *podScope) admitUsingPodResources(ctx context.Context, pod *v1.Pod, oper
 	logger.V(4).Info("Calling AllocatePod on hint providers", "pod", klog.KObj(pod))
 
 	// Store the best hint for all containers.
-	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+	for container := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
 		logger.Info("Topology Affinity", "bestHint", bestHint, "pod", klog.KObj(pod), "containerName", container.Name)
 		s.setTopologyHints(string(pod.UID), container.Name, bestHint)
 	}

--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -31,6 +31,7 @@ import (
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	v1resource "k8s.io/kubernetes/pkg/api/v1/resource"
 	"k8s.io/kubernetes/pkg/features"
 	evictionapi "k8s.io/kubernetes/pkg/kubelet/eviction/api"
@@ -1266,12 +1267,8 @@ func evictionMessage(resourceToReclaim v1.ResourceName, pod *v1.Pod, stats stats
 	// they will always be blamed for resource overuse when an eviction occurs.
 	// That’s why only regular, init and restartable init containers are considered
 	// for the eviction message.
-	containers := pod.Spec.Containers
-	if len(pod.Spec.InitContainers) != 0 {
-		containers = append(containers, pod.Spec.InitContainers...)
-	}
 	for _, containerStats := range podStats.Containers {
-		for _, container := range containers {
+		for container := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
 			if container.Name == containerStats.Name {
 				requests := container.Resources.Requests[resourceToReclaim]
 				var usage *resource.Quantity

--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -172,16 +172,6 @@ func (t probeType) String() string {
 	}
 }
 
-func getRestartableInitContainers(pod *v1.Pod) []v1.Container {
-	var restartableInitContainers []v1.Container
-	for _, c := range pod.Spec.InitContainers {
-		if podutil.IsRestartableInitContainer(&c) {
-			restartableInitContainers = append(restartableInitContainers, c)
-		}
-	}
-	return restartableInitContainers
-}
-
 func (m *manager) AddPod(ctx context.Context, pod *v1.Pod) {
 	m.workerLock.Lock()
 	defer m.workerLock.Unlock()
@@ -200,7 +190,10 @@ func (m *manager) AddPod(ctx context.Context, pod *v1.Pod) {
 	// cancelled by stop(), not the pod sync context, which cancels too early.
 	ctx = context.WithoutCancel(ctx)
 	key := probeKey{podUID: pod.UID}
-	for _, c := range append(pod.Spec.Containers, getRestartableInitContainers(pod)...) {
+	for c, containerType := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
+		if containerType == podutil.InitContainers && !podutil.IsRestartableInitContainer(c) {
+			continue
+		}
 		key.containerName = c.Name
 
 		if c.StartupProbe != nil {
@@ -210,7 +203,7 @@ func (m *manager) AddPod(ctx context.Context, pod *v1.Pod) {
 					"pod", klog.KObj(pod), "containerName", c.Name)
 				continue
 			}
-			w := newWorker(m, startup, pod, c)
+			w := newWorker(m, startup, pod, *c)
 			m.workers[key] = w
 			go w.run(ctx)
 		}
@@ -222,7 +215,7 @@ func (m *manager) AddPod(ctx context.Context, pod *v1.Pod) {
 					"pod", klog.KObj(pod), "containerName", c.Name)
 				continue
 			}
-			w := newWorker(m, readiness, pod, c)
+			w := newWorker(m, readiness, pod, *c)
 			m.workers[key] = w
 			go w.run(ctx)
 		}
@@ -234,7 +227,7 @@ func (m *manager) AddPod(ctx context.Context, pod *v1.Pod) {
 					"pod", klog.KObj(pod), "containerName", c.Name)
 				continue
 			}
-			w := newWorker(m, liveness, pod, c)
+			w := newWorker(m, liveness, pod, *c)
 			m.workers[key] = w
 			go w.run(ctx)
 		}
@@ -262,7 +255,10 @@ func (m *manager) RemovePod(pod *v1.Pod) {
 	defer m.workerLock.RUnlock()
 
 	key := probeKey{podUID: pod.UID}
-	for _, c := range append(pod.Spec.Containers, getRestartableInitContainers(pod)...) {
+	for c, containerType := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
+		if containerType == podutil.InitContainers && !podutil.IsRestartableInitContainer(c) {
+			continue
+		}
 		key.containerName = c.Name
 		for _, probeType := range [...]probeType{readiness, liveness, startup} {
 			key.probeType = probeType

--- a/pkg/scheduler/framework/plugins/dynamicresources/nodeallocatabledynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/nodeallocatabledynamicresources.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/dynamic-resource-allocation/resourceclaim"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
@@ -284,7 +285,6 @@ func (pl *DynamicResources) buildNodeAllocatableDRAInfo(pod *v1.Pod, nodeAllocat
 	if len(nodeAllocatableClaimAllocations) == 0 {
 		return []v1.NodeAllocatableResourceClaimStatus{}, nil
 	}
-
 	claimToStatus := make(map[types.UID]v1.NodeAllocatableResourceClaimStatus)
 
 	for key, alloc := range nodeAllocatableClaimAllocations {
@@ -341,14 +341,12 @@ func (pl *DynamicResources) buildNodeAllocatableDRAInfo(pod *v1.Pod, nodeAllocat
 		}
 	}
 
-	for _, containers := range [][]v1.Container{pod.Spec.InitContainers, pod.Spec.Containers} {
-		for _, container := range containers {
-			for _, podClaim := range container.Resources.Claims {
-				if claimUID, ok := claimNametoUID[podClaim.Name]; ok {
-					if nodeAllocatableClaimStatus, ok := claimToStatus[claimUID]; ok {
-						nodeAllocatableClaimStatus.Containers = append(nodeAllocatableClaimStatus.Containers, container.Name)
-						claimToStatus[claimUID] = nodeAllocatableClaimStatus
-					}
+	for container := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
+		for _, podClaim := range container.Resources.Claims {
+			if claimUID, ok := claimNametoUID[podClaim.Name]; ok {
+				if nodeAllocatableClaimStatus, ok := claimToStatus[claimUID]; ok {
+					nodeAllocatableClaimStatus.Containers = append(nodeAllocatableClaimStatus.Containers, container.Name)
+					claimToStatus[claimUID] = nodeAllocatableClaimStatus
 				}
 			}
 		}

--- a/pkg/scheduler/framework/plugins/imagelocality/image_locality.go
+++ b/pkg/scheduler/framework/plugins/imagelocality/image_locality.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	fwk "k8s.io/kube-scheduler/framework"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
 
@@ -55,11 +56,7 @@ func (pl *ImageLocality) Name() string {
 func (pl *ImageLocality) SignPod(ctx context.Context, pod *v1.Pod) ([]fwk.SignFragment, *fwk.Status) {
 	nameSet := sets.New[string]()
 
-	containers := []v1.Container{}
-	containers = append(containers, pod.Spec.Containers...)
-	containers = append(containers, pod.Spec.InitContainers...)
-
-	for _, container := range containers {
+	for container := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
 		nameSet.Insert(normalizedImageName(container.Image))
 	}
 	names := sets.List(nameSet)

--- a/pkg/volume/emptydir/empty_dir.go
+++ b/pkg/volume/emptydir/empty_dir.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	resourcehelper "k8s.io/component-helpers/resource"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
@@ -426,7 +427,7 @@ func getPageSizeMountOption(medium v1.StorageMedium, pod *v1.Pod) (string, error
 	}
 
 	// In some rare cases init containers can also consume Huge pages
-	for _, container := range append(pod.Spec.Containers, pod.Spec.InitContainers...) {
+	for container := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
 		podLevelAndContainerLevelRequests = append(podLevelAndContainerLevelRequests, container.Resources.Requests)
 	}
 

--- a/plugin/pkg/admission/imagepolicy/admission.go
+++ b/plugin/pkg/admission/imagepolicy/admission.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apiserver/pkg/util/webhook"
 	"k8s.io/client-go/rest"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	podutil "k8s.io/kubernetes/pkg/api/pod"
 	api "k8s.io/kubernetes/pkg/apis/core"
 
 	// install the clientgo image policy API for use with api registry
@@ -147,10 +148,7 @@ func (a *Plugin) Validate(ctx context.Context, attributes admission.Attributes, 
 	// Build list of ImageReviewContainerSpec
 	var imageReviewContainerSpecs []v1alpha1.ImageReviewContainerSpec
 	if subresource == "" {
-		containers := make([]api.Container, 0, len(pod.Spec.Containers)+len(pod.Spec.InitContainers))
-		containers = append(containers, pod.Spec.Containers...)
-		containers = append(containers, pod.Spec.InitContainers...)
-		for _, c := range containers {
+		for c := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
 			imageReviewContainerSpecs = append(imageReviewContainerSpecs, v1alpha1.ImageReviewContainerSpec{
 				Image: c.Image,
 			})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Iterating over containers and init containers using `append(pod.Spec.Containers, pod.Spec.InitContainers...)` allocates a new backing slice and copies large `v1.Container` structs by value. This causes unnecessary heap allocations and GC overhead on hot paths.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Microbenchmark results comparing `podutil.ContainerIter` vs `append(pod.Spec.Containers, pod.Spec.InitContainers...)`:

| Pod Size | Method | Time (`ns/op`) | Memory (`B/op`) | Allocs (`allocs/op`) |
| :--- | :--- | ---: | ---: | ---: |
| 1 init, 1 app | `ContainerIter` | 7.59 ns | 0 B | 0 |
| | `Append` | 754.70 ns | 896 B | 1 |
| 2 init, 5 app | `ContainerIter` | 22.40 ns | 0 B | 0 |
| | `Append` | 2,976.00 ns | 4,096 B | 1 |
| 5 init, 20 app | `ContainerIter` | 72.99 ns | 0 B | 0 |
| | `Append` | 9,180.00 ns | 16,384 B | 1 |

Code generated by Gemini, reviewed by @tallclair.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig node
