### PR TITLE
docs: clarify ExternalJWTSigner claims encoding

### DIFF
--- a/staging/src/k8s.io/externaljwt/apis/v1/api.proto
+++ b/staging/src/k8s.io/externaljwt/apis/v1/api.proto
@@ -49,7 +49,10 @@ service ExternalJWTSigner {
   
   message SignJWTRequest {
     // URL-safe base64 wrapped payload to be signed.
-    // Exactly as it appears in the second segment of the JWT
+    // Exactly as it appears in the second segment of the JWT.
+    // This value is already base64url-encoded and must not be encoded again.
+    // Use it as-is when constructing the signing input
+    // (`base64url(header) + "." + claims`).
     string claims = 1;
   }
   

--- a/staging/src/k8s.io/externaljwt/apis/v1alpha1/api.proto
+++ b/staging/src/k8s.io/externaljwt/apis/v1alpha1/api.proto
@@ -49,7 +49,10 @@ service ExternalJWTSigner {
   
   message SignJWTRequest {
     // URL-safe base64 wrapped payload to be signed.
-    // Exactly as it appears in the second segment of the JWT
+    // Exactly as it appears in the second segment of the JWT.
+    // This value is already base64url-encoded and must not be encoded again.
+    // Use it as-is when constructing the signing input
+    // (`base64url(header) + "." + claims`).
     string claims = 1;
   }
   


### PR DESCRIPTION
<#### What type of PR is this?
/kind documentation

#### What this PR does
Clarifies the documentation for ExternalJWTSigner SignJWTRequest.claims.

The updated documentation makes it explicit that claims is already base64url-encoded and must not be encoded again when constructing the JWT signing input.

#### Why we need this
The previous documentation could be interpreted as requiring implementations to base64url-encode the claims value again, which could result in an invalid JWT.

This change clarifies the expected format and usage of the claims field.