### PR TITLE
scheduling: migrate PriorityClass immutable fields to declarative validation

### DIFF
--- a/pkg/apis/scheduling/v1/zz_generated.validations.go
+++ b/pkg/apis/scheduling/v1/zz_generated.validations.go
@@ -29,6 +29,7 @@ import (
 	equality "k8s.io/apimachinery/pkg/api/equality"
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
+	validate "k8s.io/apimachinery/pkg/api/validate"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -88,7 +89,38 @@ func Validate_PriorityClass(
 		errs = append(errs, fn(fldPath.Child("metadata"), &obj.ObjectMeta, oldVal, oldObj != nil)...)
 	}
 
-	// field schedulingv1.PriorityClass.Value has no validation
+	{ // field schedulingv1.PriorityClass.Value
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int32,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *schedulingv1.PriorityClass) *int32 {
+				return &oldObj.Value
+			})
+		errs = append(errs, fn(fldPath.Child("value"), &obj.Value, oldVal, oldObj != nil)...)
+	}
+
 	// field schedulingv1.PriorityClass.GlobalDefault has no validation
 	// field schedulingv1.PriorityClass.Description has no validation
 	// field schedulingv1.PriorityClass.PreemptionPolicy has no validation

--- a/pkg/apis/scheduling/v1/zz_generated.validations.go
+++ b/pkg/apis/scheduling/v1/zz_generated.validations.go
@@ -25,6 +25,7 @@ import (
 	context "context"
 	fmt "fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	equality "k8s.io/apimachinery/pkg/api/equality"
 	operation "k8s.io/apimachinery/pkg/api/operation"
@@ -123,6 +124,38 @@ func Validate_PriorityClass(
 
 	// field schedulingv1.PriorityClass.GlobalDefault has no validation
 	// field schedulingv1.PriorityClass.Description has no validation
-	// field schedulingv1.PriorityClass.PreemptionPolicy has no validation
+
+	{ // field schedulingv1.PriorityClass.PreemptionPolicy
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *corev1.PreemptionPolicy,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *schedulingv1.PriorityClass) *corev1.PreemptionPolicy {
+				return oldObj.PreemptionPolicy
+			})
+		errs = append(errs, fn(fldPath.Child("preemptionPolicy"), obj.PreemptionPolicy, oldVal, oldObj != nil)...)
+	}
+
 	return errs
 }

--- a/pkg/apis/scheduling/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/scheduling/v1beta1/zz_generated.validations.go
@@ -2000,7 +2000,38 @@ func Validate_PriorityClass(
 		errs = append(errs, fn(fldPath.Child("metadata"), &obj.ObjectMeta, oldVal, oldObj != nil)...)
 	}
 
-	// field schedulingv1beta1.PriorityClass.Value has no validation
+	{ // field schedulingv1beta1.PriorityClass.Value
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int32,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *schedulingv1beta1.PriorityClass) *int32 {
+				return &oldObj.Value
+			})
+		errs = append(errs, fn(fldPath.Child("value"), &obj.Value, oldVal, oldObj != nil)...)
+	}
+
 	// field schedulingv1beta1.PriorityClass.GlobalDefault has no validation
 	// field schedulingv1beta1.PriorityClass.Description has no validation
 	// field schedulingv1beta1.PriorityClass.PreemptionPolicy has no validation

--- a/pkg/apis/scheduling/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/scheduling/v1beta1/zz_generated.validations.go
@@ -25,6 +25,7 @@ import (
 	context "context"
 	fmt "fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	equality "k8s.io/apimachinery/pkg/api/equality"
 	operation "k8s.io/apimachinery/pkg/api/operation"
@@ -2034,7 +2035,39 @@ func Validate_PriorityClass(
 
 	// field schedulingv1beta1.PriorityClass.GlobalDefault has no validation
 	// field schedulingv1beta1.PriorityClass.Description has no validation
-	// field schedulingv1beta1.PriorityClass.PreemptionPolicy has no validation
+
+	{ // field schedulingv1beta1.PriorityClass.PreemptionPolicy
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *corev1.PreemptionPolicy,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *schedulingv1beta1.PriorityClass) *corev1.PreemptionPolicy {
+				return oldObj.PreemptionPolicy
+			})
+		errs = append(errs, fn(fldPath.Child("preemptionPolicy"), obj.PreemptionPolicy, oldVal, oldObj != nil)...)
+	}
+
 	return errs
 }
 

--- a/pkg/apis/scheduling/validation/validation.go
+++ b/pkg/apis/scheduling/validation/validation.go
@@ -65,9 +65,7 @@ func ValidatePriorityClassUpdate(pc, oldPc *scheduling.PriorityClass) field.Erro
 	// name is immutable and is checked by the ObjectMeta validator.
 	allErrs := apivalidation.ValidateObjectMetaUpdate(&pc.ObjectMeta, &oldPc.ObjectMeta, field.NewPath("metadata"))
 	// value is immutable.
-	if pc.Value != oldPc.Value {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("value"), "may not be changed in an update."))
-	}
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(pc.Value, oldPc.Value, field.NewPath("value")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
 	// preemptionPolicy is immutable.
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(pc.PreemptionPolicy, oldPc.PreemptionPolicy, field.NewPath("preemptionPolicy"))...)
 	return allErrs

--- a/pkg/apis/scheduling/validation/validation.go
+++ b/pkg/apis/scheduling/validation/validation.go
@@ -67,7 +67,7 @@ func ValidatePriorityClassUpdate(pc, oldPc *scheduling.PriorityClass) field.Erro
 	// value is immutable.
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(pc.Value, oldPc.Value, field.NewPath("value")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
 	// preemptionPolicy is immutable.
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(pc.PreemptionPolicy, oldPc.PreemptionPolicy, field.NewPath("preemptionPolicy"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(pc.PreemptionPolicy, oldPc.PreemptionPolicy, field.NewPath("preemptionPolicy")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
 	return allErrs
 }
 

--- a/pkg/apis/scheduling/validation/validation_test.go
+++ b/pkg/apis/scheduling/validation/validation_test.go
@@ -148,7 +148,7 @@ func TestValidatePriorityClassUpdate(t *testing.T) {
 				ObjectMeta:       metav1.ObjectMeta{Name: "tier1", Namespace: "", ResourceVersion: "2"},
 				PreemptionPolicy: &preemptLowerPriority,
 			},
-			T: field.ErrorTypeForbidden,
+			T: field.ErrorTypeInvalid,
 		},
 		"change value": {
 			P: scheduling.PriorityClass{
@@ -156,7 +156,7 @@ func TestValidatePriorityClassUpdate(t *testing.T) {
 				Value:            101,
 				PreemptionPolicy: &preemptLowerPriority,
 			},
-			T: field.ErrorTypeForbidden,
+			T: field.ErrorTypeInvalid,
 		},
 		"change preemptionPolicy": {
 			P: scheduling.PriorityClass{

--- a/staging/src/k8s.io/api/scheduling/v1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1/generated.proto
@@ -61,6 +61,8 @@ message PriorityClass {
   // One of Never, PreemptLowerPriority.
   // Defaults to PreemptLowerPriority if unset.
   // +optional
+  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:immutable
   optional string preemptionPolicy = 5;
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1/generated.proto
@@ -40,6 +40,8 @@ message PriorityClass {
   // value represents the integer value of this priority class. This is the actual priority that pods
   // receive when they have the name of this class in their pod spec.
   // +optional
+  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:immutable
   optional int32 value = 2;
 
   // globalDefault specifies whether this PriorityClass should be considered as

--- a/staging/src/k8s.io/api/scheduling/v1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1/types.go
@@ -59,6 +59,8 @@ type PriorityClass struct {
 	// One of Never, PreemptLowerPriority.
 	// Defaults to PreemptLowerPriority if unset.
 	// +optional
+	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:immutable
 	PreemptionPolicy *apiv1.PreemptionPolicy `json:"preemptionPolicy,omitempty" protobuf:"bytes,5,opt,name=preemptionPolicy"`
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1/types.go
@@ -38,6 +38,8 @@ type PriorityClass struct {
 	// value represents the integer value of this priority class. This is the actual priority that pods
 	// receive when they have the name of this class in their pod spec.
 	// +optional
+	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:immutable
 	Value int32 `json:"value" protobuf:"bytes,2,opt,name=value"`
 
 	// globalDefault specifies whether this PriorityClass should be considered as

--- a/staging/src/k8s.io/api/scheduling/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/generated.proto
@@ -702,6 +702,8 @@ message PriorityClass {
   // One of Never, PreemptLowerPriority.
   // Defaults to PreemptLowerPriority if unset.
   // +optional
+  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:immutable
   optional string preemptionPolicy = 5;
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/generated.proto
@@ -681,6 +681,8 @@ message PriorityClass {
   // value represents the integer value of this priority class. This is the actual priority that pods
   // receive when they have the name of this class in their pod spec.
   // +optional
+  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:immutable
   optional int32 value = 2;
 
   // globalDefault specifies whether this PriorityClass should be considered as

--- a/staging/src/k8s.io/api/scheduling/v1beta1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/types.go
@@ -42,6 +42,8 @@ type PriorityClass struct {
 	// value represents the integer value of this priority class. This is the actual priority that pods
 	// receive when they have the name of this class in their pod spec.
 	// +optional
+	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:immutable
 	Value int32 `json:"value" protobuf:"bytes,2,opt,name=value"`
 
 	// globalDefault specifies whether this PriorityClass should be considered as

--- a/staging/src/k8s.io/api/scheduling/v1beta1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/types.go
@@ -63,6 +63,8 @@ type PriorityClass struct {
 	// One of Never, PreemptLowerPriority.
 	// Defaults to PreemptLowerPriority if unset.
 	// +optional
+	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:immutable
 	PreemptionPolicy *apiv1.PreemptionPolicy `json:"preemptionPolicy,omitempty" protobuf:"bytes,5,opt,name=preemptionPolicy"`
 }
 

--- a/test/declarative_validation/scheduling/priorityclass/declarative_validation_test.go
+++ b/test/declarative_validation/scheduling/priorityclass/declarative_validation_test.go
@@ -20,7 +20,9 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	scheduling "k8s.io/kubernetes/pkg/apis/scheduling"
 	registry "k8s.io/kubernetes/pkg/registry/scheduling/priorityclass"
 	"k8s.io/kubernetes/test/declarative_validation/meta"
@@ -67,6 +69,45 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 		Verb:              "update",
 	})
 
+	testCases := map[string]struct {
+		oldObj       scheduling.PriorityClass
+		updateObj    scheduling.PriorityClass
+		expectedErrs field.ErrorList
+	}{
+		"valid update": {
+			oldObj:    mkPriorityClass(TweakValue(100)),
+			updateObj: mkPriorityClass(TweakValue(100)),
+		},
+		"invalid update value changed": {
+			oldObj:    mkPriorityClass(TweakValue(100)),
+			updateObj: mkPriorityClass(TweakValue(101)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("value"), nil, "").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
+		"invalid update value set from unset": {
+			oldObj:    mkPriorityClass(),
+			updateObj: mkPriorityClass(TweakValue(100)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("value"), nil, "").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
+		"invalid update value unset from set": {
+			oldObj:    mkPriorityClass(TweakValue(100)),
+			updateObj: mkPriorityClass(),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("value"), nil, "").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
+	}
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			tc.oldObj.ResourceVersion = "1"
+			tc.updateObj.ResourceVersion = "2"
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, registry.Strategy, tc.expectedErrs)
+		})
+	}
+
 	updateObj := mkPriorityClass()
 	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
@@ -81,4 +122,10 @@ func mkPriorityClass(tweaks ...func(pc *scheduling.PriorityClass)) scheduling.Pr
 		tweak(&pc)
 	}
 	return pc
+}
+
+func TweakValue(value int32) func(pc *scheduling.PriorityClass) {
+	return func(pc *scheduling.PriorityClass) {
+		pc.Value = value
+	}
 }

--- a/test/declarative_validation/scheduling/priorityclass/declarative_validation_test.go
+++ b/test/declarative_validation/scheduling/priorityclass/declarative_validation_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	core "k8s.io/kubernetes/pkg/apis/core"
 	scheduling "k8s.io/kubernetes/pkg/apis/scheduling"
 	registry "k8s.io/kubernetes/pkg/registry/scheduling/priorityclass"
 	"k8s.io/kubernetes/test/declarative_validation/meta"
@@ -99,6 +100,27 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				field.Invalid(field.NewPath("value"), nil, "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
+		"invalid update preemptionPolicy changed": {
+			oldObj:    mkPriorityClass(TweakPreemptionPolicy(core.PreemptLowerPriority)),
+			updateObj: mkPriorityClass(TweakPreemptionPolicy(core.PreemptNever)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("preemptionPolicy"), nil, "").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
+		"invalid update preemptionPolicy set from unset": {
+			oldObj:    mkPriorityClass(),
+			updateObj: mkPriorityClass(TweakPreemptionPolicy(core.PreemptLowerPriority)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("preemptionPolicy"), nil, "").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
+		"invalid update preemptionPolicy unset from set": {
+			oldObj:    mkPriorityClass(TweakPreemptionPolicy(core.PreemptLowerPriority)),
+			updateObj: mkPriorityClass(),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("preemptionPolicy"), nil, "").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
 	}
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
@@ -127,5 +149,11 @@ func mkPriorityClass(tweaks ...func(pc *scheduling.PriorityClass)) scheduling.Pr
 func TweakValue(value int32) func(pc *scheduling.PriorityClass) {
 	return func(pc *scheduling.PriorityClass) {
 		pc.Value = value
+	}
+}
+
+func TweakPreemptionPolicy(policy core.PreemptionPolicy) func(pc *scheduling.PriorityClass) {
+	return func(pc *scheduling.PriorityClass) {
+		pc.PreemptionPolicy = &policy
 	}
 }

--- a/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1_test.go
@@ -61,6 +61,9 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"value": {
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
+			},
 		},
 	)
 }

--- a/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1_test.go
@@ -61,6 +61,9 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"preemptionPolicy": {
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
+			},
 			"value": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1beta1_test.go
@@ -61,6 +61,9 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"value": {
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
+			},
 		},
 	)
 }

--- a/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1beta1_test.go
@@ -61,6 +61,9 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"preemptionPolicy": {
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
+			},
 			"value": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Migrates two immutable PriorityClass fields from handwritten validation to declarative validation tags, as tracked in #136785:

- **`PriorityClass.Value`** (commit 1): adds `+k8s:immutable` (v1, v1beta1) and marks the handwritten check in `ValidatePriorityClassUpdate` as covered by declarative validation.
- **`PriorityClass.PreemptionPolicy`** (commit 2): same treatment; this check already used `ValidateImmutableField`, so its reported errors are unchanged.

Note on `Value`: the handwritten check returned `field.Forbidden(..., "may not be changed in an update.")`, while declarative validation reports `field.Invalid(..., "field is immutable")` with origin `immutable`. To keep the handwritten and declarative results equivalent, the handwritten check now uses `ValidateImmutableField`. As a result, an update that changes `value` now reports an `Invalid` error instead of a `Forbidden` error, consistent with `preemptionPolicy` and other immutable fields.

#### Which issue(s) this PR fixes:

Part of #136785

#### Special notes for your reviewer:

- Each field is a separate commit, following the PR structure guidance in #136785.
- Declarative equivalence tests added in `test/declarative_validation/scheduling/priorityclass/declarative_validation_test.go` cover changed / set-from-unset / unset-from-set transitions for both fields.
- The existing handwritten test expectations in `pkg/apis/scheduling/validation/validation_test.go` were updated for the `Forbidden` -> `Invalid` change on `value`.

#### Does this PR introduce a user-facing change?

```release-note
Updating a PriorityClass `value` now reports an `Invalid` error (origin: `immutable`) instead of a `Forbidden` error when the update changes the value. The field remains immutable; only the reported error type and message change.
```
