### PR TITLE
Allow workqueues to use multiple metrics providers

### DIFF
--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
@@ -55,7 +55,7 @@ type TypedDelayingQueueConfig[T comparable] struct {
 	Name string
 
 	// MetricsProvider optionally allows specifying a metrics provider to use for the queue
-	// instead of the global provider.
+	// instead of the global providers.
 	MetricsProvider MetricsProvider
 
 	// Clock optionally allows injecting a real or fake clock for testing purposes.
@@ -105,6 +105,11 @@ func NewTypedDelayingQueueWithConfig[T comparable](config TypedDelayingQueueConf
 	}
 	if config.Clock == nil {
 		config.Clock = clock.RealClock{}
+	}
+	// Use one snapshot for both queue and retry metrics, even if another
+	// provider registers while the underlying queue is being constructed.
+	if config.MetricsProvider == nil {
+		config.MetricsProvider = globalMetricsFactory.getProvider()
 	}
 
 	if config.Queue == nil {

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics.go
@@ -17,7 +17,6 @@ limitations under the License.
 package workqueue
 
 import (
-	"sync"
 	"time"
 
 	"k8s.io/utils/clock"
@@ -210,10 +209,6 @@ func (_ noopMetricsProvider) NewRetriesMetric(name string) CounterMetric {
 	return noopMetric{}
 }
 
-var globalMetricsProvider MetricsProvider = noopMetricsProvider{}
-
-var setGlobalMetricsProviderOnce sync.Once
-
 func newQueueMetrics[T comparable](mp MetricsProvider, name string, clock clock.Clock) queueMetrics[T] {
 	if len(name) == 0 || mp == (noopMetricsProvider{}) {
 		return noMetrics[T]{}
@@ -238,7 +233,7 @@ func newRetryMetrics(name string, provider MetricsProvider) retryMetrics {
 	}
 
 	if provider == nil {
-		provider = globalMetricsProvider
+		provider = globalMetricsFactory.getProvider()
 	}
 
 	return &defaultRetryMetrics{
@@ -246,10 +241,11 @@ func newRetryMetrics(name string, provider MetricsProvider) retryMetrics {
 	}
 }
 
-// SetProvider sets the metrics provider for all subsequently created work
-// queues. Only the first call has an effect.
+// SetProvider registers a metrics provider for all subsequently created work
+// queues that do not specify their own provider. Metrics are sent to each
+// registered provider in registration order. Existing queues are not affected.
+// Nil providers are ignored. Callers are responsible for avoiding duplicate
+// registration of the same provider.
 func SetProvider(metricsProvider MetricsProvider) {
-	setGlobalMetricsProviderOnce.Do(func() {
-		globalMetricsProvider = metricsProvider
-	})
+	globalMetricsFactory.setProvider(metricsProvider)
 }

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics_provider.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics_provider.go
@@ -1,0 +1,149 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+import (
+	"slices"
+	"sync"
+)
+
+var globalMetricsFactory = &metricsProviderFactory{}
+
+type metricsProviderFactory struct {
+	mu        sync.RWMutex
+	providers []MetricsProvider
+}
+
+func (f *metricsProviderFactory) setProvider(provider MetricsProvider) {
+	if provider == nil {
+		return
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.providers = append(f.providers, provider)
+}
+
+func (f *metricsProviderFactory) getProvider() MetricsProvider {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	switch len(f.providers) {
+	case 0:
+		return noopMetricsProvider{}
+	case 1:
+		return f.providers[0]
+	default:
+		// Provider callbacks run after the lock is released. Copy the slice so
+		// subsequent registrations cannot change this queue's providers.
+		return multiMetricsProvider(slices.Clone(f.providers))
+	}
+}
+
+type multiMetricsProvider []MetricsProvider
+
+func (p multiMetricsProvider) NewDepthMetric(name string) GaugeMetric {
+	metrics := make(multiGaugeMetric, len(p))
+	for i, provider := range p {
+		metrics[i] = provider.NewDepthMetric(name)
+	}
+	return metrics
+}
+
+func (p multiMetricsProvider) NewAddsMetric(name string) CounterMetric {
+	metrics := make(multiCounterMetric, len(p))
+	for i, provider := range p {
+		metrics[i] = provider.NewAddsMetric(name)
+	}
+	return metrics
+}
+
+func (p multiMetricsProvider) NewLatencyMetric(name string) HistogramMetric {
+	metrics := make(multiHistogramMetric, len(p))
+	for i, provider := range p {
+		metrics[i] = provider.NewLatencyMetric(name)
+	}
+	return metrics
+}
+
+func (p multiMetricsProvider) NewWorkDurationMetric(name string) HistogramMetric {
+	metrics := make(multiHistogramMetric, len(p))
+	for i, provider := range p {
+		metrics[i] = provider.NewWorkDurationMetric(name)
+	}
+	return metrics
+}
+
+func (p multiMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) SettableGaugeMetric {
+	metrics := make(multiSettableGaugeMetric, len(p))
+	for i, provider := range p {
+		metrics[i] = provider.NewUnfinishedWorkSecondsMetric(name)
+	}
+	return metrics
+}
+
+func (p multiMetricsProvider) NewLongestRunningProcessorSecondsMetric(name string) SettableGaugeMetric {
+	metrics := make(multiSettableGaugeMetric, len(p))
+	for i, provider := range p {
+		metrics[i] = provider.NewLongestRunningProcessorSecondsMetric(name)
+	}
+	return metrics
+}
+
+func (p multiMetricsProvider) NewRetriesMetric(name string) CounterMetric {
+	metrics := make(multiCounterMetric, len(p))
+	for i, provider := range p {
+		metrics[i] = provider.NewRetriesMetric(name)
+	}
+	return metrics
+}
+
+type multiGaugeMetric []GaugeMetric
+
+func (m multiGaugeMetric) Inc() {
+	for _, metric := range m {
+		metric.Inc()
+	}
+}
+
+func (m multiGaugeMetric) Dec() {
+	for _, metric := range m {
+		metric.Dec()
+	}
+}
+
+type multiCounterMetric []CounterMetric
+
+func (m multiCounterMetric) Inc() {
+	for _, metric := range m {
+		metric.Inc()
+	}
+}
+
+type multiHistogramMetric []HistogramMetric
+
+func (m multiHistogramMetric) Observe(value float64) {
+	for _, metric := range m {
+		metric.Observe(value)
+	}
+}
+
+type multiSettableGaugeMetric []SettableGaugeMetric
+
+func (m multiSettableGaugeMetric) Set(value float64) {
+	for _, metric := range m {
+		metric.Set(value)
+	}
+}

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics_provider_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics_provider_test.go
@@ -1,0 +1,241 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	testingclock "k8s.io/utils/clock/testing"
+)
+
+func resetMetricsProviders(t *testing.T) {
+	t.Helper()
+	previous := globalMetricsFactory
+	globalMetricsFactory = &metricsProviderFactory{}
+	t.Cleanup(func() { globalMetricsFactory = previous })
+}
+
+func TestMultipleMetricsProviders(t *testing.T) {
+	resetMetricsProviders(t)
+	first, second := &testMetricsProvider{}, &testMetricsProvider{}
+	SetProvider(first)
+	SetProvider(second)
+	c := testingclock.NewFakeClock(time.Unix(0, 0))
+	q := NewTypedDelayingQueueWithConfig(TypedDelayingQueueConfig[string]{Name: "test", Clock: c})
+	defer q.ShutDown()
+	q.AddAfter("item", 0)
+	c.Step(time.Second)
+	item, _ := q.Get()
+	c.Step(2 * time.Second)
+	base := q.(*delayingType[string]).TypedInterface.(*Typed[string])
+	base.cond.L.Lock()
+	base.metrics.updateUnfinishedWork()
+	for i, provider := range []*testMetricsProvider{first, second} {
+		if got := provider.unfinished.gaugeValue(); got != 2 {
+			t.Errorf("provider %d: unfinished work = %v, want 2", i, got)
+		}
+		if got := provider.longest.gaugeValue(); got != 2 {
+			t.Errorf("provider %d: longest running processor = %v, want 2", i, got)
+		}
+	}
+	base.cond.L.Unlock()
+	q.Done(item)
+	for i, provider := range []*testMetricsProvider{first, second} {
+		if got := provider.depth.gaugeValue(); got != 0 {
+			t.Errorf("provider %d: depth = %v, want 0", i, got)
+		}
+		if got := provider.adds.gaugeValue(); got != 1 {
+			t.Errorf("provider %d: adds = %v, want 1", i, got)
+		}
+		if got := provider.latency.observationValue(); got != 1 || provider.latency.observationCount() != 1 {
+			t.Errorf("provider %d: latency = %v with %d observations, want 1 with 1 observation", i, got, provider.latency.observationCount())
+		}
+		if got := provider.duration.observationValue(); got != 2 || provider.duration.observationCount() != 1 {
+			t.Errorf("provider %d: work duration = %v with %d observations, want 2 with 1 observation", i, got, provider.duration.observationCount())
+		}
+		if got := provider.retries.gaugeValue(); got != 1 {
+			t.Errorf("provider %d: retries = %v, want 1", i, got)
+		}
+	}
+}
+
+func TestMetricsProviderFactoryDefaults(t *testing.T) {
+	factory := &metricsProviderFactory{}
+	factory.setProvider(nil)
+	if got := factory.getProvider(); got != (noopMetricsProvider{}) {
+		t.Fatalf("empty factory provider = %T, want noopMetricsProvider", got)
+	}
+	provider := &testMetricsProvider{}
+	factory.setProvider(provider)
+	if got := factory.getProvider(); got != provider {
+		t.Fatalf("single provider = %T, want the original provider", got)
+	}
+}
+
+func TestMetricsProviderQueueConfiguration(t *testing.T) {
+	constructors := map[string]func(string, MetricsProvider) TypedInterface[string]{
+		"queue": func(name string, provider MetricsProvider) TypedInterface[string] {
+			return NewTypedWithConfig(TypedQueueConfig[string]{Name: name, MetricsProvider: provider})
+		},
+		"delaying": func(name string, provider MetricsProvider) TypedInterface[string] {
+			return NewTypedDelayingQueueWithConfig(TypedDelayingQueueConfig[string]{Name: name, MetricsProvider: provider})
+		},
+		"rate limiting": func(name string, provider MetricsProvider) TypedInterface[string] {
+			return NewTypedRateLimitingQueueWithConfig(NewTypedItemExponentialFailureRateLimiter[string](0, 0), TypedRateLimitingQueueConfig[string]{Name: name, MetricsProvider: provider})
+		},
+	}
+	for name, newQueue := range constructors {
+		t.Run(name, func(t *testing.T) {
+			resetMetricsProviders(t)
+			first, second, override := &testMetricsProvider{}, &testMetricsProvider{}, &testMetricsProvider{}
+			SetProvider(first)
+			old := newQueue("old", nil)
+			defer old.ShutDown()
+			SetProvider(second)
+			current := newQueue("current", nil)
+			defer current.ShutDown()
+			custom := newQueue("custom", override)
+			defer custom.ShutDown()
+			unnamed := newQueue("", nil)
+			defer unnamed.ShutDown()
+			unnamedCustom := newQueue("", override)
+			defer unnamedCustom.ShutDown()
+			for _, q := range []TypedInterface[string]{old, current, custom, unnamed, unnamedCustom} {
+				switch q := q.(type) {
+				case TypedRateLimitingInterface[string]:
+					q.AddRateLimited("item")
+					q.Forget("item")
+				case TypedDelayingInterface[string]:
+					q.AddAfter("item", 0)
+				default:
+					q.Add("item")
+				}
+				item, _ := q.Get()
+				q.Done(item)
+			}
+			for _, check := range []struct {
+				provider *testMetricsProvider
+				want     float64
+			}{{first, 2}, {second, 1}, {override, 1}} {
+				if got := check.provider.adds.gaugeValue(); got != check.want {
+					t.Errorf("adds = %v, want %v", got, check.want)
+				}
+				wantRetries := check.want
+				if name == "queue" {
+					wantRetries = 0
+				}
+				if got := check.provider.retries.gaugeValue(); got != wantRetries {
+					t.Errorf("retries = %v, want %v", got, wantRetries)
+				}
+			}
+		})
+	}
+}
+
+type registeringMetricsProvider struct {
+	MetricsProvider
+	onDepth func()
+}
+
+func (p registeringMetricsProvider) NewDepthMetric(name string) GaugeMetric {
+	p.onDepth()
+	return p.MetricsProvider.NewDepthMetric(name)
+}
+
+func TestMetricsProviderRegistrationDuringConstruction(t *testing.T) {
+	for _, name := range []string{"single", "multiple"} {
+		t.Run(name, func(t *testing.T) {
+			resetMetricsProviders(t)
+			first, second := &testMetricsProvider{}, &testMetricsProvider{}
+			var once sync.Once
+			SetProvider(registeringMetricsProvider{MetricsProvider: first, onDepth: func() {
+				once.Do(func() { SetProvider(second) })
+			}})
+			if name == "multiple" {
+				SetProvider(noopMetricsProvider{})
+			}
+			created := make(chan TypedDelayingInterface[string], 1)
+			go func() {
+				created <- NewTypedDelayingQueueWithConfig(TypedDelayingQueueConfig[string]{Name: "test"})
+			}()
+			select {
+			case q := <-created:
+				defer q.ShutDown()
+				q.AddAfter("item", 0)
+				if got := second.adds.gaugeValue(); got != 0 {
+					t.Errorf("late provider adds = %v, want 0", got)
+				}
+				if got := second.retries.gaugeValue(); got != 0 {
+					t.Errorf("late provider retries = %v, want 0", got)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("queue construction blocked while registering a provider from a callback")
+			}
+			next := NewTypedDelayingQueueWithConfig(TypedDelayingQueueConfig[string]{Name: "next"})
+			defer next.ShutDown()
+			next.AddAfter("item", 0)
+			if got := second.adds.gaugeValue(); got != 1 {
+				t.Errorf("late provider adds for new queue = %v, want 1", got)
+			}
+			if got := second.retries.gaugeValue(); got != 1 {
+				t.Errorf("late provider retries for new queue = %v, want 1", got)
+			}
+		})
+	}
+}
+
+func TestMetricsProviderConcurrentRegistration(t *testing.T) {
+	resetMetricsProviders(t)
+	const count = 32
+	providers := make([]*testMetricsProvider, count)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range providers {
+		providers[i] = &testMetricsProvider{}
+		wg.Go(func() {
+			<-start
+			SetProvider(providers[i])
+		})
+		wg.Go(func() {
+			<-start
+			q := NewTypedDelayingQueueWithConfig(TypedDelayingQueueConfig[string]{Name: "concurrent"})
+			defer q.ShutDown()
+			q.AddAfter("item", 0)
+			item, _ := q.Get()
+			q.Done(item)
+		})
+	}
+	close(start)
+	wg.Wait()
+	adds, retries := make([]float64, count), make([]float64, count)
+	for i, provider := range providers {
+		adds[i], retries[i] = provider.adds.gaugeValue(), provider.retries.gaugeValue()
+	}
+	q := NewTypedDelayingQueueWithConfig(TypedDelayingQueueConfig[string]{Name: "all"})
+	defer q.ShutDown()
+	q.AddAfter("item", 0)
+	for i, provider := range providers {
+		if got := provider.adds.gaugeValue(); got != adds[i]+1 {
+			t.Errorf("provider %d: adds = %v, want %v", i, got, adds[i]+1)
+		}
+		if got := provider.retries.gaugeValue(); got != retries[i]+1 {
+			t.Errorf("provider %d: retries = %v, want %v", i, got, retries[i]+1)
+		}
+	}
+}

--- a/staging/src/k8s.io/client-go/util/workqueue/queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/queue.go
@@ -88,7 +88,7 @@ type TypedQueueConfig[T comparable] struct {
 	Name string
 
 	// MetricsProvider optionally allows specifying a metrics provider to use for the queue
-	// instead of the global provider.
+	// instead of the global providers.
 	MetricsProvider MetricsProvider
 
 	// Clock ability to inject real or fake clock for testing purposes.
@@ -139,9 +139,9 @@ func NewNamed(name string) *Type {
 // newQueueWithConfig constructs a new named workqueue
 // with the ability to customize different properties for testing purposes
 func newQueueWithConfig[T comparable](config TypedQueueConfig[T], updatePeriod time.Duration) *Typed[T] {
-	metricsProvider := globalMetricsProvider
-	if config.MetricsProvider != nil {
-		metricsProvider = config.MetricsProvider
+	metricsProvider := config.MetricsProvider
+	if metricsProvider == nil {
+		metricsProvider = globalMetricsFactory.getProvider()
 	}
 
 	if config.Clock == nil {

--- a/staging/src/k8s.io/client-go/util/workqueue/rate_limiting_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/rate_limiting_queue.go
@@ -50,7 +50,7 @@ type TypedRateLimitingQueueConfig[T comparable] struct {
 	Name string
 
 	// MetricsProvider optionally allows specifying a metrics provider to use for the queue
-	// instead of the global provider.
+	// instead of the global providers.
 	MetricsProvider MetricsProvider
 
 	// Clock optionally allows injecting a real or fake clock for testing purposes.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig api-machinery
/sig instrumentation

#### What this PR does / why we need it:

When a library registers a global workqueue metrics provider, subsequent registrations currently have no effect. This prevents applications from receiving metrics through their own global provider when a dependency has already registered one. Explicit per-queue providers offer a workaround, but the application must configure each affected queue.

Retain all registered providers and send metrics to each in registration order. Each newly created queue uses a fixed snapshot; existing queues are unchanged. Delaying queues use the same snapshot for ordinary metrics and retries, including when another provider registers from a construction callback. Explicit per-queue providers continue to override the global providers, and unnamed queues remain uninstrumented.

The single-provider path returns the original provider. Multiple providers share the existing queue timing state, and metric updates do not take the registry lock or allocate.

#### Which issue(s) this PR is related to:

Part of #127739. Companion to the leader-election work in #141172.

#### Special notes for your reviewer:

This change is limited to `util/workqueue`; `tools/metrics` is being handled separately. Registration and snapshot creation are synchronized. Provider constructors and metric callbacks run outside the registry lock. Duplicate provider registration is the caller's responsibility; nil providers are ignored.

Validation, using Go 1.26.6 from `staging/src/k8s.io/client-go`:

- The initial regression test failed against the original implementation: the second provider received no queue additions or retries.
- `GOWORK=off GOTOOLCHAIN=go1.26.6 go test -race ./util/workqueue -count=1 -timeout=5m` passed.
- `GOWORK=off GOTOOLCHAIN=go1.26.6 go test -race ./util/workqueue -run 'TestMultipleMetricsProviders|TestMetricsProvider' -count=20 -timeout=5m` passed on the final changes.
- `GOWORK=off GOTOOLCHAIN=go1.26.6 go vet ./util/workqueue` passed.
- Go formatting, Kubernetes boilerplate checks, and `git diff --check` passed.
- Independent Go review found no blockers.
- `GOWORK=off GOTOOLCHAIN=go1.26.6 go test ./... -count=1 -timeout=15m` passed: 66 packages with tests, 322 packages without tests, zero failures.

#### Does this PR introduce a user-facing change?

```release-note
client-go workqueues now support multiple global metrics providers for subsequently created queues. Explicit per-queue metrics providers continue to override the global providers.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

#### AI usage disclosure:

YES. Generative AI assisted the implementation, regression tests, pre-submission code review, and PR description.
