### PR TITLE
client-go: let multiple providers register rest client metrics

### DIFF
--- a/staging/src/k8s.io/client-go/tools/metrics/metrics.go
+++ b/staging/src/k8s.io/client-go/tools/metrics/metrics.go
@@ -22,25 +22,52 @@ import (
 	"context"
 	"net/url"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
+// registerFnEntry pairs a RegisterFn installed via RegisterOpts with its own
+// sync.Once, so each callback runs exactly once even when it is registered
+// after EnsureRegistered has already run. Running one more than once would
+// re-register with legacyregistry, which panics on duplicates.
+type registerFnEntry struct {
+	once sync.Once
+	fn   func()
+}
+
 var (
-	registerMetrics      sync.Once
-	ensureRegisteredOnce sync.Once
-	// ensureRegisteredFn, if set via RegisterOpts.RegisterFn, is invoked
-	// exactly once before any rest client is constructed. Adapter packages
-	// (e.g. k8s.io/component-base/metrics/prometheus/restclient) install
-	// this callback in their init() so that the actual registration with
-	// legacyregistry — and the metric Create() that reads
-	// feature-gate-derived options like NativeHistograms — happens at
-	// runtime rather than at init() time. See EnsureRegistered for the
-	// caller-side contract.
-	ensureRegisteredFn func()
+	// registerLock guards the write path of Register and the registration
+	// state below. The exported metric hooks are read from the request path
+	// without synchronization, so Register must be called before any rest
+	// client is constructed; see the Register documentation.
+	registerLock sync.Mutex
+
+	// registerFns holds every callback installed via RegisterOpts.RegisterFn.
+	// Adapter packages (e.g. k8s.io/component-base/metrics/prometheus/restclient)
+	// install these in their init() so that the actual registration with
+	// legacyregistry — and the metric Create() that reads feature-gate-derived
+	// options like NativeHistograms — happens at runtime rather than at init()
+	// time. See EnsureRegistered for the caller-side contract.
+	//
+	// It is only ever replaced, never appended to in place, so EnsureRegistered
+	// can range over a snapshot of it without holding registerLock.
+	registerFns []*registerFnEntry
+
+	// ensureRegisteredStarted records whether EnsureRegistered has run at least
+	// once. Once it has, a callback registered afterwards is invoked
+	// immediately rather than waiting for a call that may never come. It is
+	// atomic because the lock-free fast path in EnsureRegistered has to record
+	// it without taking registerLock.
+	ensureRegisteredStarted atomic.Bool
+
+	// registerFnsPending is the lock-free fast path for EnsureRegistered, which
+	// adapters call on every observation. Its zero value, false, means there is
+	// nothing left to invoke.
+	registerFnsPending atomic.Bool
 )
 
-// EnsureRegistered invokes the callback installed via RegisterOpts.RegisterFn (if
-// any) exactly once. Callers should treat it as idempotent; subsequent calls are
+// EnsureRegistered invokes the callbacks installed via RegisterOpts.RegisterFn,
+// each exactly once. Callers should treat it as idempotent; subsequent calls are
 // effectively free.
 //
 // New public constructors or entry points for packages in client-go that create
@@ -51,10 +78,39 @@ var (
 // "first-observation" to "first client construction", meaning the metric
 // series is visible to Promteheus scrapes from process startup rather than
 // appearing only after the first request.
+//
+// A RegisterFn must not itself call Register or EnsureRegistered.
 func EnsureRegistered() {
-	if ensureRegisteredFn != nil {
-		ensureRegisteredOnce.Do(ensureRegisteredFn)
+	// Record that registration time has passed even when there is nothing to
+	// invoke, so that a provider registering later knows no further
+	// EnsureRegistered call is guaranteed. Tested before storing to keep the
+	// steady-state path read-only rather than writing the same cache line from
+	// every request on every core.
+	if !ensureRegisteredStarted.Load() {
+		ensureRegisteredStarted.Store(true)
 	}
+
+	if !registerFnsPending.Load() {
+		return
+	}
+
+	registerLock.Lock()
+	entries := registerFns
+	registerLock.Unlock()
+
+	// Callbacks run outside registerLock: they call back into metric
+	// registries and must not be serialized behind the registration state.
+	for _, entry := range entries {
+		entry.once.Do(entry.fn)
+	}
+
+	registerLock.Lock()
+	// Anything registered while the callbacks above were running is not
+	// covered by this pass, so leave the fast path armed for it.
+	if len(registerFns) == len(entries) {
+		registerFnsPending.Store(false)
+	}
+	registerLock.Unlock()
 }
 
 // DurationMetric is a measurement of some amount of time.
@@ -198,65 +254,106 @@ type RegisterOpts struct {
 	// before the first rest client is constructed. Adapters use this to defer
 	// registrations that depend on runtime state (eg., feature gates read my metric
 	// Create() without changing the import side contract of the adapter package.)
+	//
+	// Callbacks from multiple Register calls are all retained and each is
+	// invoked exactly once. A callback registered after EnsureRegistered has
+	// already run is invoked by Register itself, since no further
+	// EnsureRegistered call is guaranteed. It must not call Register or
+	// EnsureRegistered.
 	RegisterFn func()
 }
 
-// Register registers metrics for the rest client to use. This can
-// only be called once.
+// Register adds the metrics in opts to those the rest client and its transports
+// update. It may be called by more than one provider: every registered metric
+// receives every observation. Nil fields in opts are ignored.
+//
+// Earlier releases applied only the first call to Register and silently
+// ignored every later caller.
+//
+// Register should be called before any REST client, HTTP transport, or
+// credential provider is constructed, typically from an init function: the
+// metrics it installs are read from the request path without synchronization,
+// and values already captured by existing clients are not updated
+// retroactively. Registering the same metric more than once records each
+// observation once per registration.
 func Register(opts RegisterOpts) {
-	registerMetrics.Do(func() {
-		if opts.ClientCertExpiry != nil {
-			ClientCertExpiry = opts.ClientCertExpiry
-		}
-		if opts.ClientCertRotationAge != nil {
-			ClientCertRotationAge = opts.ClientCertRotationAge
-		}
-		if opts.RequestLatency != nil {
-			RequestLatency = opts.RequestLatency
-		}
-		if opts.ResolverLatency != nil {
-			ResolverLatency = opts.ResolverLatency
-		}
-		if opts.RequestSize != nil {
-			RequestSize = opts.RequestSize
-		}
-		if opts.ResponseSize != nil {
-			ResponseSize = opts.ResponseSize
-		}
-		if opts.RateLimiterLatency != nil {
-			RateLimiterLatency = opts.RateLimiterLatency
-		}
-		if opts.RequestResult != nil {
-			RequestResult = opts.RequestResult
-		}
-		if opts.ExecPluginCalls != nil {
-			ExecPluginCalls = opts.ExecPluginCalls
-		}
-		if opts.ExecPluginPolicyCalls != nil {
-			ExecPluginPolicyCalls = opts.ExecPluginPolicyCalls
-		}
-		if opts.RequestRetry != nil {
-			RequestRetry = opts.RequestRetry
-		}
-		if opts.TransportCacheEntries != nil {
-			TransportCacheEntries = opts.TransportCacheEntries
-		}
-		if opts.TransportCreateCalls != nil {
-			TransportCreateCalls = opts.TransportCreateCalls
-		}
-		if opts.TransportCAReloads != nil {
-			TransportCAReloads = opts.TransportCAReloads
-		}
-		if opts.TransportCertRotationGCCalls != nil {
-			TransportCertRotationGCCalls = opts.TransportCertRotationGCCalls
-		}
-		if opts.TransportCacheGCCalls != nil {
-			TransportCacheGCCalls = opts.TransportCacheGCCalls
-		}
-		if opts.RegisterFn != nil {
-			ensureRegisteredFn = opts.RegisterFn
-		}
-	})
+	registerLock.Lock()
+
+	// Each hook is written only when there is something to add. The combine
+	// helpers already ignore a nil addition, but the assignment itself would
+	// still be a write, and these are read from the request path without
+	// synchronization.
+	if opts.ClientCertExpiry != nil {
+		ClientCertExpiry = combineExpiry(ClientCertExpiry, opts.ClientCertExpiry)
+	}
+	if opts.ClientCertRotationAge != nil {
+		ClientCertRotationAge = combineDuration(ClientCertRotationAge, opts.ClientCertRotationAge)
+	}
+	if opts.RequestLatency != nil {
+		RequestLatency = combineLatency(RequestLatency, opts.RequestLatency)
+	}
+	if opts.ResolverLatency != nil {
+		ResolverLatency = combineResolverLatency(ResolverLatency, opts.ResolverLatency)
+	}
+	if opts.RequestSize != nil {
+		RequestSize = combineSize(RequestSize, opts.RequestSize)
+	}
+	if opts.ResponseSize != nil {
+		ResponseSize = combineSize(ResponseSize, opts.ResponseSize)
+	}
+	if opts.RateLimiterLatency != nil {
+		RateLimiterLatency = combineLatency(RateLimiterLatency, opts.RateLimiterLatency)
+	}
+	if opts.RequestResult != nil {
+		RequestResult = combineResult(RequestResult, opts.RequestResult)
+	}
+	if opts.ExecPluginCalls != nil {
+		ExecPluginCalls = combineCalls(ExecPluginCalls, opts.ExecPluginCalls)
+	}
+	if opts.ExecPluginPolicyCalls != nil {
+		ExecPluginPolicyCalls = combinePolicy(ExecPluginPolicyCalls, opts.ExecPluginPolicyCalls)
+	}
+	if opts.RequestRetry != nil {
+		RequestRetry = combineRetry(RequestRetry, opts.RequestRetry)
+	}
+	if opts.TransportCacheEntries != nil {
+		TransportCacheEntries = combineTransportCache(TransportCacheEntries, opts.TransportCacheEntries)
+	}
+	if opts.TransportCreateCalls != nil {
+		TransportCreateCalls = combineTransportCreateCalls(TransportCreateCalls, opts.TransportCreateCalls)
+	}
+	if opts.TransportCAReloads != nil {
+		TransportCAReloads = combineTransportCAReloads(TransportCAReloads, opts.TransportCAReloads)
+	}
+	if opts.TransportCertRotationGCCalls != nil {
+		TransportCertRotationGCCalls = combineTransportCertRotationGCCalls(TransportCertRotationGCCalls, opts.TransportCertRotationGCCalls)
+	}
+	if opts.TransportCacheGCCalls != nil {
+		TransportCacheGCCalls = combineTransportCacheGCCalls(TransportCacheGCCalls, opts.TransportCacheGCCalls)
+	}
+
+	fireNow := false
+	if opts.RegisterFn != nil {
+		// Copy rather than append in place: EnsureRegistered ranges over the
+		// current slice without holding registerLock.
+		next := make([]*registerFnEntry, len(registerFns)+1)
+		copy(next, registerFns)
+		next[len(registerFns)] = &registerFnEntry{fn: opts.RegisterFn}
+		registerFns = next
+		registerFnsPending.Store(true)
+
+		// RegisterFn is deliberately not invoked here. Adapters install it so
+		// that registration happens at first client construction, once
+		// feature gates are set; firing it now would defeat that. Fire it
+		// only if that moment has already passed, because no further
+		// EnsureRegistered call is guaranteed.
+		fireNow = ensureRegisteredStarted.Load()
+	}
+	registerLock.Unlock()
+
+	if fireNow {
+		EnsureRegistered()
+	}
 }
 
 type noopDuration struct{}

--- a/staging/src/k8s.io/client-go/tools/metrics/metrics_test.go
+++ b/staging/src/k8s.io/client-go/tools/metrics/metrics_test.go
@@ -1,0 +1,619 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"net/url"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// These tests mutate package-level state, so none of them call t.Parallel.
+
+// Each metric interface needs its own counting implementation: Observe and
+// Increment are overloaded across the interfaces with different signatures, so
+// a single fake cannot satisfy all of them.
+
+type countExpiry struct{ n *atomic.Int32 }
+
+func (c countExpiry) Set(*time.Time) { c.n.Add(1) }
+
+type countDuration struct{ n *atomic.Int32 }
+
+func (c countDuration) Observe(time.Duration) { c.n.Add(1) }
+
+type countLatency struct{ n *atomic.Int32 }
+
+func (c countLatency) Observe(context.Context, string, url.URL, time.Duration) { c.n.Add(1) }
+
+type countResolverLatency struct{ n *atomic.Int32 }
+
+func (c countResolverLatency) Observe(context.Context, string, time.Duration) { c.n.Add(1) }
+
+type countSize struct{ n *atomic.Int32 }
+
+func (c countSize) Observe(context.Context, string, string, float64) { c.n.Add(1) }
+
+type countResult struct{ n *atomic.Int32 }
+
+func (c countResult) Increment(context.Context, string, string, string) { c.n.Add(1) }
+
+type countCalls struct{ n *atomic.Int32 }
+
+func (c countCalls) Increment(int, string) { c.n.Add(1) }
+
+type countPolicy struct{ n *atomic.Int32 }
+
+func (c countPolicy) Increment(string) { c.n.Add(1) }
+
+type countRetry struct{ n *atomic.Int32 }
+
+func (c countRetry) IncrementRetry(context.Context, string, string, string) { c.n.Add(1) }
+
+type countTransportCache struct{ n *atomic.Int32 }
+
+func (c countTransportCache) Observe(int) { c.n.Add(1) }
+
+type countTransportCreateCalls struct{ n *atomic.Int32 }
+
+func (c countTransportCreateCalls) Increment(string) { c.n.Add(1) }
+
+type countTransportCAReloads struct{ n *atomic.Int32 }
+
+func (c countTransportCAReloads) Increment(string, string) { c.n.Add(1) }
+
+type countTransportCertRotationGCCalls struct{ n *atomic.Int32 }
+
+func (c countTransportCertRotationGCCalls) Increment() { c.n.Add(1) }
+
+type countTransportCacheGCCalls struct{ n *atomic.Int32 }
+
+func (c countTransportCacheGCCalls) Increment(string) { c.n.Add(1) }
+
+// counters holds one counter per exported hook, plus one for RegisterFn.
+type counters struct {
+	clientCertExpiry             atomic.Int32
+	clientCertRotationAge        atomic.Int32
+	requestLatency               atomic.Int32
+	resolverLatency              atomic.Int32
+	requestSize                  atomic.Int32
+	responseSize                 atomic.Int32
+	rateLimiterLatency           atomic.Int32
+	requestResult                atomic.Int32
+	execPluginCalls              atomic.Int32
+	execPluginPolicyCalls        atomic.Int32
+	requestRetry                 atomic.Int32
+	transportCacheEntries        atomic.Int32
+	transportCreateCalls         atomic.Int32
+	transportCAReloads           atomic.Int32
+	transportCertRotationGCCalls atomic.Int32
+	transportCacheGCCalls        atomic.Int32
+
+	registerFn atomic.Int32
+}
+
+// metrics returns the per-hook counts, excluding registerFn.
+func (c *counters) metrics() map[string]int32 {
+	return map[string]int32{
+		"ClientCertExpiry":             c.clientCertExpiry.Load(),
+		"ClientCertRotationAge":        c.clientCertRotationAge.Load(),
+		"RequestLatency":               c.requestLatency.Load(),
+		"ResolverLatency":              c.resolverLatency.Load(),
+		"RequestSize":                  c.requestSize.Load(),
+		"ResponseSize":                 c.responseSize.Load(),
+		"RateLimiterLatency":           c.rateLimiterLatency.Load(),
+		"RequestResult":                c.requestResult.Load(),
+		"ExecPluginCalls":              c.execPluginCalls.Load(),
+		"ExecPluginPolicyCalls":        c.execPluginPolicyCalls.Load(),
+		"RequestRetry":                 c.requestRetry.Load(),
+		"TransportCacheEntries":        c.transportCacheEntries.Load(),
+		"TransportCreateCalls":         c.transportCreateCalls.Load(),
+		"TransportCAReloads":           c.transportCAReloads.Load(),
+		"TransportCertRotationGCCalls": c.transportCertRotationGCCalls.Load(),
+		"TransportCacheGCCalls":        c.transportCacheGCCalls.Load(),
+	}
+}
+
+// newCountingOpts returns a RegisterOpts with every field populated by a
+// distinct counting metric, along with the counters they increment.
+func newCountingOpts() (RegisterOpts, *counters) {
+	c := &counters{}
+	return RegisterOpts{
+		ClientCertExpiry:             countExpiry{&c.clientCertExpiry},
+		ClientCertRotationAge:        countDuration{&c.clientCertRotationAge},
+		RequestLatency:               countLatency{&c.requestLatency},
+		ResolverLatency:              countResolverLatency{&c.resolverLatency},
+		RequestSize:                  countSize{&c.requestSize},
+		ResponseSize:                 countSize{&c.responseSize},
+		RateLimiterLatency:           countLatency{&c.rateLimiterLatency},
+		RequestResult:                countResult{&c.requestResult},
+		ExecPluginCalls:              countCalls{&c.execPluginCalls},
+		ExecPluginPolicyCalls:        countPolicy{&c.execPluginPolicyCalls},
+		RequestRetry:                 countRetry{&c.requestRetry},
+		TransportCacheEntries:        countTransportCache{&c.transportCacheEntries},
+		TransportCreateCalls:         countTransportCreateCalls{&c.transportCreateCalls},
+		TransportCAReloads:           countTransportCAReloads{&c.transportCAReloads},
+		TransportCertRotationGCCalls: countTransportCertRotationGCCalls{&c.transportCertRotationGCCalls},
+		TransportCacheGCCalls:        countTransportCacheGCCalls{&c.transportCacheGCCalls},
+		RegisterFn:                   func() { c.registerFn.Add(1) },
+	}, c
+}
+
+// invokeAllHooks calls every exported metric hook exactly once.
+func invokeAllHooks() {
+	ctx := context.Background()
+	now := time.Now()
+	u := url.URL{Scheme: "https", Host: "example.com"}
+
+	ClientCertExpiry.Set(&now)
+	ClientCertRotationAge.Observe(time.Second)
+	RequestLatency.Observe(ctx, "GET", u, time.Second)
+	ResolverLatency.Observe(ctx, "example.com", time.Second)
+	RequestSize.Observe(ctx, "GET", "example.com", 1)
+	ResponseSize.Observe(ctx, "GET", "example.com", 1)
+	RateLimiterLatency.Observe(ctx, "GET", u, time.Second)
+	RequestResult.Increment(ctx, "200", "GET", "example.com")
+	ExecPluginCalls.Increment(0, "no_error")
+	ExecPluginPolicyCalls.Increment("allowed")
+	RequestRetry.IncrementRetry(ctx, "429", "GET", "example.com")
+	TransportCacheEntries.Observe(1)
+	TransportCreateCalls.Increment("hit")
+	TransportCAReloads.Increment("success", "reload")
+	TransportCertRotationGCCalls.Increment()
+	TransportCacheGCCalls.Increment("deleted")
+}
+
+// resetForTest returns the package to its pristine state and restores whatever
+// was there when the test finishes, so these tests neither see nor leak the
+// registrations any other test in this binary may have made.
+func resetForTest(tb testing.TB) {
+	tb.Helper()
+
+	registerLock.Lock()
+	var (
+		origClientCertExpiry             = ClientCertExpiry
+		origClientCertRotationAge        = ClientCertRotationAge
+		origRequestLatency               = RequestLatency
+		origResolverLatency              = ResolverLatency
+		origRequestSize                  = RequestSize
+		origResponseSize                 = ResponseSize
+		origRateLimiterLatency           = RateLimiterLatency
+		origRequestResult                = RequestResult
+		origExecPluginCalls              = ExecPluginCalls
+		origExecPluginPolicyCalls        = ExecPluginPolicyCalls
+		origRequestRetry                 = RequestRetry
+		origTransportCacheEntries        = TransportCacheEntries
+		origTransportCreateCalls         = TransportCreateCalls
+		origTransportCAReloads           = TransportCAReloads
+		origTransportCertRotationGCCalls = TransportCertRotationGCCalls
+		origTransportCacheGCCalls        = TransportCacheGCCalls
+
+		origRegisterFns             = registerFns
+		origEnsureRegisteredStarted = ensureRegisteredStarted.Load()
+		origRegisterFnsPending      = registerFnsPending.Load()
+	)
+
+	ClientCertExpiry = noopExpiry{}
+	ClientCertRotationAge = noopDuration{}
+	RequestLatency = noopLatency{}
+	ResolverLatency = noopResolverLatency{}
+	RequestSize = noopSize{}
+	ResponseSize = noopSize{}
+	RateLimiterLatency = noopLatency{}
+	RequestResult = noopResult{}
+	ExecPluginCalls = noopCalls{}
+	ExecPluginPolicyCalls = noopPolicy{}
+	RequestRetry = noopRetry{}
+	TransportCacheEntries = noopTransportCache{}
+	TransportCreateCalls = noopTransportCreateCalls{}
+	TransportCAReloads = noopTransportCAReloads{}
+	TransportCertRotationGCCalls = noopTransportCertRotationGCCalls{}
+	TransportCacheGCCalls = noopTransportCacheGCCalls{}
+
+	registerFns = nil
+	ensureRegisteredStarted.Store(false)
+	registerFnsPending.Store(false)
+	registerLock.Unlock()
+
+	tb.Cleanup(func() {
+		registerLock.Lock()
+		defer registerLock.Unlock()
+
+		ClientCertExpiry = origClientCertExpiry
+		ClientCertRotationAge = origClientCertRotationAge
+		RequestLatency = origRequestLatency
+		ResolverLatency = origResolverLatency
+		RequestSize = origRequestSize
+		ResponseSize = origResponseSize
+		RateLimiterLatency = origRateLimiterLatency
+		RequestResult = origRequestResult
+		ExecPluginCalls = origExecPluginCalls
+		ExecPluginPolicyCalls = origExecPluginPolicyCalls
+		RequestRetry = origRequestRetry
+		TransportCacheEntries = origTransportCacheEntries
+		TransportCreateCalls = origTransportCreateCalls
+		TransportCAReloads = origTransportCAReloads
+		TransportCertRotationGCCalls = origTransportCertRotationGCCalls
+		TransportCacheGCCalls = origTransportCacheGCCalls
+
+		registerFns = origRegisterFns
+		ensureRegisteredStarted.Store(origEnsureRegisteredStarted)
+		registerFnsPending.Store(origRegisterFnsPending)
+	})
+}
+
+// TestRegisterSingleProviderStoredDirectly guards the hot path: with exactly
+// one provider - the overwhelmingly common case - each hook must hold that
+// provider's metric itself, with no fan-out wrapper to iterate on every
+// request.
+func TestRegisterSingleProviderStoredDirectly(t *testing.T) {
+	resetForTest(t)
+
+	opts, _ := newCountingOpts()
+	Register(opts)
+
+	stored := map[string][2]any{
+		"ClientCertExpiry":             {ClientCertExpiry, opts.ClientCertExpiry},
+		"ClientCertRotationAge":        {ClientCertRotationAge, opts.ClientCertRotationAge},
+		"RequestLatency":               {RequestLatency, opts.RequestLatency},
+		"ResolverLatency":              {ResolverLatency, opts.ResolverLatency},
+		"RequestSize":                  {RequestSize, opts.RequestSize},
+		"ResponseSize":                 {ResponseSize, opts.ResponseSize},
+		"RateLimiterLatency":           {RateLimiterLatency, opts.RateLimiterLatency},
+		"RequestResult":                {RequestResult, opts.RequestResult},
+		"ExecPluginCalls":              {ExecPluginCalls, opts.ExecPluginCalls},
+		"ExecPluginPolicyCalls":        {ExecPluginPolicyCalls, opts.ExecPluginPolicyCalls},
+		"RequestRetry":                 {RequestRetry, opts.RequestRetry},
+		"TransportCacheEntries":        {TransportCacheEntries, opts.TransportCacheEntries},
+		"TransportCreateCalls":         {TransportCreateCalls, opts.TransportCreateCalls},
+		"TransportCAReloads":           {TransportCAReloads, opts.TransportCAReloads},
+		"TransportCertRotationGCCalls": {TransportCertRotationGCCalls, opts.TransportCertRotationGCCalls},
+		"TransportCacheGCCalls":        {TransportCacheGCCalls, opts.TransportCacheGCCalls},
+	}
+	for name, pair := range stored {
+		if got, want := pair[0], pair[1]; got != want {
+			t.Errorf("%s = %#v, want the registered metric itself (%#v); a single provider must not be wrapped", name, got, want)
+		}
+	}
+}
+
+// TestRegisterTwoProvidersBothObserve is the bug this change fixes: before it,
+// the second registrant was silently dropped.
+func TestRegisterTwoProvidersBothObserve(t *testing.T) {
+	resetForTest(t)
+
+	optsA, a := newCountingOpts()
+	optsB, b := newCountingOpts()
+	Register(optsA)
+	Register(optsB)
+
+	invokeAllHooks()
+
+	for name, got := range a.metrics() {
+		if got != 1 {
+			t.Errorf("first provider: %s observed %d times, want 1", name, got)
+		}
+	}
+	for name, got := range b.metrics() {
+		if got != 1 {
+			t.Errorf("second provider: %s observed %d times, want 1", name, got)
+		}
+	}
+}
+
+// TestRegisterThreeProvidersStayFlat checks that repeated registration extends
+// one fan-out rather than nesting them, which would make dispatch cost grow
+// with registration depth.
+func TestRegisterThreeProvidersStayFlat(t *testing.T) {
+	resetForTest(t)
+
+	optsA, a := newCountingOpts()
+	optsB, b := newCountingOpts()
+	optsC, c := newCountingOpts()
+	Register(optsA)
+	Register(optsB)
+	Register(optsC)
+
+	fanout, ok := RequestLatency.(multiLatency)
+	if !ok {
+		t.Fatalf("RequestLatency is %T, want multiLatency", RequestLatency)
+	}
+	if len(fanout) != 3 {
+		t.Errorf("fan-out holds %d metrics, want 3 (nested rather than flattened?)", len(fanout))
+	}
+
+	invokeAllHooks()
+	for i, counter := range []*counters{a, b, c} {
+		if got := counter.requestLatency.Load(); got != 1 {
+			t.Errorf("provider %d: RequestLatency observed %d times, want 1", i, got)
+		}
+	}
+}
+
+func TestRegisterNilFieldsIgnored(t *testing.T) {
+	resetForTest(t)
+
+	c := &counters{}
+	Register(RegisterOpts{RequestResult: countResult{&c.requestResult}})
+
+	if _, ok := RequestResult.(countResult); !ok {
+		t.Errorf("RequestResult = %T, want the registered countResult", RequestResult)
+	}
+
+	// Every other hook must be untouched, still holding its noop default.
+	untouched := map[string]any{
+		"ClientCertExpiry":             ClientCertExpiry,
+		"ClientCertRotationAge":        ClientCertRotationAge,
+		"RequestLatency":               RequestLatency,
+		"ResolverLatency":              ResolverLatency,
+		"RequestSize":                  RequestSize,
+		"ResponseSize":                 ResponseSize,
+		"RateLimiterLatency":           RateLimiterLatency,
+		"ExecPluginCalls":              ExecPluginCalls,
+		"ExecPluginPolicyCalls":        ExecPluginPolicyCalls,
+		"RequestRetry":                 RequestRetry,
+		"TransportCacheEntries":        TransportCacheEntries,
+		"TransportCreateCalls":         TransportCreateCalls,
+		"TransportCAReloads":           TransportCAReloads,
+		"TransportCertRotationGCCalls": TransportCertRotationGCCalls,
+		"TransportCacheGCCalls":        TransportCacheGCCalls,
+	}
+	for name, got := range untouched {
+		switch got.(type) {
+		case noopExpiry, noopDuration, noopLatency, noopResolverLatency, noopSize,
+			noopResult, noopCalls, noopPolicy, noopRetry, noopTransportCache,
+			noopTransportCreateCalls, noopTransportCAReloads,
+			noopTransportCertRotationGCCalls, noopTransportCacheGCCalls:
+		default:
+			t.Errorf("%s = %T, want its noop default; a nil field must not register anything", name, got)
+		}
+	}
+}
+
+// TestRegisterPreservesDirectAssignment covers callers that assign the exported
+// variables directly, which several in-tree tests and downstream projects do.
+func TestRegisterPreservesDirectAssignment(t *testing.T) {
+	resetForTest(t)
+
+	direct := &counters{}
+	RequestLatency = countLatency{&direct.requestLatency}
+
+	opts, registered := newCountingOpts()
+	Register(opts)
+
+	RequestLatency.Observe(context.Background(), "GET", url.URL{}, time.Second)
+
+	if got := direct.requestLatency.Load(); got != 1 {
+		t.Errorf("directly assigned metric observed %d times, want 1; Register must not clobber it", got)
+	}
+	if got := registered.requestLatency.Load(); got != 1 {
+		t.Errorf("registered metric observed %d times, want 1", got)
+	}
+}
+
+// TestEnsureRegisteredFansOutAndStaysLazy pins the property that is easiest to
+// break: RegisterFn must not fire at Register time, because adapters install it
+// precisely so registration happens once feature gates are set.
+func TestEnsureRegisteredFansOutAndStaysLazy(t *testing.T) {
+	resetForTest(t)
+
+	optsA, a := newCountingOpts()
+	optsB, b := newCountingOpts()
+	Register(optsA)
+	Register(optsB)
+
+	if got := a.registerFn.Load(); got != 0 {
+		t.Errorf("first RegisterFn ran %d times before EnsureRegistered, want 0", got)
+	}
+	if got := b.registerFn.Load(); got != 0 {
+		t.Errorf("second RegisterFn ran %d times before EnsureRegistered, want 0", got)
+	}
+
+	EnsureRegistered()
+
+	if got := a.registerFn.Load(); got != 1 {
+		t.Errorf("first RegisterFn ran %d times, want 1", got)
+	}
+	if got := b.registerFn.Load(); got != 1 {
+		t.Errorf("second RegisterFn ran %d times, want 1", got)
+	}
+
+	EnsureRegistered()
+	EnsureRegistered()
+
+	if got := a.registerFn.Load(); got != 1 {
+		t.Errorf("first RegisterFn ran %d times after repeat calls, want 1", got)
+	}
+	if got := b.registerFn.Load(); got != 1 {
+		t.Errorf("second RegisterFn ran %d times after repeat calls, want 1", got)
+	}
+}
+
+// TestEnsureRegisteredLateRegistrant covers a provider that registers after the
+// first client was already built: nothing guarantees another EnsureRegistered
+// call, so Register has to run the callback itself.
+func TestEnsureRegisteredLateRegistrant(t *testing.T) {
+	resetForTest(t)
+
+	optsA, a := newCountingOpts()
+	Register(optsA)
+	EnsureRegistered()
+
+	optsB, b := newCountingOpts()
+	Register(optsB)
+
+	if got := b.registerFn.Load(); got != 1 {
+		t.Errorf("late RegisterFn ran %d times, want 1; it would otherwise never run", got)
+	}
+	if got := a.registerFn.Load(); got != 1 {
+		t.Errorf("earlier RegisterFn ran %d times, want 1", got)
+	}
+
+	EnsureRegistered()
+
+	if got := a.registerFn.Load(); got != 1 {
+		t.Errorf("earlier RegisterFn ran %d times after a further EnsureRegistered, want 1", got)
+	}
+	if got := b.registerFn.Load(); got != 1 {
+		t.Errorf("late RegisterFn ran %d times after a further EnsureRegistered, want 1", got)
+	}
+}
+
+func TestEnsureRegisteredWithoutRegistrants(t *testing.T) {
+	resetForTest(t)
+
+	// Must not panic, and must stay cheap: nothing was ever registered.
+	EnsureRegistered()
+	EnsureRegistered()
+}
+
+// TestRegisterConcurrent checks that concurrent registrants do not lose each
+// other, which is the failure the write lock exists to prevent. It deliberately
+// does not observe while registering: the read path is documented as
+// unsynchronized, with registration expected to happen before any client is
+// built.
+func TestRegisterConcurrent(t *testing.T) {
+	resetForTest(t)
+
+	const providers = 20
+	all := make([]*counters, providers)
+
+	var wg sync.WaitGroup
+	for i := range providers {
+		opts, c := newCountingOpts()
+		all[i] = c
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			Register(opts)
+		}()
+	}
+	wg.Wait()
+
+	invokeAllHooks()
+	EnsureRegistered()
+
+	for i, c := range all {
+		for name, got := range c.metrics() {
+			if got != 1 {
+				t.Errorf("provider %d: %s observed %d times, want 1", i, name, got)
+			}
+		}
+		if got := c.registerFn.Load(); got != 1 {
+			t.Errorf("provider %d: RegisterFn ran %d times, want 1", i, got)
+		}
+	}
+}
+
+func BenchmarkRequestLatencyOneProvider(b *testing.B) {
+	resetForTest(b)
+
+	opts, _ := newCountingOpts()
+	Register(opts)
+
+	ctx := context.Background()
+	u := url.URL{Scheme: "https", Host: "example.com"}
+	b.ResetTimer()
+	for range b.N {
+		RequestLatency.Observe(ctx, "GET", u, time.Second)
+	}
+}
+
+func BenchmarkRequestLatencyTwoProviders(b *testing.B) {
+	resetForTest(b)
+
+	optsA, _ := newCountingOpts()
+	optsB, _ := newCountingOpts()
+	Register(optsA)
+	Register(optsB)
+
+	ctx := context.Background()
+	u := url.URL{Scheme: "https", Host: "example.com"}
+	b.ResetTimer()
+	for range b.N {
+		RequestLatency.Observe(ctx, "GET", u, time.Second)
+	}
+}
+
+func BenchmarkEnsureRegisteredSteadyState(b *testing.B) {
+	resetForTest(b)
+
+	opts, _ := newCountingOpts()
+	Register(opts)
+	EnsureRegistered()
+
+	b.ResetTimer()
+	for range b.N {
+		EnsureRegistered()
+	}
+}
+
+// TestEnsureRegisteredLateRegistrantAfterEmptyEnsure covers a provider that
+// registers a callback after EnsureRegistered has already run with nothing
+// installed, which is what happens when a client is built before any provider
+// registers. The callback still has to run: nothing guarantees a further
+// EnsureRegistered call.
+func TestEnsureRegisteredLateRegistrantAfterEmptyEnsure(t *testing.T) {
+	resetForTest(t)
+
+	EnsureRegistered()
+
+	opts, c := newCountingOpts()
+	Register(opts)
+
+	if got := c.registerFn.Load(); got != 1 {
+		t.Errorf("late RegisterFn ran %d times, want 1; EnsureRegistered had already run, so no further call is guaranteed", got)
+	}
+}
+
+// TestRegisterNilFieldsDoNotWriteHooks guards against Register storing into the
+// exported hooks when it has nothing to add. They are read from the request
+// path without synchronization, so writing back an identical value is still a
+// data race. Only meaningful under -race.
+func TestRegisterNilFieldsDoNotWriteHooks(t *testing.T) {
+	resetForTest(t)
+
+	opts, _ := newCountingOpts()
+	Register(opts)
+
+	ctx := context.Background()
+	u := url.URL{Scheme: "https", Host: "example.com"}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				RequestLatency.Observe(ctx, "GET", u, time.Second)
+			}
+		}
+	}()
+
+	for range 100 {
+		Register(RegisterOpts{})
+	}
+	close(stop)
+	wg.Wait()
+}

--- a/staging/src/k8s.io/client-go/tools/metrics/multi.go
+++ b/staging/src/k8s.io/client-go/tools/metrics/multi.go
@@ -1,0 +1,397 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"net/url"
+	"time"
+)
+
+// This file lets more than one provider register the same metric hook. Each
+// multi* type fans an observation out to every metric it holds, and each
+// combine* function folds a newly registered metric into whatever the hook
+// currently holds:
+//
+//   - a nil addition leaves the hook untouched, so nil fields in RegisterOpts
+//     are ignored exactly as they were before;
+//   - registering into an unset hook (the noop default, or nil) stores the
+//     metric directly, so the single-provider case - by far the common one -
+//     carries no wrapper and no loop on the read path;
+//   - registering into a hook that already fans out extends it, keeping the
+//     fan-out flat rather than nesting;
+//   - anything else, including a value assigned directly to the exported
+//     variable by a caller, becomes a two-element fan-out, so such an
+//     assignment is preserved rather than dropped.
+//
+// Extending a fan-out always copies: a value already published to the exported
+// variable may be being ranged over by an in-flight request, so its backing
+// array must never be written in place.
+//
+// Registering the same metric twice records the observation twice. Suppressing
+// that would mean comparing metrics for equality, which panics when the dynamic
+// type is uncomparable, so it is deliberately not attempted.
+
+type multiExpiry []ExpiryMetric
+
+func (m multiExpiry) Set(expiry *time.Time) {
+	for _, metric := range m {
+		metric.Set(expiry)
+	}
+}
+
+func combineExpiry(cur, add ExpiryMetric) ExpiryMetric {
+	if add == nil {
+		return cur
+	}
+	switch c := cur.(type) {
+	case nil, noopExpiry:
+		return add
+	case multiExpiry:
+		next := make(multiExpiry, len(c)+1)
+		copy(next, c)
+		next[len(c)] = add
+		return next
+	default:
+		return multiExpiry{cur, add}
+	}
+}
+
+type multiDuration []DurationMetric
+
+func (m multiDuration) Observe(duration time.Duration) {
+	for _, metric := range m {
+		metric.Observe(duration)
+	}
+}
+
+func combineDuration(cur, add DurationMetric) DurationMetric {
+	if add == nil {
+		return cur
+	}
+	switch c := cur.(type) {
+	case nil, noopDuration:
+		return add
+	case multiDuration:
+		next := make(multiDuration, len(c)+1)
+		copy(next, c)
+		next[len(c)] = add
+		return next
+	default:
+		return multiDuration{cur, add}
+	}
+}
+
+type multiLatency []LatencyMetric
+
+func (m multiLatency) Observe(ctx context.Context, verb string, u url.URL, latency time.Duration) {
+	for _, metric := range m {
+		metric.Observe(ctx, verb, u, latency)
+	}
+}
+
+func combineLatency(cur, add LatencyMetric) LatencyMetric {
+	if add == nil {
+		return cur
+	}
+	switch c := cur.(type) {
+	case nil, noopLatency:
+		return add
+	case multiLatency:
+		next := make(multiLatency, len(c)+1)
+		copy(next, c)
+		next[len(c)] = add
+		return next
+	default:
+		return multiLatency{cur, add}
+	}
+}
+
+type multiResolverLatency []ResolverLatencyMetric
+
+func (m multiResolverLatency) Observe(ctx context.Context, host string, latency time.Duration) {
+	for _, metric := range m {
+		metric.Observe(ctx, host, latency)
+	}
+}
+
+func combineResolverLatency(cur, add ResolverLatencyMetric) ResolverLatencyMetric {
+	if add == nil {
+		return cur
+	}
+	switch c := cur.(type) {
+	case nil, noopResolverLatency:
+		return add
+	case multiResolverLatency:
+		next := make(multiResolverLatency, len(c)+1)
+		copy(next, c)
+		next[len(c)] = add
+		return next
+	default:
+		return multiResolverLatency{cur, add}
+	}
+}
+
+type multiSize []SizeMetric
+
+func (m multiSize) Observe(ctx context.Context, verb string, host string, size float64) {
+	for _, metric := range m {
+		metric.Observe(ctx, verb, host, size)
+	}
+}
+
+func combineSize(cur, add SizeMetric) SizeMetric {
+	if add == nil {
+		return cur
+	}
+	switch c := cur.(type) {
+	case nil, noopSize:
+		return add
+	case multiSize:
+		next := make(multiSize, len(c)+1)
+		copy(next, c)
+		next[len(c)] = add
+		return next
+	default:
+		return multiSize{cur, add}
+	}
+}
+
+type multiResult []ResultMetric
+
+func (m multiResult) Increment(ctx context.Context, code string, method string, host string) {
+	for _, metric := range m {
+		metric.Increment(ctx, code, method, host)
+	}
+}
+
+func combineResult(cur, add ResultMetric) ResultMetric {
+	if add == nil {
+		return cur
+	}
+	switch c := cur.(type) {
+	case nil, noopResult:
+		return add
+	case multiResult:
+		next := make(multiResult, len(c)+1)
+		copy(next, c)
+		next[len(c)] = add
+		return next
+	default:
+		return multiResult{cur, add}
+	}
+}
+
+type multiCalls []CallsMetric
+
+func (m multiCalls) Increment(exitCode int, callStatus string) {
+	for _, metric := range m {
+		metric.Increment(exitCode, callStatus)
+	}
+}
+
+func combineCalls(cur, add CallsMetric) CallsMetric {
+	if add == nil {
+		return cur
+	}
+	switch c := cur.(type) {
+	case nil, noopCalls:
+		return add
+	case multiCalls:
+		next := make(multiCalls, len(c)+1)
+		copy(next, c)
+		next[len(c)] = add
+		return next
+	default:
+		return multiCalls{cur, add}
+	}
+}
+
+type multiPolicy []PolicyCallsMetric
+
+func (m multiPolicy) Increment(status string) {
+	for _, metric := range m {
+		metric.Increment(status)
+	}
+}
+
+func combinePolicy(cur, add PolicyCallsMetric) PolicyCallsMetric {
+	if add == nil {
+		return cur
+	}
+	switch c := cur.(type) {
+	case nil, noopPolicy:
+		return add
+	case multiPolicy:
+		next := make(multiPolicy, len(c)+1)
+		copy(next, c)
+		next[len(c)] = add
+		return next
+	default:
+		return multiPolicy{cur, add}
+	}
+}
+
+type multiRetry []RetryMetric
+
+func (m multiRetry) IncrementRetry(ctx context.Context, code string, method string, host string) {
+	for _, metric := range m {
+		metric.IncrementRetry(ctx, code, method, host)
+	}
+}
+
+func combineRetry(cur, add RetryMetric) RetryMetric {
+	if add == nil {
+		return cur
+	}
+	switch c := cur.(type) {
+	case nil, noopRetry:
+		return add
+	case multiRetry:
+		next := make(multiRetry, len(c)+1)
+		copy(next, c)
+		next[len(c)] = add
+		return next
+	default:
+		return multiRetry{cur, add}
+	}
+}
+
+type multiTransportCache []TransportCacheMetric
+
+func (m multiTransportCache) Observe(value int) {
+	for _, metric := range m {
+		metric.Observe(value)
+	}
+}
+
+func combineTransportCache(cur, add TransportCacheMetric) TransportCacheMetric {
+	if add == nil {
+		return cur
+	}
+	switch c := cur.(type) {
+	case nil, noopTransportCache:
+		return add
+	case multiTransportCache:
+		next := make(multiTransportCache, len(c)+1)
+		copy(next, c)
+		next[len(c)] = add
+		return next
+	default:
+		return multiTransportCache{cur, add}
+	}
+}
+
+type multiTransportCreateCalls []TransportCreateCallsMetric
+
+func (m multiTransportCreateCalls) Increment(result string) {
+	for _, metric := range m {
+		metric.Increment(result)
+	}
+}
+
+func combineTransportCreateCalls(cur, add TransportCreateCallsMetric) TransportCreateCallsMetric {
+	if add == nil {
+		return cur
+	}
+	switch c := cur.(type) {
+	case nil, noopTransportCreateCalls:
+		return add
+	case multiTransportCreateCalls:
+		next := make(multiTransportCreateCalls, len(c)+1)
+		copy(next, c)
+		next[len(c)] = add
+		return next
+	default:
+		return multiTransportCreateCalls{cur, add}
+	}
+}
+
+type multiTransportCAReloads []TransportCAReloadsMetric
+
+func (m multiTransportCAReloads) Increment(result, reason string) {
+	for _, metric := range m {
+		metric.Increment(result, reason)
+	}
+}
+
+func combineTransportCAReloads(cur, add TransportCAReloadsMetric) TransportCAReloadsMetric {
+	if add == nil {
+		return cur
+	}
+	switch c := cur.(type) {
+	case nil, noopTransportCAReloads:
+		return add
+	case multiTransportCAReloads:
+		next := make(multiTransportCAReloads, len(c)+1)
+		copy(next, c)
+		next[len(c)] = add
+		return next
+	default:
+		return multiTransportCAReloads{cur, add}
+	}
+}
+
+type multiTransportCertRotationGCCalls []TransportCertRotationGCCallsMetric
+
+func (m multiTransportCertRotationGCCalls) Increment() {
+	for _, metric := range m {
+		metric.Increment()
+	}
+}
+
+func combineTransportCertRotationGCCalls(cur, add TransportCertRotationGCCallsMetric) TransportCertRotationGCCallsMetric {
+	if add == nil {
+		return cur
+	}
+	switch c := cur.(type) {
+	case nil, noopTransportCertRotationGCCalls:
+		return add
+	case multiTransportCertRotationGCCalls:
+		next := make(multiTransportCertRotationGCCalls, len(c)+1)
+		copy(next, c)
+		next[len(c)] = add
+		return next
+	default:
+		return multiTransportCertRotationGCCalls{cur, add}
+	}
+}
+
+type multiTransportCacheGCCalls []TransportCacheGCCallsMetric
+
+func (m multiTransportCacheGCCalls) Increment(result string) {
+	for _, metric := range m {
+		metric.Increment(result)
+	}
+}
+
+func combineTransportCacheGCCalls(cur, add TransportCacheGCCallsMetric) TransportCacheGCCallsMetric {
+	if add == nil {
+		return cur
+	}
+	switch c := cur.(type) {
+	case nil, noopTransportCacheGCCalls:
+		return add
+	case multiTransportCacheGCCalls:
+		next := make(multiTransportCacheGCCalls, len(c)+1)
+		copy(next, c)
+		next[len(c)] = add
+		return next
+	default:
+		return multiTransportCacheGCCalls{cur, add}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`tools/metrics.Register` is guarded by a `sync.Once`, so the first caller wins and every later registrant is silently dropped. A binary that links two libraries wanting client-go metrics gets metrics for exactly one of them, with no error and nothing in the logs. Unlike `workqueue`, this package has no per-client override, so the losing side has no workaround at all.

`Register` now folds each newly registered metric into whatever the hook currently holds:

- a nil field leaves the hook untouched, as before;
- registering into an unset hook stores the metric **directly**, so the single-provider case carries no wrapper and no loop on the request path;
- a second registrant produces a fan-out, and further ones extend it rather than nesting;
- a value assigned directly to an exported variable is folded in rather than clobbered.

`RegisterFn` callbacks are all retained and each runs exactly once, via a per-callback `sync.Once`.

#### Which issue(s) this PR is related to:

Part of #127739

Follows the same direction as #141172, which does this for `tools/leaderelection`. @JasonColapietro confirmed on the issue that they are not working on `tools/metrics` and are keeping `workqueue` on their side, so this should not overlap.

#### Special notes for your reviewer:

Points I expect questions on, answered up front.

**Does this add work to the per-request path?** No, for the case that matters. With one provider the hook holds that provider itself, so the read path is identical to today by construction — `TestRegisterSingleProviderStoredDirectly` asserts the stored value is the registered metric, not a wrapper. The fan-out cost is only paid once you actually have two providers, which today gets you no metrics at all.

```
BenchmarkRequestLatencyOneProvider-10       2.503 ns/op   0 B/op   0 allocs/op
BenchmarkRequestLatencyTwoProviders-10     11.79  ns/op   0 B/op   0 allocs/op
BenchmarkEnsureRegisteredSteadyState-10     1.243 ns/op   0 B/op   0 allocs/op
```

`EnsureRegistered` is itself on the hot path — the adapters call it at the top of every observation — so it keeps a lock-free fast path: two `atomic.Bool` loads, where before it was a nil check plus `Once.Do`. Measured side by side in isolation those come out the same, ~0.47 ns/op vs ~0.49 ns/op, so this is the same cost class rather than a regression or a win.

**Why not put the variables behind `atomic.Value` or accessors?** They are assigned directly by callers, so that would be both a compile break and a silent behavior break. In-tree alone: `transport/ca_rotation_test.go`, `transport/cache_test.go`, `plugin/pkg/client/auth/exec/metrics_test.go`, `rest/request_test.go`, `test/integration/client/exec_test.go`. The exported variables and their types are unchanged here; the only new declaration in the package is the unexported `registerFnEntry`.

**What about racing reads?** Reads stay unsynchronized, exactly as today. `Register` writes a hook only when the corresponding field is non-nil, so a call that adds nothing writes nothing — worth stating because the old `sync.Once` swallowed later calls entirely, and dropping it would otherwise have made even `Register(RegisterOpts{})` touch globals that in-flight requests are reading. The write-side mutex is not decorative: it makes each hook's read-modify-write atomic across concurrent registrants, which is what stops two racing `Register` calls from losing one of them. Extending a fan-out always copies, so a value already published to the exported variable is never mutated under an in-flight request. The remaining torn-read hazard is the one that exists today and is closed by contract — register before constructing a client — which is now written down on `Register`.

**Does `RegisterFn` still stay lazy?** Yes, and there is a test pinning it. Adapters install it so registration lands after feature gates are set, so `Register` deliberately does not fire it. The one exception is a callback registered *after* `EnsureRegistered` has already run, which would otherwise never run at all.

**Double registration** now records twice. Suppressing that would mean comparing metrics for equality, which panics when the dynamic type is uncomparable, so it is deliberately not attempted. It is documented on `Register`.

The single in-tree registrant, `component-base/metrics/prometheus/restclient`, is unchanged and keeps working.

The package had no test file at all; this adds one. Tests cover single-provider identity, two and three providers, nil fields, direct assignment, `RegisterFn` laziness and fan-out, late registrants, and 20 concurrent registrants under `-race`. I also checked the tests fail if the old first-wins behavior is reintroduced.

Two of those tests come from bugs found reviewing my own first cut, both since fixed and each pinned by a test that fails without the fix: `EnsureRegistered`'s fast path returned before recording that registration time had passed, so a callback registered afterwards never ran; and `Register` wrote all sixteen hooks unconditionally, so nil fields raced with in-flight readers.

Verified with `go test -race` on this package plus `rest`, `transport`, `plugin/pkg/client/auth/exec` and `component-base/metrics/prometheus/restclient`.

/sig api-machinery
/sig instrumentation

cc @wojtek-t @jayunit100 @dgrisonnet

#### Does this PR introduce a user-facing change?

```release-note
client-go: `tools/metrics.Register` may now be called by more than one provider. Every registered metric receives every observation, instead of only the first registration taking effect.
```
