### PR TITLE
Support PKCS#8-encoded ECDSA keys in keyutil.ParsePublicKeysPEM

### DIFF
--- a/staging/src/k8s.io/client-go/util/keyutil/key.go
+++ b/staging/src/k8s.io/client-go/util/keyutil/key.go
@@ -308,7 +308,9 @@ func parseECPrivateKey(data []byte) (*ecdsa.PrivateKey, error) {
 	// Parse the key
 	var parsedKey interface{}
 	if parsedKey, err = x509.ParseECPrivateKey(data); err != nil {
-		return nil, err
+		if parsedKey, err = x509.ParsePKCS8PrivateKey(data); err != nil {
+			return nil, err
+		}
 	}
 
 	// Test if parsed key is an ECDSA Private Key

--- a/staging/src/k8s.io/client-go/util/keyutil/key_test.go
+++ b/staging/src/k8s.io/client-go/util/keyutil/key_test.go
@@ -111,6 +111,14 @@ Vdc3psr1OaNzyTyuhTECyRdFKXm63cMnGg==
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZZzi1u5f2/AEGFI/HYUhU+u6cTK1
 q2bbtE7r1JMK+/sQA5sNAp+7Vdc3psr1OaNzyTyuhTECyRdFKXm63cMnGg==
 -----END PUBLIC KEY-----`
+
+	// ecdsaPrivateKeyPKCS8 is an ECDSA Private Key in unencrypted PKCS#8 format
+	// openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256
+	ecdsaPrivateKeyPKCS8 = `-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgwT13QkeA46l7QPdI
+Iuvo5ZTj+0h3XAu2bfKFMdnXhd+hRANCAATDE2ubMIhLuXhUaXJSa+6fKDnkIOvx
+RN7UYjUYaNfwAggNPxwE1SFtdfK1rSWKx6nNpOaoXR0E9OWg64BCZQG5
+-----END PRIVATE KEY-----`
 )
 
 func TestReadPrivateKey(t *testing.T) {
@@ -171,6 +179,15 @@ func TestReadPublicKeys(t *testing.T) {
 	}
 	if keys, err := PublicKeysFromFile(f.Name()); err != nil {
 		t.Fatalf("error reading ECDSA public key: %v", err)
+	} else if len(keys) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(keys))
+	}
+
+	if err := os.WriteFile(f.Name(), []byte(ecdsaPrivateKeyPKCS8), os.FileMode(0600)); err != nil {
+		t.Fatalf("error writing PKCS#8 ECDSA private key to tmpfile: %v", err)
+	}
+	if keys, err := PublicKeysFromFile(f.Name()); err != nil {
+		t.Fatalf("error reading public key from PKCS#8 ECDSA private key: %v", err)
 	} else if len(keys) != 1 {
 		t.Fatalf("expected 1 key, got %d", len(keys))
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`keyutil.parseECPrivateKey` only tried `x509.ParseECPrivateKey` (SEC1 / RFC 5915), so an ECDSA private key in unencrypted **PKCS#8** form (a `-----BEGIN PRIVATE KEY-----` block, e.g. the default output of `openssl genpkey -algorithm EC`) was rejected by `ParsePublicKeysPEM` / `PublicKeysFromFile` with `data does not contain any valid RSA or ECDSA public keys`.

The sibling `parseRSAPrivateKey` already falls back to `x509.ParsePKCS8PrivateKey`, and `ParsePrivateKeyPEM` treats a PKCS#8 `PRIVATE KEY` block as a valid RSA-or-ECDSA key, so PKCS#8-encoded EC keys are expected to be supported. This adds the same PKCS#8 fallback to `parseECPrivateKey`, and extends `TestReadPublicKeys` with a PKCS#8 EC key (fails before / passes after).

Reachable from public/private key file inputs such as `--service-account-key-file`.

**Which issue(s) this PR fixes**:

Fixes #141773

**Special notes for your reviewer**:

The fix mirrors the existing `parseRSAPrivateKey` fallback exactly (`x509.ParseECPrivateKey` → `x509.ParsePKCS8PrivateKey`). `go test`, `go vet` and `gofmt` are clean for the package.

**Does this PR introduce a user-facing change?**

```release-note
keyutil.ParsePublicKeysPEM (used e.g. for --service-account-key-file) now accepts ECDSA private keys in unencrypted PKCS#8 format, matching the existing support for RSA PKCS#8 keys.
```

/sig auth