### PR TITLE
DV:Migrate Objectmeta resourceVersion to DV

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
@@ -344,7 +344,7 @@ func ValidateObjectMetaAccessorUpdate(newMeta, oldMeta metav1.Object, fldPath *f
 
 	// Reject updates that don't specify a resource version
 	if len(newMeta.GetResourceVersion()) == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("resourceVersion"), newMeta.GetResourceVersion(), "must be specified for an update"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("resourceVersion"), newMeta.GetResourceVersion(), "must be specified for an update").WithOrigin("update").MarkCoveredByDeclarative())
 	}
 
 	// Generation shouldn't be decremented

--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta_test.go
@@ -896,6 +896,15 @@ func TestValidateObjectMetaDeclaratively(t *testing.T) {
 				field.Invalid(fldPath.Child("deletionGracePeriodSeconds"), &gracePeriod40, "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
+		{
+			name:              "missing resourceVersion on update",
+			obj:               mkMeta(tweakResourceVersion("")),
+			oldObj:            mkMeta(tweakResourceVersion("1")),
+			requiresNamespace: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("resourceVersion"), "", "must be specified for an update").WithOrigin("update").MarkAlpha(),
+			},
+		},
 	}
 
 	for _, tc := range updateCases {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -828,6 +828,8 @@ message ObjectMeta {
   // Value must be treated as opaque by clients and .
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
   // +optional
+  // +k8s:alpha(since: "1.38")=+k8s:optional
+  // +k8s:alpha(since: "1.38")=+k8s:update=NoUnset
   optional string resourceVersion = 6;
 
   // A sequence number representing a specific generation of the desired state.

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -191,6 +191,8 @@ type ObjectMeta struct {
 	// Value must be treated as opaque by clients and .
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
 	// +optional
+	// +k8s:alpha(since: "1.38")=+k8s:optional
+	// +k8s:alpha(since: "1.38")=+k8s:update=NoUnset
 	ResourceVersion string `json:"resourceVersion,omitempty" protobuf:"bytes,6,opt,name=resourceVersion"`
 
 	// A sequence number representing a specific generation of the desired state.

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
@@ -312,7 +312,37 @@ func Validate_ObjectMeta(
 		errs = append(errs, fn(fldPath.Child("uid"), &obj.UID, oldVal, oldObj != nil)...)
 	}
 
-	// field v1.ObjectMeta.ResourceVersion has no validation
+	{ // field v1.ObjectMeta.ResourceVersion
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoUnset).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *v1.ObjectMeta) *string {
+				return &oldObj.ResourceVersion
+			})
+		errs = append(errs, fn(fldPath.Child("resourceVersion"), &obj.ResourceVersion, oldVal, oldObj != nil)...)
+	}
 
 	{ // field v1.ObjectMeta.Generation
 		fn := func(

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1alpha1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/admissionregistration/mutatingwebhookconfiguration/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingwebhookconfiguration/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/admissionregistration/mutatingwebhookconfiguration/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingwebhookconfiguration/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1alpha1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/admissionregistration/validatingwebhookconfiguration/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingwebhookconfiguration/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/admissionregistration/validatingwebhookconfiguration/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingwebhookconfiguration/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1beta2_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/apps/daemonset/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/daemonset/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/apps/daemonset/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/daemonset/zz_generated.validations.v1beta2_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/apps/deployment/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/deployment/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta2_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/apps/replicaset/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/replicaset/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/apps/replicaset/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/replicaset/zz_generated.validations.v1beta2_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/apps/statefulset/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/statefulset/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/apps/statefulset/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/apps/statefulset/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/apps/statefulset/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/statefulset/zz_generated.validations.v1beta2_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/autoscaling/horizontalpodautoscaler/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/autoscaling/horizontalpodautoscaler/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/autoscaling/horizontalpodautoscaler/zz_generated.validations.v2_test.go
+++ b/test/declarative_validation/autoscaling/horizontalpodautoscaler/zz_generated.validations.v2_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/batch/cronjob/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/batch/cronjob/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/batch/cronjob/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/batch/cronjob/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/batch/job/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/batch/job/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/certificates/certificatesigningrequest/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/certificates/certificatesigningrequest/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/certificates/certificatesigningrequest/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/certificates/certificatesigningrequest/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/certificates/clustertrustbundle/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/certificates/clustertrustbundle/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/certificates/clustertrustbundle/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/certificates/clustertrustbundle/zz_generated.validations.v1alpha1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/certificates/clustertrustbundle/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/certificates/clustertrustbundle/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/coordination/lease/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/coordination/lease/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/coordination/lease/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/coordination/lease/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1alpha2_test.go
+++ b/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1alpha2_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/core/configmap/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/configmap/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/core/endpoints/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/endpoints/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/core/event/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/event/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/core/limitrange/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/limitrange/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/core/namespace/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/namespace/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/core/node/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/node/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/core/persistentvolume/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/persistentvolume/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/core/persistentvolumeclaim/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/persistentvolumeclaim/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/core/pod/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/pod/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/core/podtemplate/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/podtemplate/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/core/replicationcontroller/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/replicationcontroller/zz_generated.validations.v1_test.go
@@ -61,6 +61,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/core/resourcequota/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/resourcequota/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/core/secret/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/secret/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/core/service/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/service/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/core/serviceaccount/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/serviceaccount/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/discovery/endpointslice/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/discovery/endpointslice/zz_generated.validations.v1_test.go
@@ -67,6 +67,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/discovery/endpointslice/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/discovery/endpointslice/zz_generated.validations.v1beta1_test.go
@@ -67,6 +67,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/events/event/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/events/event/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta2_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta3_test.go
+++ b/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta3_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta2_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta3_test.go
+++ b/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta3_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/internal/storageversion/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/internal/storageversion/zz_generated.validations.v1alpha1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/lifecycle/eviction/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/lifecycle/eviction/zz_generated.validations.v1alpha1_test.go
@@ -61,6 +61,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/lifecycle/evictionrequest/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/lifecycle/evictionrequest/zz_generated.validations.v1alpha1_test.go
@@ -61,6 +61,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/meta/objectmeta.go
+++ b/test/declarative_validation/meta/objectmeta.go
@@ -529,7 +529,7 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 				new.SetResourceVersion("")
 			},
 			ExpectedErrs: field.ErrorList{
-				field.Invalid(fldPath.Child("resourceVersion"), "", "must be specified for an update").MarkFromImperative(),
+				field.Invalid(fldPath.Child("resourceVersion"), "", "must be specified for an update").WithOrigin("update").MarkAlpha(),
 			},
 		},
 		{

--- a/test/declarative_validation/networking/ingress/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/networking/ingress/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/networking/ingress/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/networking/ingress/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/networking/ipaddress/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/networking/ipaddress/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/networking/ipaddress/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/networking/ipaddress/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/networking/networkpolicy/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/networking/networkpolicy/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/networking/servicecidr/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/networking/servicecidr/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/networking/servicecidr/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/networking/servicecidr/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1_test.go
@@ -63,6 +63,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1alpha1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1beta1_test.go
@@ -63,6 +63,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1alpha1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1alpha1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/rbac/role/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/rbac/role/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/rbac/role/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/rbac/role/zz_generated.validations.v1alpha1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/rbac/role/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/rbac/role/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1alpha1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1_test.go
@@ -61,6 +61,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1beta1_test.go
@@ -61,6 +61,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1beta2_test.go
@@ -61,6 +61,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1alpha3_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1beta2_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta2_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1beta2_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/resource/resourcepoolstatusrequest/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/resource/resourcepoolstatusrequest/zz_generated.validations.v1alpha3_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1beta2_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/scheduling/compositepodgroup/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/scheduling/compositepodgroup/zz_generated.validations.v1alpha3_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1alpha3_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/scheduling/workload/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/scheduling/workload/zz_generated.validations.v1alpha3_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/scheduling/workload/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/scheduling/workload/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/storage/csidriver/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/csidriver/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/storage/csidriver/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/csidriver/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/storage/csinode/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/csinode/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/storage/csinode/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/csinode/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1alpha1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/storage/storageclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/storageclass/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/storage/storageclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/storageclass/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1alpha1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1alpha1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},

--- a/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1beta1_test.go
@@ -58,6 +58,9 @@ func init() {
 			"metadata.ownerReferences[*].uid": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"metadata.resourceVersion": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR migrates the `objectMeta.resourceVersion` check `must be specified for an update` to DV. 

DV tags added:
+k8s:optional
+k8s:update=NoUnset


#### Which issue(s) this PR is related to:
part of #141634

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
