### PR TITLE
apiserver: improve performance of streamed list responses via buffering

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -17,6 +17,7 @@ limitations under the License.
 package responsewriters
 
 import (
+	"bufio"
 	"compress/gzip"
 	"context"
 	"encoding/json"
@@ -24,6 +25,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -148,6 +150,13 @@ func SerializeObject(mediaType string, encoder runtime.Encoder, hw http.Response
 
 var gzipPool = NewGzipWriterPoolOrDie()
 
+// batchBufferPool recycles lazyBatchWriter's batch buffers across responses.
+var batchBufferPool = &sync.Pool{
+	New: func() interface{} {
+		return bufio.NewWriterSize(nil, streamingBatchBufferBytes)
+	},
+}
+
 const (
 	// defaultGzipThresholdBytes is compared to the size of the first write from the stream
 	// (usually the entire object), and if the size is smaller no gzipping will be performed
@@ -156,7 +165,89 @@ const (
 	// Use the length of the first write to recognize streaming implementations.
 	// When streaming JSON first write is "{", while Kubernetes protobuf starts unique 4 byte header.
 	firstWriteStreamingThresholdBytes = 4
+	// streamingBatchBufferBytes is the size of the buffer that batches a large
+	// streamed response's output. A ten-point sweep (4KiB-4MiB) on multi-GB
+	// list responses measured a flat performance plateau from 128KiB through
+	// 1MiB, degradation below 64KiB (item-sized writes pass through a small
+	// bufio unbatched), and regression at 2MiB and above (larger bursts make
+	// flow control choppier). 128KiB is the smallest size on the plateau,
+	// which keeps pooled memory minimal: at most one buffer per in-flight
+	// large streamed response.
+	streamingBatchBufferBytes = 128 * 1024
+	// streamingBatchEngageThresholdBytes is how many bytes lazyBatchWriter
+	// passes straight to the response writer (compressed bytes, under gzip)
+	// before it takes a pooled buffer and batches the rest. Responses that
+	// stay under it, the small-cluster steady state, never take a pooled
+	// buffer and reach the response writer exactly as on the unbatched path;
+	// larger responses forfeit batching only for this prefix (item-sized
+	// writes under identity, the compressor's small writes under gzip), a
+	// sliver of a multi-GB response. 64KiB is where the sweep put ~85% of the
+	// achievable benefit: below it, batching has little left to save.
+	streamingBatchEngageThresholdBytes = 64 * 1024
 )
+
+// firstWriteIsStreaming reports whether a response's first write looks like a
+// streaming collection encoder's opening bytes rather than a fully-marshaled
+// single object. Gzip negotiation and output batching must agree on this
+// classification, so both use this helper.
+func firstWriteIsStreaming(p []byte) bool {
+	return len(p) <= firstWriteStreamingThresholdBytes
+}
+
+// lazyBatchWriter is the last stage above the HTTP response writer for a
+// committed streamed response, under both encodings (encoder ->
+// lazyBatchWriter, or encoder -> gzip -> lazyBatchWriter).
+//
+// Streamed list responses arrive as one small write per item, and the
+// transports below make each such write expensive: HTTP/2 turns roughly every
+// one into a cross-goroutine DATA-frame handoff that parks the handler
+// goroutine (its 4KiB buffer only coalesces writes smaller than itself), so a
+// multi-GB list pays on the order of a million scheduler round-trips and
+// ships mostly sub-full frames; HTTP/1.1 turns each into its own
+// chunked-transfer frame, with TLS records fragmented to match. Batching
+// turns those into one handoff, or one chunk, per buffer.
+//
+// The writer passes bytes straight through until the response has proven
+// large (streamingBatchEngageThresholdBytes written directly), then takes a
+// pooled buffer and batches the remainder, so small responses never hold a
+// pooled buffer and reach the response writer exactly as before, whatever the
+// encoding.
+type lazyBatchWriter struct {
+	hw     io.Writer     // the response writer
+	direct int           // bytes written straight to hw so far; decides engagement
+	batch  *bufio.Writer // from batchBufferPool once engaged; nil before, and after close
+}
+
+func (b *lazyBatchWriter) Write(p []byte) (int, error) {
+	if b.batch == nil {
+		if b.direct < streamingBatchEngageThresholdBytes {
+			n, err := b.hw.Write(p)
+			if err == nil {
+				// a failed (possibly partial) write must not count: engaging
+				// on the next write would accept it into a fresh buffer
+				// instead of failing it too
+				b.direct += n
+			}
+			return n, err
+		}
+		b.batch = batchBufferPool.Get().(*bufio.Writer)
+		b.batch.Reset(b.hw)
+	}
+	return b.batch.Write(p)
+}
+
+// close flushes any batched bytes to the response writer and returns the
+// buffer to the pool.
+func (b *lazyBatchWriter) close() error {
+	if b.batch == nil {
+		return nil // batching never engaged
+	}
+	err := b.batch.Flush()
+	b.batch.Reset(nil)
+	batchBufferPool.Put(b.batch)
+	b.batch = nil
+	return err
+}
 
 type deferredResponseWriter struct {
 	mediaType       string
@@ -168,9 +259,15 @@ type deferredResponseWriter struct {
 	hasWritten  bool
 	hw          http.ResponseWriter
 	w           io.Writer
-	// totalBytes is the number of bytes written to `w` and does not include buffered bytes
+	// batcher sits between a streamed response and hw (with the gzip writer,
+	// if any, above it) and batches the response's writes once it proves
+	// large; see lazyBatchWriter. Single-object responses bypass it.
+	batcher lazyBatchWriter
+	// totalBytes is the number of bytes written to `w` (including bytes still
+	// batched below it) and does not include buffered bytes
 	totalBytes int
-	// lastWriteErr holds the error result (if any) of the last write attempt to `w`
+	// lastWriteErr holds the error result (if any) of the last write attempt
+	// to `w`, or of Close's final flush
 	lastWriteErr error
 
 	ctx context.Context
@@ -190,7 +287,7 @@ func (w *deferredResponseWriter) Write(p []byte) (n int, err error) {
 		// not yet buffered, first write is long enough to trigger gzip, no need to buffer
 		return w.unbufferedWrite(p)
 
-	case !w.hasBuffered && len(p) > firstWriteStreamingThresholdBytes:
+	case !w.hasBuffered && !firstWriteIsStreaming(p):
 		// not yet buffered, first write is longer than expected for streaming scenarios that would require buffering, no need to buffer
 		return w.unbufferedWrite(p)
 
@@ -221,6 +318,11 @@ func (w *deferredResponseWriter) discardBufferedResponse() {
 	w.buffer = nil
 }
 
+// unbufferedWrite commits the response on its first call (status code and
+// content-encoding headers, chosen from what Write accumulated) and writes p.
+// "Unbuffered" refers to that gzip-negotiation buffer, not to delivery: a
+// streamed response that proves large is batched by lazyBatchWriter below
+// this point.
 func (w *deferredResponseWriter) unbufferedWrite(p []byte) (n int, err error) {
 	defer func() {
 		w.totalBytes += n
@@ -234,17 +336,28 @@ func (w *deferredResponseWriter) unbufferedWrite(p []byte) (n int, err error) {
 
 	hw := w.hw
 	header := hw.Header()
+
+	// Route streamed responses through the lazy batcher; single objects go to
+	// hw directly. A response is streamed if its first write was tiny, which
+	// shows up here in one of two ways: Write buffered that first write for
+	// gzip negotiation (hasBuffered, and p is now the accumulated prefix), or
+	// passed it straight through (p is that first write).
+	var sink io.Writer = hw
+	if w.hasBuffered || firstWriteIsStreaming(p) {
+		w.batcher = lazyBatchWriter{hw: hw}
+		sink = &w.batcher
+	}
 	switch {
 	case w.contentEncoding == "gzip" && len(p) > defaultGzipThresholdBytes:
 		header.Set("Content-Encoding", "gzip")
 		header.Add("Vary", "Accept-Encoding")
 
 		gw := gzipPool.Get().(*gzip.Writer)
-		gw.Reset(hw)
+		gw.Reset(sink)
 
 		w.w = gw
 	default:
-		w.w = hw
+		w.w = sink
 	}
 
 	span := tracing.SpanFromContext(w.ctx)
@@ -280,18 +393,31 @@ func (w *deferredResponseWriter) Close() (err error) {
 		if !w.hasBuffered {
 			return nil
 		}
-		// never reached defaultGzipThresholdBytes, no need to do the gzip writer cleanup
-		_, err := w.unbufferedWrite(w.buffer)
+		// never reached defaultGzipThresholdBytes: commit now, writing the
+		// accumulated body uncompressed
+		_, err = w.unbufferedWrite(w.buffer)
 		w.buffer = nil
-		return err
 	}
 
+	// Release whatever the response engaged; a body drained just above is one
+	// uncompressed write and engaged nothing.
 	switch t := w.w.(type) {
 	case *gzip.Writer:
 		err = t.Close()
 		t.Reset(nil)
 		gzipPool.Put(t)
 	}
+	if flushErr := w.batcher.close(); flushErr != nil && err == nil {
+		err = flushErr
+	}
+	// A cleanup failure is recorded like a write error so the span reports it.
+	if err != nil && w.lastWriteErr == nil {
+		w.lastWriteErr = err
+	}
+	// The pooled writers released above may already serve another response;
+	// drop w.w so that a Write after Close (which no caller does) panics on
+	// the nil writer instead of reaching them.
+	w.w = nil
 	return err
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_batch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_batch_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package responsewriters
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// countingResponseWriter is an httptest.ResponseRecorder that counts the
+// Write calls reaching the network-facing response writer (hw), as opposed
+// to the encoder's writes into deferredResponseWriter, and can inject write
+// failures.
+type countingResponseWriter struct {
+	*httptest.ResponseRecorder
+	writeCount int
+	failWrites bool
+}
+
+func newCountingResponseWriter() *countingResponseWriter {
+	return &countingResponseWriter{ResponseRecorder: httptest.NewRecorder()}
+}
+
+func (w *countingResponseWriter) Write(p []byte) (int, error) {
+	w.writeCount++
+	if w.failWrites {
+		return 0, errors.New("connection reset by peer")
+	}
+	return w.ResponseRecorder.Write(p)
+}
+
+func newDeferredWriter(hw http.ResponseWriter, mediaType, contentEncoding string) *deferredResponseWriter {
+	return &deferredResponseWriter{
+		mediaType:       mediaType,
+		statusCode:      http.StatusOK,
+		contentEncoding: contentEncoding,
+		hw:              hw,
+		ctx:             context.Background(),
+	}
+}
+
+// streamWrite simulates a streaming collection encoder: a small opening
+// write, one write per item, and an optional closing write. It returns the
+// concatenation the response body must equal.
+func streamWrite(t testing.TB, w io.Writer, opener, item, closer []byte, items int) []byte {
+	t.Helper()
+	var want bytes.Buffer
+	writeBoth := func(p []byte) {
+		want.Write(p)
+		if _, err := w.Write(p); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+	}
+	writeBoth(opener)
+	for range items {
+		writeBoth(item)
+	}
+	if len(closer) > 0 {
+		writeBoth(closer)
+	}
+	return want.Bytes()
+}
+
+// varyingItem returns a ~1KiB item whose content differs per index, so a
+// stream of them compresses the way real lists do (a few x) instead of
+// collapsing to almost nothing.
+func varyingItem(i int) []byte {
+	var b strings.Builder
+	x := uint64(i)*0x9E3779B97F4A7C15 | 1
+	for b.Len() < 1024 {
+		x ^= x << 13
+		x ^= x >> 7
+		x ^= x << 17
+		fmt.Fprintf(&b, `{"name":"pod-%d","uid":"%016x","phase":"Running"},`, i, x)
+	}
+	return []byte(b.String())
+}
+
+// TestStreamedResponseBatchesWrites pins the lazy engagement contract and
+// byte-identity for identity responses: a streamed response (JSON's "{" or
+// the protobuf stream header first) reaches the response writer write for
+// write until streamingBatchEngageThresholdBytes, then in buffer-sized
+// batches; a streamed response under the threshold, and a single-object
+// response, are never batched.
+func TestStreamedResponseBatchesWrites(t *testing.T) {
+	jsonOpener, protobufOpener := []byte("{"), []byte{0x6b, 0x38, 0x73, 0x00}
+	const itemSize = 1024
+	tests := []struct {
+		name    string
+		opener  []byte // nil: a single object, written in one call
+		items   int
+		batched bool
+	}{
+		{name: "large JSON stream engages after threshold", opener: jsonOpener, items: 3000, batched: true},
+		{name: "large protobuf stream engages after threshold", opener: protobufOpener, items: 3000, batched: true},
+		{name: "small stream stays direct", opener: jsonOpener, items: streamingBatchEngageThresholdBytes/itemSize - 16},
+		{name: "single object stays direct", items: 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := newCountingResponseWriter()
+			drw := newDeferredWriter(rec, "application/json", "")
+			var want []byte
+			if tc.opener == nil {
+				want = bytes.Repeat([]byte("y"), 512*1024)
+				if _, err := drw.Write(want); err != nil {
+					t.Fatalf("write failed: %v", err)
+				}
+			} else {
+				want = streamWrite(t, drw, tc.opener, bytes.Repeat([]byte("x"), itemSize), []byte("}"), tc.items)
+			}
+			if err := drw.Close(); err != nil {
+				t.Fatalf("close failed: %v", err)
+			}
+			if !bytes.Equal(rec.Body.Bytes(), want) {
+				t.Errorf("body differs from what was written: got %d bytes, want %d", rec.Body.Len(), len(want))
+			}
+			// Unbatched, every write reaches the response writer; batched, the
+			// writes before the threshold do and the rest arrive in
+			// buffer-sized flushes (+2 slack for the opener and closer).
+			directWrites := 1
+			if tc.opener != nil {
+				directWrites = tc.items + 2
+			}
+			minWrites, maxWrites := directWrites, directWrites
+			if tc.batched {
+				minWrites = streamingBatchEngageThresholdBytes / itemSize
+				maxWrites = minWrites + 2 + tc.items*itemSize/streamingBatchBufferBytes + 2
+			}
+			if rec.writeCount < minWrites || rec.writeCount > maxWrites {
+				t.Errorf("response reached the response writer in %d writes, want %d..%d", rec.writeCount, minWrites, maxWrites)
+			}
+		})
+	}
+}
+
+// TestStreamedGzipResponseEngagesLazily pins that batching is lazy under
+// gzip too: the first compressed bytes reach the response writer as soon as
+// the gzip threshold commits the response, not once a batch buffer of
+// compressed output has filled, and the batched body still decompresses to
+// what was written.
+func TestStreamedGzipResponseEngagesLazily(t *testing.T) {
+	rec := newCountingResponseWriter()
+	drw := newDeferredWriter(rec, "application/json", "gzip")
+	var want bytes.Buffer
+	firstByteAt := -1 // plaintext bytes written when compressed output first reached rec
+	write := func(p []byte) {
+		want.Write(p)
+		if _, err := drw.Write(p); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+		if firstByteAt < 0 && rec.Body.Len() > 0 {
+			firstByteAt = want.Len()
+		}
+	}
+	write([]byte("{"))
+	const items = 4096 // ~4MiB of plaintext, ~1.5MiB compressed
+	for i := range items {
+		write(varyingItem(i))
+	}
+	if err := drw.Close(); err != nil {
+		t.Fatalf("close failed: %v", err)
+	}
+
+	if firstByteAt < 0 || firstByteAt > defaultGzipThresholdBytes+2*1024 {
+		t.Errorf("first compressed bytes reached the response writer after %d bytes of plaintext, want at commit (~%d)", firstByteAt, defaultGzipThresholdBytes)
+	}
+	// Past the threshold the compressor's small writes are batched, so far
+	// fewer writes reach the response writer than items were written.
+	if rec.writeCount >= items {
+		t.Errorf("%d writes reached the response writer for %d items, want batching", rec.writeCount, items)
+	}
+	zr, err := gzip.NewReader(bytes.NewReader(rec.Body.Bytes()))
+	if err != nil {
+		t.Fatalf("body is not valid gzip: %v", err)
+	}
+	if got, err := io.ReadAll(zr); err != nil || !bytes.Equal(got, want.Bytes()) {
+		t.Fatalf("decompressed body differs from streamed input (err=%v): got %d bytes, want %d", err, len(got), want.Len())
+	}
+}
+
+// TestStreamedResponseFlushErrorSurfaces pins that once batching is engaged,
+// a network write failure discovered at Close's flush is returned to the
+// caller (and recorded like any other write error) rather than swallowed,
+// under both encodings.
+func TestStreamedResponseFlushErrorSurfaces(t *testing.T) {
+	for _, contentEncoding := range []string{"", "gzip"} {
+		t.Run("contentEncoding="+contentEncoding, func(t *testing.T) {
+			rec := newCountingResponseWriter()
+			drw := newDeferredWriter(rec, "application/json", contentEncoding)
+			if _, err := drw.Write([]byte("{")); err != nil {
+				t.Fatalf("write failed: %v", err)
+			}
+			// Stream while the connection is healthy until batching engages...
+			for i := 0; drw.batcher.batch == nil; i++ {
+				if i > 8192 {
+					t.Fatal("batching never engaged")
+				}
+				if _, err := drw.Write(varyingItem(i)); err != nil {
+					t.Fatalf("write failed: %v", err)
+				}
+			}
+			// ...then break the connection: the next write lands in the batch
+			// buffer, and only the Close-time flush can discover the failure.
+			rec.failWrites = true
+			if _, err := drw.Write(varyingItem(0)); err != nil {
+				t.Fatalf("unexpected write error before flush: %v", err)
+			}
+			if err := drw.Close(); err == nil {
+				t.Fatal("Close succeeded despite the underlying writer failing")
+			}
+			if drw.lastWriteErr == nil {
+				t.Error("flush failure not recorded in lastWriteErr")
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig api-machinery

#### What this PR does / why we need it:

Streamed LIST responses reach net/http as one write per item. Over HTTP/2 each of those writes (once past the handler's 4KiB buffer) becomes a cross-goroutine DATA-frame handoff that parks the serving goroutine; over HTTP/1.1 each becomes its own chunked-transfer frame. #141586 added the benchmark that shows the cost: on master, serving 10k protobuf pods takes ~209ms over HTTP/1.1 and ~484ms over HTTP/2 for the same bytes, and the difference is almost entirely the per-item write handoffs.

This adds a small last stage above the response writer, `lazyBatchWriter`, that passes writes straight through until 64KiB have reached the transport and then batches the rest through a pooled 128KiB buffer. Small responses (and every response's first 64KiB) are written exactly as today; output bytes are unchanged. Both sizes come from a buffer sweep (4KiB–4MiB): a flat plateau from 128KiB to 1MiB, degrading below 64KiB and above 2MiB.

`BenchmarkSerializeObject` (#141586), master vs this PR, 6 runs each, compared with `benchstat` (medians, ± confidence interval, Mann-Whitney p; `~` = no significant difference); reproduce with `go test ./staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/ -run '^$' -bench 'BenchmarkSerializeObject$' -count 6` on each branch and `benchstat old.txt new.txt`.

Go 1.26.6 (the toolchain master builds with):

```
count   encoding compress protocol        master       patched    delta
   100  Json     identity HTTP/1.1  7.20ms ±  2%  6.63ms ±  1%   -7.93%  p=0.002
   100  Json     identity HTTP/2    8.33ms ±  1%  8.02ms ±  1%   -3.69%  p=0.002
   100  Json     gzip     HTTP/1.1  9.67ms ±  3%  9.54ms ±  1%        ~  p=0.180
   100  Json     gzip     HTTP/2    9.99ms ±  1%  9.86ms ±  3%        ~  p=0.065
   100  Protobuf identity HTTP/1.1  1.94ms ±  8%  1.46ms ±  2%  -24.83%  p=0.002
   100  Protobuf identity HTTP/2    4.52ms ±  1%  2.55ms ±  2%  -43.68%  p=0.002
   100  Protobuf gzip     HTTP/1.1  2.92ms ±  2%  2.92ms ±  2%        ~  p=0.699
   100  Protobuf gzip     HTTP/2    3.19ms ±  1%  3.26ms ±  5%   +2.05%  p=0.009

  1000  Json     identity HTTP/1.1  68.8ms ±  4%  63.7ms ±  3%   -7.45%  p=0.002
  1000  Json     identity HTTP/2    81.4ms ±  1%  78.7ms ±  1%   -3.30%  p=0.002
  1000  Json     gzip     HTTP/1.1  89.1ms ±  0%  88.1ms ±  1%   -1.14%  p=0.002
  1000  Json     gzip     HTTP/2    96.8ms ±  2%  88.8ms ±  5%   -8.21%  p=0.002
  1000  Protobuf identity HTTP/1.1  18.1ms ±  4%  12.6ms ±  6%  -30.32%  p=0.002
  1000  Protobuf identity HTTP/2    43.8ms ±  5%  22.4ms ±  4%  -48.76%  p=0.002
  1000  Protobuf gzip     HTTP/1.1  25.1ms ±  5%  24.5ms ±  1%   -2.25%  p=0.009
  1000  Protobuf gzip     HTTP/2    27.0ms ±  3%  25.6ms ±  2%   -5.13%  p=0.002

 10000  Json     identity HTTP/1.1   696ms ±  2%   619ms ±  1%  -11.00%  p=0.002
 10000  Json     identity HTTP/2     811ms ±  3%   775ms ±  4%   -4.51%  p=0.004
 10000  Json     gzip     HTTP/1.1   886ms ±  2%   870ms ± 18%        ~  p=0.180
 10000  Json     gzip     HTTP/2     957ms ±  8%   877ms ±  0%   -8.39%  p=0.002
 10000  Protobuf identity HTTP/1.1   209ms ±  6%   150ms ±  4%  -28.22%  p=0.002
 10000  Protobuf identity HTTP/2     484ms ±  1%   251ms ±  2%  -48.05%  p=0.002
 10000  Protobuf gzip     HTTP/1.1   278ms ±  2%   269ms ±  1%   -3.02%  p=0.002
 10000  Protobuf gzip     HTTP/2     305ms ±  2%   272ms ±  4%  -10.77%  p=0.002

100000  Json     identity HTTP/1.1  6942ms ±  2%  6216ms ±  1%  -10.46%  p=0.002
100000  Json     identity HTTP/2    8134ms ±  1%  7751ms ±  1%   -4.70%  p=0.002
100000  Json     gzip     HTTP/1.1  8935ms ±  2%  8650ms ±  2%   -3.19%  p=0.002
100000  Json     gzip     HTTP/2    9638ms ±  2%  8836ms ±  3%   -8.33%  p=0.002
100000  Protobuf identity HTTP/1.1  2152ms ±  3%  1549ms ±  5%  -28.04%  p=0.002
100000  Protobuf identity HTTP/2    4856ms ±  2%  2558ms ±  2%  -47.32%  p=0.002
100000  Protobuf gzip     HTTP/1.1  2813ms ±  1%  2690ms ±  0%   -4.40%  p=0.002
100000  Protobuf gzip     HTTP/2    3083ms ±  1%  2773ms ±  4%  -10.04%  p=0.002

geomean                                  157.9ms       134.6ms  -14.73%
```

Go 1.27.0, where json/v2 is the default `encoding/json` and gzip is faster, so the write path is a larger share of each response:

```
count   encoding compress protocol        master       patched    delta
   100  Json     identity HTTP/1.1  6.05ms ±  2%  5.72ms ±  4%   -5.57%  p=0.002
   100  Json     identity HTTP/2    7.45ms ±  4%  6.00ms ±  2%  -19.41%  p=0.002
   100  Json     gzip     HTTP/1.1  6.58ms ±  4%  6.67ms ±  5%        ~  p=0.310
   100  Json     gzip     HTTP/2    7.20ms ±  4%  7.22ms ±  3%        ~  p=0.937
   100  Protobuf identity HTTP/1.1  1.83ms ±  4%  1.39ms ±  2%  -23.89%  p=0.002
   100  Protobuf identity HTTP/2    4.45ms ±  1%  2.10ms ±  8%  -52.79%  p=0.002
   100  Protobuf gzip     HTTP/1.1  2.15ms ±  4%  2.15ms ±  1%        ~  p=0.818
   100  Protobuf gzip     HTTP/2    2.42ms ±  0%  2.44ms ±  1%        ~  p=0.310

  1000  Json     identity HTTP/1.1  60.3ms ±  5%  53.2ms ±  2%  -11.81%  p=0.002
  1000  Json     identity HTTP/2    71.8ms ±  7%  56.8ms ±  2%  -20.89%  p=0.002
  1000  Json     gzip     HTTP/1.1  62.0ms ±  3%  60.6ms ±  1%   -2.33%  p=0.026
  1000  Json     gzip     HTTP/2    65.5ms ±  2%  60.8ms ±  0%   -7.13%  p=0.002
  1000  Protobuf identity HTTP/1.1  16.9ms ±  7%  12.5ms ±  5%  -25.94%  p=0.002
  1000  Protobuf identity HTTP/2    42.9ms ±  2%  17.3ms ±  3%  -59.66%  p=0.002
  1000  Protobuf gzip     HTTP/1.1  16.9ms ± 10%  16.6ms ±  2%   -1.87%  p=0.015
  1000  Protobuf gzip     HTTP/2    19.2ms ±  1%  17.3ms ±  4%   -9.51%  p=0.002

 10000  Json     identity HTTP/1.1   587ms ±  2%   530ms ±  6%   -9.60%  p=0.002
 10000  Json     identity HTTP/2     744ms ±  5%   564ms ±  4%  -24.18%  p=0.002
 10000  Json     gzip     HTTP/1.1   604ms ±  1%   593ms ±  6%        ~  p=0.394
 10000  Json     gzip     HTTP/2     674ms ±  5%   592ms ±  1%  -12.28%  p=0.002
 10000  Protobuf identity HTTP/1.1   205ms ±  4%   145ms ±  2%  -28.96%  p=0.002
 10000  Protobuf identity HTTP/2     478ms ±  1%   192ms ±  1%  -59.74%  p=0.002
 10000  Protobuf gzip     HTTP/1.1   200ms ±  2%   188ms ±  8%   -6.04%  p=0.041
 10000  Protobuf gzip     HTTP/2     227ms ±  5%   190ms ±  3%  -16.24%  p=0.002

100000  Json     identity HTTP/1.1  5908ms ±  1%  5386ms ± 10%   -8.83%  p=0.015
100000  Json     identity HTTP/2    7355ms ±  1%  5694ms ±  2%  -22.58%  p=0.002
100000  Json     gzip     HTTP/1.1  6059ms ±  1%  5896ms ±  2%   -2.68%  p=0.002
100000  Json     gzip     HTTP/2    6633ms ±  3%  5950ms ±  3%  -10.28%  p=0.002
100000  Protobuf identity HTTP/1.1  2024ms ±  2%  1513ms ±  1%  -25.24%  p=0.002
100000  Protobuf identity HTTP/2    4755ms ±  2%  1958ms ±  5%  -58.83%  p=0.002
100000  Protobuf gzip     HTTP/1.1  2010ms ±  1%  1909ms ±  2%   -5.02%  p=0.002
100000  Protobuf gzip     HTTP/2    2325ms ±  2%  1930ms ±  1%  -17.02%  p=0.002

geomean                                  127.4ms       102.5ms  -19.59%
```

The effect follows how much of a response's cost is the write path: protobuf (cheap to encode) gains 45–50% over HTTP/2 and 25–30% over HTTP/1.1 on 1.26 (53–60% / 24–29% on 1.27); JSON gains 3–11% on 1.26 and 19–24% over HTTP/2 on 1.27; gzip'd responses, whose compressed bytes are what get batched, gain up to 11% (1.26) / 17% (1.27) over HTTP/2. No cell regresses beyond noise; the small gzip'd responses read `~` because they stay under the engage threshold and take the unchanged path.

#### Which issue(s) this PR is related to:

Follow-up to #141586. Prior review discussion that asked for buffering on this path: https://github.com/kubernetes/kubernetes/pull/130281#discussion_r1964531348 and https://github.com/kubernetes/kubernetes/pull/129407#discussion_r1989625640.

#### Special notes for your reviewer:

Alternatives, as drafts for comparison: #141835 writes every response through one 128KiB buffer ahead of the gzip decision, replacing the existing negotiation buffer (`writers.go` net ±0) — identity responses gain the same, gzip'd responses are unchanged because `compress/flate` emits ~240-byte writes below it; #141834 is this PR without the laziness (`writers.go` +43/−7) — same gains including gzip, but every in-flight response holds a pooled buffer and gzip time-to-first-byte roughly doubles. Benchmark geomean on Go 1.26.6 / 1.27.0: this PR −14.7% / −19.6%, #141835 −14.6% / −16.7%, #141834 −15.9% / −18.7%.

Semantics: the response is already committed when batching engages, so a client disconnect mid-stream is noticed within one 128KiB buffer (under gzip, 128KiB of compressed output) instead of within one item; when it lands in the final buffer the error surfaces from `Close` rather than `Encode`, which `SerializeObject` already handles for gzip responses today. Tests pin byte-identity, lazy engagement under both encodings, and flush-error surfacing.

This PR was written in part with the assistance of generative AI.

#### Does this PR introduce a user-facing change?

```release-note
kube-apiserver: large streamed LIST responses are written to the connection in batches rather than one item at a time, reducing CPU and wall-clock time for large LISTs over both HTTP/2 and HTTP/1.1. Response bytes are unchanged.
```
