### PR TITLE
build: retry kube-cross image pulls

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -50,6 +50,15 @@ readonly KUBE_CROSS_VERSION
 KUBE_CROSS_CONTAINER_ROOT="/go/src/k8s.io/kubernetes"
 readonly KUBE_CROSS_CONTAINER_ROOT
 
+# Controls how image pulls are retried. Registries can return transient errors
+# (e.g. HTTP 5xx) that last only a few seconds, which would otherwise fail an
+# entire build. With the defaults below a pull is attempted 6 times, sleeping
+# 1, 2, 4, 8 and 16 seconds in between, for roughly 31 seconds of total backoff.
+KUBE_IMAGE_PULL_RETRIES="${KUBE_IMAGE_PULL_RETRIES:-6}"
+readonly KUBE_IMAGE_PULL_RETRIES
+KUBE_IMAGE_PULL_RETRY_INITIAL_DELAY="${KUBE_IMAGE_PULL_RETRY_INITIAL_DELAY:-1}"
+readonly KUBE_IMAGE_PULL_RETRY_INITIAL_DELAY
+
 # Here we map the output directories across both the local and remote _output
 # directories:
 #
@@ -353,6 +362,51 @@ function kube::build::clean() {
   fi
 }
 
+# Pull an image, retrying with exponential backoff if the pull fails.
+#
+# `docker run` pulls missing images implicitly, but a single transient registry
+# failure then aborts the entire build. Pulling explicitly lets us retry just
+# the pull instead.
+#
+# Arguments:
+#  $1 - image reference, e.g. registry.k8s.io/build-image/kube-cross:v1.2.3
+function kube::build::pull_image_with_retry() {
+  local -r image="$1"
+
+  local -a pull_cmd=("${DOCKER[@]}" pull "${image}")
+
+  local delay="${KUBE_IMAGE_PULL_RETRY_INITIAL_DELAY}"
+  local attempt
+  for (( attempt=1; attempt<=KUBE_IMAGE_PULL_RETRIES; attempt++ )); do
+    if "${pull_cmd[@]}"; then
+      return 0
+    fi
+    if (( attempt == KUBE_IMAGE_PULL_RETRIES )); then
+      break
+    fi
+    kube::log::status "Failed to pull ${image} (attempt ${attempt}/${KUBE_IMAGE_PULL_RETRIES}), retrying in ${delay}s ..."
+    sleep "${delay}"
+    delay=$(( delay * 2 ))
+  done
+
+  kube::log::error "Failed to pull ${image} after ${KUBE_IMAGE_PULL_RETRIES} attempts"
+  return 1
+}
+
+# Ensure an image is present locally, pulling it with retries if it is not.
+#
+# Arguments:
+#  $1 - image reference, e.g. registry.k8s.io/build-image/kube-cross:v1.2.3
+function kube::build::ensure_image() {
+  local -r image="$1"
+
+  if "${DOCKER[@]}" image inspect "${image}" &>/dev/null; then
+    return 0
+  fi
+
+  kube::build::pull_image_with_retry "${image}"
+}
+
 # Run a command in the kube-build image.  This assumes that the image has
 # already been built.
 function kube::build::run_build_command() {
@@ -460,6 +514,10 @@ function kube::build::run_build_command_ex() {
   elif [[ "${detach}" == false ]]; then
     docker_run_opts+=("--attach=stdout" "--attach=stderr")
   fi
+
+  # `docker run` would pull this implicitly, but that pull is not retried and a
+  # transient registry error would fail the build.
+  kube::build::ensure_image "${KUBE_CROSS_IMAGE}:${KUBE_CROSS_VERSION}" || return 1
 
   local -ra docker_cmd=(
     "${DOCKER[@]}" run "${docker_run_opts[@]}" "${KUBE_CROSS_IMAGE}:${KUBE_CROSS_VERSION}")

--- a/build/common_test.go
+++ b/build/common_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestImagePullRetries(t *testing.T) {
+	script := `
+KUBE_IMAGE_PULL_RETRIES=3
+KUBE_IMAGE_PULL_RETRY_INITIAL_DELAY=1
+source ./common.sh
+
+pull_attempts=0
+inspect_attempts=0
+failures_before_success=0
+image_present=false
+sleep_calls=()
+
+fake_docker() {
+  case "$1" in
+    image)
+      if [[ "$2" != inspect ]]; then
+        return 2
+      fi
+      inspect_attempts=$((inspect_attempts + 1))
+      [[ "${image_present}" == true ]]
+      ;;
+    pull)
+      pull_attempts=$((pull_attempts + 1))
+      if (( pull_attempts <= failures_before_success )); then
+        return 1
+      fi
+      image_present=true
+      ;;
+    *)
+      return 2
+      ;;
+  esac
+}
+
+sleep() {
+  sleep_calls+=("$1")
+}
+
+assert_equal() {
+  if [[ "$1" != "$2" ]]; then
+    echo "expected '$1', got '$2'" >&2
+    return 1
+  fi
+}
+
+reset_fake() {
+  pull_attempts=0
+  inspect_attempts=0
+  failures_before_success=0
+  image_present=false
+  sleep_calls=()
+}
+
+DOCKER=(fake_docker)
+
+failures_before_success=2
+kube::build::pull_image_with_retry example.com/image:test
+assert_equal 3 "${pull_attempts}"
+assert_equal "1 2" "${sleep_calls[*]}"
+
+reset_fake
+failures_before_success=3
+if kube::build::pull_image_with_retry example.com/image:test; then
+  echo "expected image pull to fail" >&2
+  exit 1
+fi
+assert_equal 3 "${pull_attempts}"
+assert_equal "1 2" "${sleep_calls[*]}"
+
+reset_fake
+image_present=true
+kube::build::ensure_image example.com/image:test
+assert_equal 1 "${inspect_attempts}"
+assert_equal 0 "${pull_attempts}"
+
+reset_fake
+kube::build::ensure_image example.com/image:test
+assert_equal 1 "${inspect_attempts}"
+assert_equal 1 "${pull_attempts}"
+`
+
+	cmd := exec.Command("bash")
+	cmd.Dir = "."
+	cmd.Stdin = strings.NewReader(script)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("image pull tests failed: %v\n%s", err, output)
+	}
+}


### PR DESCRIPTION
Pull build and release images explicitly with exponential backoff, avoiding unretried implicit pulls while preserving KUBE_BUILD_PULL_LATEST_IMAGES behavior.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake

#### What this PR does / why we need it:

This PR adds image pull retries during CI/automation (and probably manual for some folks) to make CI more resilient when encountering transient image registry outages and other temporary failures.

I encountered a registry 500 response here:

- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/141736/pull-kubernetes-conformance-kind-ga-only-parallel/2094815250145611776
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/141736/pull-kubernetes-e2e-gce/2094815245934530560

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
