### PR TITLE
Fix Scheduler Preemption Ignoring Empty PDB Selectors

### DIFF
--- a/pkg/scheduler/framework/preemption/util.go
+++ b/pkg/scheduler/framework/preemption/util.go
@@ -208,10 +208,6 @@ func GetPodPriority(p *v1.Pod, podGroupLister fwk.PodGroupLister, compositePodGr
 func FilterVictimsWithPDBViolation[T Victim](victims []T, pdbs []*policy.PodDisruptionBudget) (violatingVictims []ViolatingVictim[T], nonViolatingVictims []T) {
 	pdbsAllowed := make([]int32, len(pdbs))
 	podIsViolating := func(pod *v1.Pod) bool {
-		if len(pod.Labels) == 0 {
-			return false
-		}
-
 		for i, pdb := range pdbs {
 			if pdb.Namespace != pod.Namespace {
 				continue
@@ -221,8 +217,7 @@ func FilterVictimsWithPDBViolation[T Victim](victims []T, pdbs []*policy.PodDisr
 				// This object has an invalid selector, it does not match the pod
 				continue
 			}
-			// A PDB with a nil or empty selector matches nothing.
-			if selector.Empty() || !selector.Matches(labels.Set(pod.Labels)) {
+			if !selector.Matches(labels.Set(pod.Labels)) {
 				continue
 			}
 

--- a/pkg/scheduler/framework/preemption/util_test.go
+++ b/pkg/scheduler/framework/preemption/util_test.go
@@ -41,6 +41,7 @@ func TestFilterVictimsWithPDBViolation(t *testing.T) {
 	viNoPDBMatch := &victim{pods: []fwk.PodInfo{newPodInfo(st.MakePod().Name("p1").Label("app", "foo").Obj())}, keyType: fwk.PodKeyType}
 	viMatchPDB := &victim{pods: []fwk.PodInfo{newPodInfo(st.MakePod().Name("p1").Namespace(metav1.NamespaceDefault).Label("app", "foo").Obj())}, keyType: fwk.PodKeyType}
 	viMatchPDB2 := &victim{pods: []fwk.PodInfo{newPodInfo(st.MakePod().Name("p2").Namespace(metav1.NamespaceDefault).Label("app", "foo").Obj())}, keyType: fwk.PodKeyType}
+	viNoLabels := &victim{pods: []fwk.PodInfo{newPodInfo(st.MakePod().Name("p1").Namespace(metav1.NamespaceDefault).Obj())}, keyType: fwk.PodKeyType}
 	viPodGroup := &victim{
 		pods: []fwk.PodInfo{
 			newPodInfo(st.MakePod().Name("p1").Namespace(metav1.NamespaceDefault).Label("app", "foo").Obj()),
@@ -205,7 +206,29 @@ func TestFilterVictimsWithPDBViolation(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
 					Spec: policy.PodDisruptionBudgetSpec{
-						Selector: &metav1.LabelSelector{}, // matches nothing
+						Selector: &metav1.LabelSelector{},
+					},
+					Status: policy.PodDisruptionBudgetStatus{
+						DisruptionsAllowed: 0,
+					},
+				},
+			},
+			expectedViolating: []ViolatingVictim[*victim]{
+				{
+					Victim:       viMatchPDB,
+					ViolateCount: 1,
+				},
+			},
+			expectedNonViolating: nil,
+		},
+		{
+			name:    "PDB with nil selector",
+			victims: []*victim{viMatchPDB},
+			pdbs: []*policy.PodDisruptionBudget{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
+					Spec: policy.PodDisruptionBudgetSpec{
+						Selector: nil,
 					},
 					Status: policy.PodDisruptionBudgetStatus{
 						DisruptionsAllowed: 0,
@@ -214,6 +237,74 @@ func TestFilterVictimsWithPDBViolation(t *testing.T) {
 			},
 			expectedViolating:    nil,
 			expectedNonViolating: []*victim{viMatchPDB},
+		},
+		{
+			name:    "unlabeled victim with empty PDB selector",
+			victims: []*victim{viNoLabels},
+			pdbs: []*policy.PodDisruptionBudget{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
+					Spec: policy.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{},
+					},
+					Status: policy.PodDisruptionBudgetStatus{
+						DisruptionsAllowed: 0,
+					},
+				},
+			},
+			expectedViolating: []ViolatingVictim[*victim]{
+				{
+					Victim:       viNoLabels,
+					ViolateCount: 1,
+				},
+			},
+			expectedNonViolating: nil,
+		},
+		{
+			name:    "unlabeled victim with nil PDB selector",
+			victims: []*victim{viNoLabels},
+			pdbs: []*policy.PodDisruptionBudget{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
+					Spec: policy.PodDisruptionBudgetSpec{
+						Selector: nil,
+					},
+					Status: policy.PodDisruptionBudgetStatus{
+						DisruptionsAllowed: 0,
+					},
+				},
+			},
+			expectedViolating:    nil,
+			expectedNonViolating: []*victim{viNoLabels},
+		},
+		{
+			name:    "unlabeled victim matching PDB",
+			victims: []*victim{viNoLabels},
+			pdbs: []*policy.PodDisruptionBudget{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault},
+					Spec: policy.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "app",
+									Operator: metav1.LabelSelectorOpDoesNotExist,
+								},
+							},
+						},
+					},
+					Status: policy.PodDisruptionBudgetStatus{
+						DisruptionsAllowed: 0,
+					},
+				},
+			},
+			expectedViolating: []ViolatingVictim[*victim]{
+				{
+					Victim:       viNoLabels,
+					ViolateCount: 1,
+				},
+			},
+			expectedNonViolating: nil,
 		},
 		{
 			name:    "Multiple PDBs",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

Kubernetes documentation describes following PodDisruptionBudget behavior:

```
// https://kubernetes.io/docs/tasks/run-application/configure-pdb/
Note:
The behavior for an empty selector differs between the policy/v1beta1 
and policy/v1 APIs for PodDisruptionBudgets. For policy/v1beta1 an 
empty selector matches zero pods, while for policy/v1 an empty 
selector matches every pod in the namespace.
```

For a `policy/v1` PodDisruptionBudget, `spec.selector: {}` selects every Pod in PDB's namespace, including unlabeled Pods. Scheduler preemption logic contains two checks inconsistent with this behavior.

1.  directly skips unlabeled Pods:

```
if len(pod.Labels) == 0 {
    return false
}
```

This can prevent `spec.selector: {}` from taking effect for unlabeled Pods, causing PDB protection to be ignored. 

2. incorrectly uses `selector.Empty()` to determine whether PDB selector matches no Pods:

```
if selector.Empty() || !selector.Matches(labels.Set(pod.Labels)) {
    continue
}
```

`selector.Empty()` means selector imposes no restrictions; it does not mean selector matches no objects. PDB selectors are converted as follows:

```
policy/v1 spec.selector: {}  → labels.Everything() → Empty() == true
policy/v1 spec.selector: nil → labels.Nothing()    → Empty() == false
```

As a result, original code incorrectly skips a `policy/v1` PDB with `selector: {}`, causing its match-all protection semantics to be ignored during scheduler preemption calculations.

For `selector: nil`, `Empty()` returns `false`, but subsequent `Matches()` call returns `false`, so selector is still skipped correctly.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed preemption algorithm in kube-scheduler so that it no longer ignores a PodDisruptionBudget with an empty selector.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
