### PR TITLE
scheduler: support CompositePodGroup in queue metrics

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -6836,8 +6836,8 @@
 - name: queue_incoming_entities_total
   subsystem: scheduler
   help: Number of scheduling entities added to scheduling queues by event, queue type,
-    and entity type. Entity types are either 'pod' (for individual pods that are not
-    members of any podgroup) or 'podgroup'.
+    and entity type. Entity types are 'pod' (for individual pods that are not members
+    of any podgroup), 'podgroup', or 'compositepodgroup'.
   type: Counter
   stabilityLevel: ALPHA
   labels:
@@ -6849,12 +6849,13 @@
     endpoint: /metrics
 - name: queued_entities
   subsystem: scheduler
-  help: Number of queued scheduling entities ('pod' or 'podgroup'; 'pod' stands for
-    individual pods that are not members of any podgroup) by the queue type. 'active'
-    means number of entities in activeQ; 'backoff' means number of entities in backoffQ;
-    'unschedulable' means number of entities in unschedulableEntities that the scheduler
-    attempted to schedule and failed; 'gated' is the number of unschedulable entities
-    that the scheduler never attempted to schedule because they are gated.
+  help: Number of queued scheduling entities ('pod', 'podgroup', or 'compositepodgroup';
+    'pod' stands for individual pods that are not members of any podgroup) by the
+    queue type. 'active' means number of entities in activeQ; 'backoff' means number
+    of entities in backoffQ; 'unschedulable' means number of entities in unschedulableEntities
+    that the scheduler attempted to schedule and failed; 'gated' is the number of
+    unschedulable entities that the scheduler never attempted to schedule because
+    they are gated.
   type: Gauge
   stabilityLevel: ALPHA
   labels:

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -61,12 +61,12 @@ const queueMetricMetadata = `
 	`
 
 const queueIncomingEntitiesMetricMetadata = `
-	# HELP scheduler_queue_incoming_entities_total [ALPHA] Number of scheduling entities added to scheduling queues by event, queue type, and entity type. Entity types are either 'pod' (for individual pods that are not members of any podgroup) or 'podgroup'.
+	# HELP scheduler_queue_incoming_entities_total [ALPHA] Number of scheduling entities added to scheduling queues by event, queue type, and entity type. Entity types are 'pod' (for individual pods that are not members of any podgroup), 'podgroup', or 'compositepodgroup'.
 	# TYPE scheduler_queue_incoming_entities_total counter
 `
 
 const queuedEntitiesMetricMetadata = `
-	# HELP scheduler_queued_entities [ALPHA] Number of queued scheduling entities ('pod' or 'podgroup'; 'pod' stands for individual pods that are not members of any podgroup) by the queue type. 'active' means number of entities in activeQ; 'backoff' means number of entities in backoffQ; 'unschedulable' means number of entities in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable entities that the scheduler never attempted to schedule because they are gated.
+	# HELP scheduler_queued_entities [ALPHA] Number of queued scheduling entities ('pod', 'podgroup', or 'compositepodgroup'; 'pod' stands for individual pods that are not members of any podgroup) by the queue type. 'active' means number of entities in activeQ; 'backoff' means number of entities in backoffQ; 'unschedulable' means number of entities in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable entities that the scheduler never attempted to schedule because they are gated.
 	# TYPE scheduler_queued_entities gauge
 `
 
@@ -5042,14 +5042,36 @@ func TestIncomingPodsMetrics(t *testing.T) {
 			if err := testutil.CollectAndCompare(metrics.SchedulerQueueIncomingPods, strings.NewReader(queueMetricMetadata+test.want), metricName); err != nil {
 				t.Errorf("unexpected collecting result:\n%s", err)
 			}
-
 		})
 	}
 }
 
+var podGroupGateSetups = []struct {
+	name       string
+	cpgEnabled bool
+	features   featuregatetesting.FeatureOverrides
+}{
+	{
+		name:       "Generic",
+		cpgEnabled: false,
+		features: featuregatetesting.FeatureOverrides{
+			features.GenericWorkload: true,
+		},
+	},
+	{
+		name:       "CPG",
+		cpgEnabled: true,
+		// CompositePodGroup depends on GenericWorkload and TopologyAwareWorkloadScheduling.
+		features: featuregatetesting.FeatureOverrides{
+			features.GenericWorkload:                 true,
+			features.TopologyAwareWorkloadScheduling: true,
+			features.CompositePodGroup:               true,
+		},
+	},
+}
+
 func TestIncomingEntitiesMetrics(t *testing.T) {
 	logger := klog.Background()
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
 	timestamp := time.Now()
 
 	unschedulablePlugin := "unschedulable_plugin"
@@ -5063,17 +5085,34 @@ func TestIncomingEntitiesMetrics(t *testing.T) {
 		makeQueuedPodInfo(t, "pod2", "ns-pg", queuingParams, withPodGroup("pg-1")),
 		makeQueuedPodInfo(t, "pod3", "ns-pg", queuingParams, withPodGroup("pg-1")),
 		makeQueuedPodInfo(t, "pod4", "ns-pg", queuingParams, withPodGroup("pg-1")),
+		makeQueuedPodInfo(t, "pod5", "ns-pg", queuingParams, withPodGroup("pg-cpg-1")),
+		makeQueuedPodInfo(t, "pod6", "ns-pg", queuingParams, withPodGroup("pg-cpg-1")),
+		makeQueuedPodInfo(t, "pod7", "ns-pg", queuingParams, withPodGroup("pg-cpg-2")),
 	}
 
 	metricName := metrics.SchedulerSubsystem + "_" + metrics.SchedulerQueueIncomingEntities.Name
 
 	tests := []struct {
-		name string
-		run  func(tCtx ktesting.TContext, queue *PriorityQueue)
-		want string
+		name  string
+		isCPG bool
+		run   func(tCtx ktesting.TContext, queue *PriorityQueue)
+		want  string
 	}{
 		{
 			name: "add all pods to active queue",
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				for _, pInfo := range pInfos[:4] {
+					queue.Add(tCtx, pInfo.Pod)
+				}
+			},
+			want: `
+				scheduler_queue_incoming_entities_total{event="UnscheduledPodAdd",queue="active",type="pod"} 1
+				scheduler_queue_incoming_entities_total{event="UnscheduledPodAdd",queue="active",type="podgroup"} 1
+			`,
+		},
+		{
+			name:  "add all pods including compositepodgroup to active queue",
+			isCPG: true,
 			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
 				for _, pInfo := range pInfos {
 					queue.Add(tCtx, pInfo.Pod)
@@ -5082,6 +5121,7 @@ func TestIncomingEntitiesMetrics(t *testing.T) {
 			want: `
 				scheduler_queue_incoming_entities_total{event="UnscheduledPodAdd",queue="active",type="pod"} 1
 				scheduler_queue_incoming_entities_total{event="UnscheduledPodAdd",queue="active",type="podgroup"} 1
+				scheduler_queue_incoming_entities_total{event="UnscheduledPodAdd",queue="active",type="compositepodgroup"} 1
 			`,
 		},
 		{
@@ -5107,6 +5147,28 @@ func TestIncomingEntitiesMetrics(t *testing.T) {
 			`,
 		},
 		{
+			name: "add pods of a podgroup, mark as unschedulable and add to unschedulable queue",
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				queue.Add(tCtx, pInfos[1].Pod)
+				queue.Add(tCtx, pInfos[2].Pod)
+				queue.Add(tCtx, pInfos[3].Pod)
+				entityGroup, err := queue.Pop(logger)
+				if err != nil {
+					tCtx.Fatalf("Unexpected error popping from queue: %v", err)
+				}
+				pgInfo := entityGroup.(*framework.QueuedPodGroupInfo)
+				queue.pendingPodGroupPods.add(pInfos[2])
+				queue.pendingPodGroupPods.add(pInfos[3])
+				pgInfo.UnschedulablePlugins = sets.New(unschedulablePlugin)
+				pgInfo.UnschedulableCount = 1
+				queue.unschedulableEntities.addOrUpdate(pgInfo, false, framework.ScheduleAttemptFailure, nil)
+			},
+			want: `
+				scheduler_queue_incoming_entities_total{event="UnscheduledPodAdd",queue="active",type="podgroup"} 1
+				scheduler_queue_incoming_entities_total{event="ScheduleAttemptFailure",queue="unschedulable",type="podgroup"} 1
+			`,
+		},
+		{
 			name: "add individual pod to active queue",
 			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
 				queue.Add(tCtx, pInfos[0].Pod)
@@ -5124,26 +5186,115 @@ func TestIncomingEntitiesMetrics(t *testing.T) {
 				scheduler_queue_incoming_entities_total{event="UnscheduledPodAdd",queue="active",type="pod"} 1
 			`,
 		},
+		{
+			name: "add individual pod, mark as unschedulable and add to unschedulable queue",
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				queue.Add(tCtx, pInfos[0].Pod)
+				entity, err := queue.Pop(logger)
+				if err != nil {
+					tCtx.Fatalf("Unexpected error popping from queue: %v", err)
+				}
+				pod := entity.(*framework.QueuedPodInfo)
+				pod.UnschedulablePlugins = sets.New(unschedulablePlugin)
+				pod.UnschedulableCount = 1
+				queue.unschedulableEntities.addOrUpdate(pod, false, framework.ScheduleAttemptFailure, nil)
+			},
+			want: `
+				scheduler_queue_incoming_entities_total{event="UnscheduledPodAdd",queue="active",type="pod"} 1
+				scheduler_queue_incoming_entities_total{event="ScheduleAttemptFailure",queue="unschedulable",type="pod"} 1
+			`,
+		},
+		{
+			name:  "add pods of a compositepodgroup to active queue",
+			isCPG: true,
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				queue.Add(tCtx, pInfos[4].Pod)
+				queue.Add(tCtx, pInfos[5].Pod)
+				queue.Add(tCtx, pInfos[6].Pod)
+			},
+			want: `
+				scheduler_queue_incoming_entities_total{event="UnscheduledPodAdd",queue="active",type="compositepodgroup"} 1
+			`,
+		},
+		{
+			name:  "add pods of a compositepodgroup to active queue, simulate scheduling failure attempt, and requeue compositepodgroup to backoff queue",
+			isCPG: true,
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				queue.Add(tCtx, pInfos[4].Pod)
+				queue.Add(tCtx, pInfos[5].Pod)
+				queue.Add(tCtx, pInfos[6].Pod)
+				entityGroup, err := queue.Pop(logger)
+				if err != nil {
+					tCtx.Fatalf("Unexpected error popping from queue: %v", err)
+				}
+				cpgInfo := entityGroup.(*framework.QueuedPodGroupInfo)
+				queue.pendingPodGroupPods.add(pInfos[5])
+				queue.pendingPodGroupPods.add(pInfos[6])
+				if err := queue.AddAttemptedPodGroupIfNeeded(logger, cpgInfo, 1, fwk.NewStatus(fwk.Unschedulable)); err != nil {
+					tCtx.Fatalf("Unexpected error adding attempted pod group: %v", err)
+				}
+			},
+			want: `
+				scheduler_queue_incoming_entities_total{event="UnscheduledPodAdd",queue="active",type="compositepodgroup"} 1
+				scheduler_queue_incoming_entities_total{event="ScheduleAttemptFailure",queue="backoff",type="compositepodgroup"} 1
+			`,
+		},
+		{
+			name:  "add pods of a compositepodgroup, mark as unschedulable and add to unschedulable queue",
+			isCPG: true,
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				queue.Add(tCtx, pInfos[4].Pod)
+				queue.Add(tCtx, pInfos[5].Pod)
+				queue.Add(tCtx, pInfos[6].Pod)
+				entityGroup, err := queue.Pop(logger)
+				if err != nil {
+					tCtx.Fatalf("Unexpected error popping from queue: %v", err)
+				}
+				cpgInfo := entityGroup.(*framework.QueuedPodGroupInfo)
+				queue.pendingPodGroupPods.add(pInfos[5])
+				queue.pendingPodGroupPods.add(pInfos[6])
+				cpgInfo.UnschedulablePlugins = sets.New(unschedulablePlugin)
+				cpgInfo.UnschedulableCount = 1
+				queue.unschedulableEntities.addOrUpdate(cpgInfo, false, framework.ScheduleAttemptFailure, nil)
+			},
+			want: `
+				scheduler_queue_incoming_entities_total{event="UnscheduledPodAdd",queue="active",type="compositepodgroup"} 1
+				scheduler_queue_incoming_entities_total{event="ScheduleAttemptFailure",queue="unschedulable",type="compositepodgroup"} 1
+			`,
+		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			tCtx := ktesting.Init(t)
-			metrics.SchedulerQueueIncomingEntities.Reset()
-			queue := NewTestQueue(tCtx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)))
-			queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(st.MakePodGroup().Name("pg-1").Namespace("ns-pg").Obj()))
-			test.run(tCtx, queue)
-			if err := testutil.CollectAndCompare(metrics.SchedulerQueueIncomingEntities, strings.NewReader(queueIncomingEntitiesMetricMetadata+test.want), metricName); err != nil {
-				t.Errorf("unexpected collecting result:\n%s", err)
+	for _, setup := range podGroupGateSetups {
+		t.Run(setup.name, func(t *testing.T) {
+			for _, test := range tests {
+				if test.isCPG && !setup.cpgEnabled {
+					continue
+				}
+				t.Run(test.name, func(t *testing.T) {
+					featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, setup.features)
+					tCtx := ktesting.Init(t)
+					metrics.SchedulerQueueIncomingEntities.Reset()
+					queue := NewTestQueue(tCtx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)))
+					queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(st.MakePodGroup().Name("pg-1").Namespace("ns-pg").Obj()))
+					if setup.cpgEnabled {
+						queue.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(st.MakeCompositePodGroup().Name("cpg-root").Namespace("ns-pg").Obj()))
+						queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(st.MakePodGroup().Name("pg-cpg-1").Namespace("ns-pg").ParentCompositePodGroup("cpg-root").Obj()))
+						queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(st.MakePodGroup().Name("pg-cpg-2").Namespace("ns-pg").ParentCompositePodGroup("cpg-root").Obj()))
+					}
+					test.run(tCtx, queue)
+					if err := testutil.CollectAndCompare(metrics.SchedulerQueueIncomingEntities, strings.NewReader(queueIncomingEntitiesMetricMetadata+test.want), metricName); err != nil {
+						t.Errorf("unexpected collecting result:\n%s", err)
+					}
+				})
 			}
 		})
 	}
 }
 
 func TestQueuedEntitiesMetrics(t *testing.T) {
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
 	timestamp := time.Now()
 	unschedulablePlugin := "unschedulable_plugin"
+	gatingPlugin := "gating_plugin"
 	logger := klog.Background()
 	queuingParams := framework.QueueingParams{
 		Timestamp:            timestamp,
@@ -5155,17 +5306,34 @@ func TestQueuedEntitiesMetrics(t *testing.T) {
 		makeQueuedPodInfo(t, "pod2", "ns-pg", queuingParams, withPodGroup("pg-1")),
 		makeQueuedPodInfo(t, "pod3", "ns-pg", queuingParams, withPodGroup("pg-1")),
 		makeQueuedPodInfo(t, "pod4", "ns-pg", queuingParams, withPodGroup("pg-1")),
+		makeQueuedPodInfo(t, "pod5", "ns-pg", queuingParams, withPodGroup("pg-cpg-1")),
+		makeQueuedPodInfo(t, "pod6", "ns-pg", queuingParams, withPodGroup("pg-cpg-1")),
+		makeQueuedPodInfo(t, "pod7", "ns-pg", queuingParams, withPodGroup("pg-cpg-2")),
 	}
 
 	metricName := metrics.SchedulerSubsystem + "_" + metrics.QueuedEntities.Name
 
 	tests := []struct {
-		name string
-		run  func(tCtx ktesting.TContext, queue *PriorityQueue)
-		want string
+		name  string
+		isCPG bool
+		run   func(tCtx ktesting.TContext, queue *PriorityQueue)
+		want  string
 	}{
 		{
 			name: "add all pods to active queue",
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				for _, pInfo := range pInfos[:4] {
+					queue.Add(tCtx, pInfo.Pod)
+				}
+			},
+			want: `
+				scheduler_queued_entities{queue="active",type="pod"} 1
+				scheduler_queued_entities{queue="active",type="podgroup"} 1
+			`,
+		},
+		{
+			name:  "add all pods including compositepodgroup to active queue",
+			isCPG: true,
 			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
 				for _, pInfo := range pInfos {
 					queue.Add(tCtx, pInfo.Pod)
@@ -5174,6 +5342,7 @@ func TestQueuedEntitiesMetrics(t *testing.T) {
 			want: `
 				scheduler_queued_entities{queue="active",type="pod"} 1
 				scheduler_queued_entities{queue="active",type="podgroup"} 1
+				scheduler_queued_entities{queue="active",type="compositepodgroup"} 1
 			`,
 		},
 		{
@@ -5199,6 +5368,49 @@ func TestQueuedEntitiesMetrics(t *testing.T) {
 			`,
 		},
 		{
+			name: "add pods of a podgroup, mark as unschedulable and add to unschedulable queue",
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				queue.Add(tCtx, pInfos[1].Pod)
+				queue.Add(tCtx, pInfos[2].Pod)
+				queue.Add(tCtx, pInfos[3].Pod)
+				entityGroup, err := queue.Pop(logger)
+				if err != nil {
+					tCtx.Fatalf("Unexpected error popping from queue: %v", err)
+				}
+				pgInfo := entityGroup.(*framework.QueuedPodGroupInfo)
+				queue.pendingPodGroupPods.add(pInfos[2])
+				queue.pendingPodGroupPods.add(pInfos[3])
+				pgInfo.UnschedulablePlugins = sets.New(unschedulablePlugin)
+				pgInfo.UnschedulableCount = 1
+				queue.unschedulableEntities.addOrUpdate(pgInfo, false, framework.ScheduleAttemptFailure, nil)
+			},
+			want: `
+				scheduler_queued_entities{queue="active",type="podgroup"} 0
+				scheduler_queued_entities{queue="unschedulable",type="podgroup"} 1
+			`,
+		},
+		{
+			name: "add pods of a podgroup, mark as gated and add to unschedulable queue",
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				queue.Add(tCtx, pInfos[1].Pod)
+				queue.Add(tCtx, pInfos[2].Pod)
+				queue.Add(tCtx, pInfos[3].Pod)
+				entityGroup, err := queue.Pop(logger)
+				if err != nil {
+					tCtx.Fatalf("Unexpected error popping from queue: %v", err)
+				}
+				pgInfo := entityGroup.(*framework.QueuedPodGroupInfo)
+				queue.pendingPodGroupPods.add(pInfos[2])
+				queue.pendingPodGroupPods.add(pInfos[3])
+				pgInfo.SetGatingPlugin(gatingPlugin, nil)
+				queue.unschedulableEntities.addOrUpdate(pgInfo, false, framework.ScheduleAttemptFailure, nil)
+			},
+			want: `
+				scheduler_queued_entities{queue="active",type="podgroup"} 0
+				scheduler_queued_entities{queue="gated",type="podgroup"} 1
+			`,
+		},
+		{
 			name: "Add individual pod to active queue, then mark it as unschedulable and add it unschedulable queue",
 			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
 				queue.Add(tCtx, pInfos[0].Pod)
@@ -5215,6 +5427,23 @@ func TestQueuedEntitiesMetrics(t *testing.T) {
 			want: `
 				scheduler_queued_entities{queue="active",type="pod"} 0
 				scheduler_queued_entities{queue="unschedulable",type="pod"} 1
+			`,
+		},
+		{
+			name: "Add individual pod to active queue, then mark it as gated and add it unschedulable queue",
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				queue.Add(tCtx, pInfos[0].Pod)
+				entity, err := queue.Pop(logger)
+				if err != nil {
+					tCtx.Fatalf("Unexpected error popping from queue: %v", err)
+				}
+				pod := entity.(*framework.QueuedPodInfo)
+				pod.SetGatingPlugin(gatingPlugin, nil)
+				queue.unschedulableEntities.addOrUpdate(pod, false, framework.ScheduleAttemptFailure, nil)
+			},
+			want: `
+				scheduler_queued_entities{queue="active",type="pod"} 0
+				scheduler_queued_entities{queue="gated",type="pod"} 1
 			`,
 		},
 		{
@@ -5236,6 +5465,28 @@ func TestQueuedEntitiesMetrics(t *testing.T) {
 			want: `
 				scheduler_queued_entities{queue="active",type="pod"} 0
 				scheduler_queued_entities{queue="backoff",type="pod"} 1
+				scheduler_queued_entities{queue="unschedulable",type="pod"} 0
+			`,
+		},
+		{
+			name: "Move an individual pod from backoff queue to active queue",
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				queue.Add(tCtx, pInfos[0].Pod)
+				entity, err := queue.Pop(logger)
+				if err != nil {
+					tCtx.Fatalf("Unexpected error popping from queue: %v", err)
+				}
+				pod := entity.(*framework.QueuedPodInfo)
+				pod.UnschedulablePlugins = sets.New(unschedulablePlugin)
+				if err := queue.AddUnschedulablePodIfNotPresent(logger, pod, 1); err != nil {
+					tCtx.Fatalf("Unexpected error adding unschedulable pod: %v", err)
+				}
+
+				queue.clock.(*testingclock.FakeClock).Step(3 * time.Second)
+				queue.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+			},
+			want: `
+				scheduler_queued_entities{queue="active",type="pod"} 1
 				scheduler_queued_entities{queue="unschedulable",type="pod"} 0
 			`,
 		},
@@ -5289,18 +5540,155 @@ func TestQueuedEntitiesMetrics(t *testing.T) {
 				scheduler_queued_entities{queue="unschedulable",type="podgroup"} 0
 			`,
 		},
+		{
+			name:  "add pods of a compositepodgroup to active queue",
+			isCPG: true,
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				queue.Add(tCtx, pInfos[4].Pod)
+				queue.Add(tCtx, pInfos[5].Pod)
+				queue.Add(tCtx, pInfos[6].Pod)
+			},
+			want: `
+				scheduler_queued_entities{queue="active",type="compositepodgroup"} 1
+			`,
+		},
+		{
+			name:  "add pods of a compositepodgroup to active queue, simulate scheduling failure attempt, and requeue compositepodgroup to backoff queue",
+			isCPG: true,
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				queue.Add(tCtx, pInfos[4].Pod)
+				queue.Add(tCtx, pInfos[5].Pod)
+				queue.Add(tCtx, pInfos[6].Pod)
+				entityGroup, err := queue.Pop(logger)
+				if err != nil {
+					tCtx.Fatalf("Unexpected error popping from queue: %v", err)
+				}
+				cpgInfo := entityGroup.(*framework.QueuedPodGroupInfo)
+				queue.pendingPodGroupPods.add(pInfos[5])
+				queue.pendingPodGroupPods.add(pInfos[6])
+				if err := queue.AddAttemptedPodGroupIfNeeded(logger, cpgInfo, 1, fwk.NewStatus(fwk.Unschedulable)); err != nil {
+					tCtx.Fatalf("Unexpected error adding attempted pod group: %v", err)
+				}
+			},
+			want: `
+				scheduler_queued_entities{queue="active",type="compositepodgroup"} 0
+				scheduler_queued_entities{queue="backoff",type="compositepodgroup"} 1
+			`,
+		},
+		{
+			name:  "add pods of a compositepodgroup, mark as unschedulable and add to unschedulable queue",
+			isCPG: true,
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				queue.Add(tCtx, pInfos[4].Pod)
+				queue.Add(tCtx, pInfos[5].Pod)
+				queue.Add(tCtx, pInfos[6].Pod)
+				entityGroup, err := queue.Pop(logger)
+				if err != nil {
+					tCtx.Fatalf("Unexpected error popping from queue: %v", err)
+				}
+				cpgInfo := entityGroup.(*framework.QueuedPodGroupInfo)
+				cpgInfo.UnschedulablePlugins = sets.New(unschedulablePlugin)
+				cpgInfo.UnschedulableCount = 1
+				queue.unschedulableEntities.addOrUpdate(cpgInfo, false, framework.ScheduleAttemptFailure, nil)
+			},
+			want: `
+				scheduler_queued_entities{queue="active",type="compositepodgroup"} 0
+				scheduler_queued_entities{queue="unschedulable",type="compositepodgroup"} 1
+			`,
+		},
+		{
+			name:  "add pods of a compositepodgroup, mark as gated and add to unschedulable queue",
+			isCPG: true,
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				queue.Add(tCtx, pInfos[4].Pod)
+				queue.Add(tCtx, pInfos[5].Pod)
+				queue.Add(tCtx, pInfos[6].Pod)
+				entityGroup, err := queue.Pop(logger)
+				if err != nil {
+					tCtx.Fatalf("Unexpected error popping from queue: %v", err)
+				}
+				cpgInfo := entityGroup.(*framework.QueuedPodGroupInfo)
+				cpgInfo.SetGatingPlugin(gatingPlugin, nil)
+				queue.unschedulableEntities.addOrUpdate(cpgInfo, false, framework.ScheduleAttemptFailure, nil)
+			},
+			want: `
+				scheduler_queued_entities{queue="active",type="compositepodgroup"} 0
+				scheduler_queued_entities{queue="gated",type="compositepodgroup"} 1
+			`,
+		},
+		{
+			name:  "add pods of a compositepodgroup, mark as unschedulable and move to unschedulable queue, then to backoff queue",
+			isCPG: true,
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				queue.Add(tCtx, pInfos[4].Pod)
+				queue.Add(tCtx, pInfos[5].Pod)
+				queue.Add(tCtx, pInfos[6].Pod)
+				entityGroup, err := queue.Pop(logger)
+				if err != nil {
+					tCtx.Fatalf("Unexpected error popping from queue: %v", err)
+				}
+				cpgInfo := entityGroup.(*framework.QueuedPodGroupInfo)
+				cpgInfo.UnschedulablePlugins = sets.New(unschedulablePlugin)
+				cpgInfo.UnschedulableCount = 1
+				queue.unschedulableEntities.addOrUpdate(cpgInfo, false, framework.ScheduleAttemptFailure, nil)
+
+				queue.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+			},
+			want: `
+				scheduler_queued_entities{queue="active",type="compositepodgroup"} 0
+				scheduler_queued_entities{queue="backoff",type="compositepodgroup"} 1
+				scheduler_queued_entities{queue="unschedulable",type="compositepodgroup"} 0
+			`,
+		},
+		{
+			name:  "Move a compositepodgroup from backoff queue to active queue",
+			isCPG: true,
+			run: func(tCtx ktesting.TContext, queue *PriorityQueue) {
+				queue.Add(tCtx, pInfos[4].Pod)
+				queue.Add(tCtx, pInfos[5].Pod)
+				queue.Add(tCtx, pInfos[6].Pod)
+				entityGroup, err := queue.Pop(logger)
+				if err != nil {
+					tCtx.Fatalf("Unexpected error popping from queue: %v", err)
+				}
+				cpgInfo := entityGroup.(*framework.QueuedPodGroupInfo)
+				cpgInfo.UnschedulablePlugins = sets.New(unschedulablePlugin)
+				cpgInfo.UnschedulableCount = 1
+				queue.unschedulableEntities.addOrUpdate(cpgInfo, false, framework.ScheduleAttemptFailure, nil)
+
+				queue.clock.(*testingclock.FakeClock).Step(3 * time.Second)
+				queue.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+			},
+			want: `
+				scheduler_queued_entities{queue="active",type="compositepodgroup"} 1
+				scheduler_queued_entities{queue="unschedulable",type="compositepodgroup"} 0
+			`,
+		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			tCtx := ktesting.Init(t)
-			metrics.QueuedEntities.Reset()
-			queue := NewTestQueue(tCtx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)))
-			queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(st.MakePodGroup().Name("pg-1").Namespace("ns-pg").Obj()))
-			test.run(tCtx, queue)
+	for _, setup := range podGroupGateSetups {
+		t.Run(setup.name, func(t *testing.T) {
+			for _, test := range tests {
+				if test.isCPG && !setup.cpgEnabled {
+					continue
+				}
+				t.Run(test.name, func(t *testing.T) {
+					featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, setup.features)
+					tCtx := ktesting.Init(t)
+					metrics.QueuedEntities.Reset()
+					queue := NewTestQueue(tCtx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)))
+					queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(st.MakePodGroup().Name("pg-1").Namespace("ns-pg").Obj()))
+					if setup.cpgEnabled {
+						queue.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(st.MakeCompositePodGroup().Name("cpg-root").Namespace("ns-pg").Obj()))
+						queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(st.MakePodGroup().Name("pg-cpg-1").Namespace("ns-pg").ParentCompositePodGroup("cpg-root").Obj()))
+						queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(st.MakePodGroup().Name("pg-cpg-2").Namespace("ns-pg").ParentCompositePodGroup("cpg-root").Obj()))
+					}
+					test.run(tCtx, queue)
 
-			if err := testutil.CollectAndCompare(metrics.QueuedEntities, strings.NewReader(queuedEntitiesMetricMetadata+test.want), metricName); err != nil {
-				t.Errorf("unexpected collecting result:\n%s", err)
+					if err := testutil.CollectAndCompare(metrics.QueuedEntities, strings.NewReader(queuedEntitiesMetricMetadata+test.want), metricName); err != nil {
+						t.Errorf("unexpected collecting result:\n%s", err)
+					}
+				})
 			}
 		})
 	}

--- a/pkg/scheduler/metrics/metric_recorder.go
+++ b/pkg/scheduler/metrics/metric_recorder.go
@@ -23,11 +23,11 @@ import (
 	fwk "k8s.io/kube-scheduler/framework"
 )
 
-// Entity is either a pod or a podgroup that gets recorded in the metrics.
+// Entity is either a pod, a pod group, or a composite pod group that gets recorded in the metrics.
 type Entity interface {
 	// Size returns the number of pods within the entity (1 for a single pod, or the pod count for a pod group).
 	Size() int
-	// Type returns the entity type (e.g. "pod" or "podgroup").
+	// Type returns the entity type (e.g. "pod", "podgroup", or "compositepodgroup").
 	Type() fwk.EntityKeyType
 }
 
@@ -94,6 +94,8 @@ func EntityToLabel(entity Entity) (string, bool) {
 		return Pod, true
 	case fwk.PodGroupKeyType:
 		return PodGroup, true
+	case fwk.CompositePodGroupKeyType:
+		return CompositePodGroup, true
 	}
 
 	return "", false
@@ -130,6 +132,7 @@ func (r *QueuedEntitiesRecorder) Clear() {
 	r.pods.Set(float64(0))
 	r.entities(Pod).Set(float64(0))
 	r.entities(PodGroup).Set(float64(0))
+	r.entities(CompositePodGroup).Set(float64(0))
 }
 
 // histogramVecMetric is the data structure passed in the buffer channel between the main framework thread

--- a/pkg/scheduler/metrics/metric_recorder_test.go
+++ b/pkg/scheduler/metrics/metric_recorder_test.go
@@ -110,6 +110,7 @@ func TestClear(t *testing.T) {
 		go func() {
 			fakeRecorder.Add(&testEntity{size: 1, t: "pod"})
 			fakeRecorder.Add(&testEntity{size: 2, t: "podgroup"})
+			fakeRecorder.Add(&testEntity{size: 3, t: "compositepodgroup"})
 			wg.Done()
 		}()
 	}
@@ -120,7 +121,7 @@ func TestClear(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-	expected := int64(incLoops*3 - decLoops)
+	expected := int64(incLoops*6 - decLoops)
 	if fakeRecorder.counter != expected {
 		t.Errorf("Expected %v, got %v", expected, fakeRecorder.counter)
 	}
@@ -222,6 +223,12 @@ func TestEntityToLabel(t *testing.T) {
 			wantOK:    true,
 		},
 		{
+			name:      "compositepodgroup entity",
+			entity:    &testEntity{t: "compositepodgroup"},
+			wantLabel: CompositePodGroup,
+			wantOK:    true,
+		},
+		{
 			name:   "unknown entity type",
 			entity: &testEntity{t: "unknown"},
 			wantOK: false,
@@ -247,7 +254,9 @@ func TestQueuedEntitiesRecorder(t *testing.T) {
 	pInfo1 := &testEntity{size: 1, t: "pod"}
 	pInfo2 := &testEntity{size: 5, t: "podgroup"}
 	pInfo3 := &testEntity{size: 1, t: "pod"}
+	pInfo4 := &testEntity{size: 10, t: "compositepodgroup"}
 	updatedPInfo2 := &testEntity{size: 8, t: "podgroup"}
+	updatedPInfo4 := &testEntity{size: 12, t: "compositepodgroup"}
 
 	tests := []struct {
 		name string
@@ -260,13 +269,15 @@ func TestQueuedEntitiesRecorder(t *testing.T) {
 				recorder.Add(pInfo1)
 				recorder.Add(pInfo2)
 				recorder.Add(pInfo3)
+				recorder.Add(pInfo4)
 			},
 			want: `
 				# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
 				# TYPE scheduler_pending_pods gauge
-				scheduler_pending_pods{queue="active"} 7
-				# HELP scheduler_queued_entities [ALPHA] Number of queued scheduling entities ('pod' or 'podgroup'; 'pod' stands for individual pods that are not members of any podgroup) by the queue type. 'active' means number of entities in activeQ; 'backoff' means number of entities in backoffQ; 'unschedulable' means number of entities in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable entities that the scheduler never attempted to schedule because they are gated.
+				scheduler_pending_pods{queue="active"} 17
+				# HELP scheduler_queued_entities [ALPHA] Number of queued scheduling entities ('pod', 'podgroup', or 'compositepodgroup'; 'pod' stands for individual pods that are not members of any podgroup) by the queue type. 'active' means number of entities in activeQ; 'backoff' means number of entities in backoffQ; 'unschedulable' means number of entities in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable entities that the scheduler never attempted to schedule because they are gated.
 				# TYPE scheduler_queued_entities gauge
+				scheduler_queued_entities{queue="active",type="compositepodgroup"} 1
 				scheduler_queued_entities{queue="active",type="pod"} 2
 				scheduler_queued_entities{queue="active",type="podgroup"} 1
 			`,
@@ -275,13 +286,15 @@ func TestQueuedEntitiesRecorder(t *testing.T) {
 			name: "Remove entity",
 			op: func() {
 				recorder.Remove(pInfo1)
+				recorder.Remove(pInfo4)
 			},
 			want: `
 				# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
 				# TYPE scheduler_pending_pods gauge
 				scheduler_pending_pods{queue="active"} 6
-				# HELP scheduler_queued_entities [ALPHA] Number of queued scheduling entities ('pod' or 'podgroup'; 'pod' stands for individual pods that are not members of any podgroup) by the queue type. 'active' means number of entities in activeQ; 'backoff' means number of entities in backoffQ; 'unschedulable' means number of entities in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable entities that the scheduler never attempted to schedule because they are gated.
+				# HELP scheduler_queued_entities [ALPHA] Number of queued scheduling entities ('pod', 'podgroup', or 'compositepodgroup'; 'pod' stands for individual pods that are not members of any podgroup) by the queue type. 'active' means number of entities in activeQ; 'backoff' means number of entities in backoffQ; 'unschedulable' means number of entities in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable entities that the scheduler never attempted to schedule because they are gated.
 				# TYPE scheduler_queued_entities gauge
+				scheduler_queued_entities{queue="active",type="compositepodgroup"} 0
 				scheduler_queued_entities{queue="active",type="pod"} 1
 				scheduler_queued_entities{queue="active",type="podgroup"} 1
 			`,
@@ -289,14 +302,17 @@ func TestQueuedEntitiesRecorder(t *testing.T) {
 		{
 			name: "Update entity",
 			op: func() {
+				recorder.Add(pInfo4)
 				recorder.Update(pInfo2, updatedPInfo2)
+				recorder.Update(pInfo4, updatedPInfo4)
 			},
 			want: `
 				# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
 				# TYPE scheduler_pending_pods gauge
-				scheduler_pending_pods{queue="active"} 9
-				# HELP scheduler_queued_entities [ALPHA] Number of queued scheduling entities ('pod' or 'podgroup'; 'pod' stands for individual pods that are not members of any podgroup) by the queue type. 'active' means number of entities in activeQ; 'backoff' means number of entities in backoffQ; 'unschedulable' means number of entities in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable entities that the scheduler never attempted to schedule because they are gated.
+				scheduler_pending_pods{queue="active"} 21
+				# HELP scheduler_queued_entities [ALPHA] Number of queued scheduling entities ('pod', 'podgroup', or 'compositepodgroup'; 'pod' stands for individual pods that are not members of any podgroup) by the queue type. 'active' means number of entities in activeQ; 'backoff' means number of entities in backoffQ; 'unschedulable' means number of entities in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable entities that the scheduler never attempted to schedule because they are gated.
 				# TYPE scheduler_queued_entities gauge
+				scheduler_queued_entities{queue="active",type="compositepodgroup"} 1
 				scheduler_queued_entities{queue="active",type="pod"} 1
 				scheduler_queued_entities{queue="active",type="podgroup"} 1
 			`,
@@ -310,8 +326,9 @@ func TestQueuedEntitiesRecorder(t *testing.T) {
 				# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated; 'incomplete' means number of pods in incompletePodGroupPods; 'pending' means number of pods in pendingPodGroupPods.
 				# TYPE scheduler_pending_pods gauge
 				scheduler_pending_pods{queue="active"} 0
-				# HELP scheduler_queued_entities [ALPHA] Number of queued scheduling entities ('pod' or 'podgroup'; 'pod' stands for individual pods that are not members of any podgroup) by the queue type. 'active' means number of entities in activeQ; 'backoff' means number of entities in backoffQ; 'unschedulable' means number of entities in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable entities that the scheduler never attempted to schedule because they are gated.
+				# HELP scheduler_queued_entities [ALPHA] Number of queued scheduling entities ('pod', 'podgroup', or 'compositepodgroup'; 'pod' stands for individual pods that are not members of any podgroup) by the queue type. 'active' means number of entities in activeQ; 'backoff' means number of entities in backoffQ; 'unschedulable' means number of entities in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable entities that the scheduler never attempted to schedule because they are gated.
 				# TYPE scheduler_queued_entities gauge
+				scheduler_queued_entities{queue="active",type="compositepodgroup"} 0
 				scheduler_queued_entities{queue="active",type="pod"} 0
 				scheduler_queued_entities{queue="active",type="podgroup"} 0
 			`,

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -101,8 +101,9 @@ const (
 
 // Entity label values used for queued_entities and queue_incoming_entities metrics.
 const (
-	Pod      = "pod"
-	PodGroup = "podgroup"
+	Pod               = "pod"
+	PodGroup          = "podgroup"
+	CompositePodGroup = "compositepodgroup"
 )
 
 const (
@@ -327,7 +328,7 @@ func InitMetrics() {
 		&metrics.GaugeOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "queued_entities",
-			Help:           "Number of queued scheduling entities ('pod' or 'podgroup'; 'pod' stands for individual pods that are not members of any podgroup) by the queue type. 'active' means number of entities in activeQ; 'backoff' means number of entities in backoffQ; 'unschedulable' means number of entities in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable entities that the scheduler never attempted to schedule because they are gated.",
+			Help:           "Number of queued scheduling entities ('pod', 'podgroup', or 'compositepodgroup'; 'pod' stands for individual pods that are not members of any podgroup) by the queue type. 'active' means number of entities in activeQ; 'backoff' means number of entities in backoffQ; 'unschedulable' means number of entities in unschedulableEntities that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable entities that the scheduler never attempted to schedule because they are gated.",
 			StabilityLevel: metrics.ALPHA,
 		}, []string{"queue", "type"})
 	InFlightEvents = metrics.NewGaugeVec(
@@ -450,7 +451,7 @@ func InitMetrics() {
 		&metrics.CounterOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "queue_incoming_entities_total",
-			Help:           "Number of scheduling entities added to scheduling queues by event, queue type, and entity type. Entity types are either 'pod' (for individual pods that are not members of any podgroup) or 'podgroup'.",
+			Help:           "Number of scheduling entities added to scheduling queues by event, queue type, and entity type. Entity types are 'pod' (for individual pods that are not members of any podgroup), 'podgroup', or 'compositepodgroup'.",
 			StabilityLevel: metrics.ALPHA,
 		}, []string{"queue", "event", "type"})
 
@@ -769,22 +770,22 @@ func PendingPodGroupPods() metrics.GaugeMetric {
 	return pendingPods.With(metrics.Labels{"queue": "pending"})
 }
 
-// ActiveEntities returns the queued entities metric with the queue label set to "active" and type label set to "Pod" or "PodGroup".
+// ActiveEntities returns the queued entities metric with the queue label set to "active" and type label set to "pod", "podgroup", or "compositepodgroup".
 func ActiveEntities(entityType string) metrics.GaugeMetric {
 	return QueuedEntities.With(metrics.Labels{"queue": "active", "type": entityType})
 }
 
-// BackoffEntities returns the queued entities metric with the queue label set to "backoff" and type label set to "Pod" or "PodGroup".
+// BackoffEntities returns the queued entities metric with the queue label set to "backoff" and type label set to "pod", "podgroup", or "compositepodgroup".
 func BackoffEntities(entityType string) metrics.GaugeMetric {
 	return QueuedEntities.With(metrics.Labels{"queue": "backoff", "type": entityType})
 }
 
-// UnschedulableEntities returns the queued entities metric with the queue label set to "unschedulable" and type label set to "Pod" or "PodGroup".
+// UnschedulableEntities returns the queued entities metric with the queue label set to "unschedulable" and type label set to "pod", "podgroup", or "compositepodgroup".
 func UnschedulableEntities(entityType string) metrics.GaugeMetric {
 	return QueuedEntities.With(metrics.Labels{"queue": "unschedulable", "type": entityType})
 }
 
-// GatedEntities returns the queued entities metric with the queue label set to "gated" and type label set to "Pod" or "PodGroup".
+// GatedEntities returns the queued entities metric with the queue label set to "gated" and type label set to "pod", "podgroup", or "compositepodgroup".
 func GatedEntities(entityType string) metrics.GaugeMetric {
 	return QueuedEntities.With(metrics.Labels{"queue": "gated", "type": entityType})
 }


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR extends the scheduler's queue metrics to support `CompositePodGroup` (CPG) alongside `PodGroup` (PG) and individual `Pod`s:
- Adds the `compositepodgroup` entity type constant and updates metric descriptions for `scheduler_queued_entities` and `scheduler_queue_incoming_entities_total`.
- Maps `CompositePodGroupKeyType` in `QueuedEntitiesRecorder` and ensures it is properly tracked and cleared across `active`, `backoff`, and `unschedulable` queues.
- Adds comprehensive unit test coverage in `TestQueuedEntitiesMetrics` and `TestIncomingEntitiesMetrics` verifying multi-pod / multi-child-group CPG accounting and state transitions.

#### Which issue(s) this PR is related to:

KEP: [KEP-6012](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/6012-composite-podgroup-api#readme)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Extends the scheduler's queue metrics to support `CompositePodGroup`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
