### PR TITLE
kube-apiserver: use contextual logging

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -147,10 +147,11 @@ cluster's shared state through which all other components interact.`,
 
 // Run runs the specified APIServer.  This should never exit.
 func Run(ctx context.Context, opts options.CompletedOptions) error {
+	logger := klog.FromContext(ctx)
 	// To help debugging, immediately log version
-	klog.Infof("Version: %+v", utilversion.Get())
+	logger.Info("Version", "version", utilversion.Get())
 
-	klog.InfoS("Golang settings", "GOGC", os.Getenv("GOGC"), "GOMAXPROCS", os.Getenv("GOMAXPROCS"), "GOTRACEBACK", os.Getenv("GOTRACEBACK"))
+	logger.Info("Golang settings", "GOGC", os.Getenv("GOGC"), "GOMAXPROCS", os.Getenv("GOMAXPROCS"), "GOTRACEBACK", os.Getenv("GOTRACEBACK"))
 
 	if opts.InformerName == nil {
 		informerName, err := cache.NewInformerName("kube-apiserver")

--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -184,7 +184,7 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 		if errCh != nil {
 			err, ok := <-errCh
 			if ok && err != nil {
-				klog.Errorf("Failed to shutdown test server clearly: %v", err)
+				klog.FromContext(tCtx).Error(err, "Failed to shutdown test server clearly")
 			}
 		}
 		os.RemoveAll(result.TmpDir)

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -365,6 +365,7 @@ linters:
             contextual k8s.io/sample-apiserver/.*
             contextual k8s.io/sample-cli-plugin/.*
             contextual k8s.io/sample-controller/.*
+            contextual k8s.io/kubernetes/cmd/kube-apiserver/.*
             contextual k8s.io/kubernetes/cmd/kube-proxy/.*
             contextual k8s.io/kubernetes/cmd/kube-scheduler/.*
             contextual k8s.io/kubernetes/cmd/kubelet/.*

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -378,6 +378,7 @@ linters:
             contextual k8s.io/sample-apiserver/.*
             contextual k8s.io/sample-cli-plugin/.*
             contextual k8s.io/sample-controller/.*
+            contextual k8s.io/kubernetes/cmd/kube-apiserver/.*
             contextual k8s.io/kubernetes/cmd/kube-proxy/.*
             contextual k8s.io/kubernetes/cmd/kube-scheduler/.*
             contextual k8s.io/kubernetes/cmd/kubelet/.*

--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -41,6 +41,7 @@ contextual k8s.io/kube-scheduler/.*
 contextual k8s.io/sample-apiserver/.*
 contextual k8s.io/sample-cli-plugin/.*
 contextual k8s.io/sample-controller/.*
+contextual k8s.io/kubernetes/cmd/kube-apiserver/.*
 contextual k8s.io/kubernetes/cmd/kube-proxy/.*
 contextual k8s.io/kubernetes/cmd/kube-scheduler/.*
 contextual k8s.io/kubernetes/cmd/kubelet/.*


### PR DESCRIPTION
**What this PR does / why we need it**:

Migrates the remaining global `klog` calls in `cmd/kube-apiserver` to contextual logging:

- `Run()`: use `klog.FromContext(ctx)` for the version and Golang settings logs
- `StartTestServer()`: use `klog.FromContext(tCtx)` for the shutdown failure log

With this change and `contextual k8s.io/kubernetes/cmd/kube-apiserver/.*` now enabled in `hack/logcheck.conf`, kube-apiserver joins the other main `cmd/` components (kube-controller-manager via #141553, kube-proxy, kube-scheduler, kubelet) with contextual logging enforced.

**Which issue(s) this PR fixes**:

X-Ref #126379

**Special notes for your reviewer**:

`hack/golangci.yaml` and `hack/golangci-hints.yaml` were regenerated with `hack/update-golangci-lint-config.sh`.

This may conflict with #141553 in `hack/logcheck.conf` and the generated configs (adjacent lines) — whichever merges last only needs a trivial rebase.

**Release note**:

```release-note
None
```
