### PR TITLE
storage/testing/coverage: classify storage.Interface calls, add coverage.Wrap (Step 1 of #141652)

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_delete.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_delete.go
@@ -1,0 +1,30 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+import (
+	"k8s.io/apiserver/pkg/storage"
+)
+
+// ClassifyDelete classifies a storage.Interface.Delete call.
+func ClassifyDelete(preconditions *storage.Preconditions, err error) State {
+	return State{
+		Verb:          VerbDelete,
+		Preconditions: classifyPreconditionMode(preconditions),
+		Outcome:       classifyTerminalErrorOutcome(err),
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_get.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_get.go
@@ -1,0 +1,31 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+import (
+	"k8s.io/apiserver/pkg/storage"
+)
+
+// ClassifyGet classifies a storage.Interface.Get call.
+func ClassifyGet(opts storage.GetOptions, err error) State {
+	return State{
+		Verb:            VerbGet,
+		ResourceVersion: classifyResourceVersionMode(opts.ResourceVersion),
+		IgnoreNotFound:  opts.IgnoreNotFound,
+		Outcome:         classifyTerminalErrorOutcome(err),
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_list.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_list.go
@@ -1,0 +1,35 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+import (
+	"k8s.io/apiserver/pkg/storage"
+)
+
+// ClassifyList classifies a storage.Interface.GetList call.
+func ClassifyList(opts storage.ListOptions, err error) State {
+	selector, pagination := classifySelectionPredicate(opts.Predicate)
+	return State{
+		Verb:                 VerbList,
+		ResourceVersion:      classifyResourceVersionMode(opts.ResourceVersion),
+		ResourceVersionMatch: classifyResourceVersionMatchMode(opts.ResourceVersionMatch),
+		Recursive:            opts.Recursive,
+		Pagination:           pagination,
+		Selector:             selector,
+		Outcome:              classifyTerminalErrorOutcome(err),
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_pagination.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_pagination.go
@@ -1,0 +1,36 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+// PaginationMode classifies the pagination shape of a list SelectionPredicate.
+type PaginationMode string
+
+const (
+	PaginationNone     PaginationMode = "PaginationNone"     // no Limit, no Continue
+	PaginationLimit    PaginationMode = "PaginationLimit"    // Limit set, first page
+	PaginationContinue PaginationMode = "PaginationContinue" // Continue token set
+)
+
+func classifyPagination(limit int64, continueToken string) PaginationMode {
+	if continueToken != "" {
+		return PaginationContinue
+	}
+	if limit > 0 {
+		return PaginationLimit
+	}
+	return PaginationNone
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_precondition_mode.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_precondition_mode.go
@@ -1,0 +1,46 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+import (
+	"k8s.io/apiserver/pkg/storage"
+)
+
+// PreconditionMode classifies a Delete call's *storage.Preconditions.
+type PreconditionMode string
+
+const (
+	PreconditionNone            PreconditionMode = "PreconditionNone"
+	PreconditionUID             PreconditionMode = "PreconditionUID"
+	PreconditionResourceVersion PreconditionMode = "PreconditionResourceVersion"
+	PreconditionBoth            PreconditionMode = "PreconditionBoth"
+)
+
+func classifyPreconditionMode(p *storage.Preconditions) PreconditionMode {
+	switch {
+	case p == nil:
+		return PreconditionNone
+	case p.UID != nil && p.ResourceVersion != nil:
+		return PreconditionBoth
+	case p.UID != nil:
+		return PreconditionUID
+	case p.ResourceVersion != nil:
+		return PreconditionResourceVersion
+	default:
+		return PreconditionNone
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_resource_version_match_mode.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_resource_version_match_mode.go
@@ -1,0 +1,41 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ResourceVersionMatchMode classifies ListOptions.ResourceVersionMatch.
+type ResourceVersionMatchMode string
+
+const (
+	RVMatchUnset        ResourceVersionMatchMode = "RVMatchUnset"
+	RVMatchNotOlderThan ResourceVersionMatchMode = "RVMatchNotOlderThan"
+	RVMatchExact        ResourceVersionMatchMode = "RVMatchExact"
+)
+
+func classifyResourceVersionMatchMode(m metav1.ResourceVersionMatch) ResourceVersionMatchMode {
+	switch m {
+	case metav1.ResourceVersionMatchNotOlderThan:
+		return RVMatchNotOlderThan
+	case metav1.ResourceVersionMatchExact:
+		return RVMatchExact
+	default:
+		return RVMatchUnset
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_resource_version_mode.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_resource_version_mode.go
@@ -1,0 +1,38 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+// ResourceVersionMode classifies the ResourceVersion string on a
+// GetOptions/ListOptions request.
+type ResourceVersionMode string
+
+const (
+	RVUnset ResourceVersionMode = "RVUnset" // ResourceVersion == ""
+	RVZero  ResourceVersionMode = "RVZero"  // ResourceVersion == "0"
+	RVExact ResourceVersionMode = "RVExact" // ResourceVersion == any other value
+)
+
+func classifyResourceVersionMode(rvm string) ResourceVersionMode {
+	switch rvm {
+	case "":
+		return RVUnset
+	case "0":
+		return RVZero
+	default:
+		return RVExact
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_selection_predicate.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_selection_predicate.go
@@ -1,0 +1,27 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+import (
+	"k8s.io/apiserver/pkg/storage"
+)
+
+func classifySelectionPredicate(p storage.SelectionPredicate) (SelectorMode, PaginationMode) {
+	hasLabel := p.Label != nil && !p.Label.Empty()
+	hasField := p.Field != nil && !p.Field.Empty()
+	return classifySelector(hasLabel, hasField), classifyPagination(p.Limit, p.Continue)
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_selector.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_selector.go
@@ -1,0 +1,40 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+// SelectorMode classifies the label/field selector shape of a SelectionPredicate.
+type SelectorMode string
+
+const (
+	SelectorNone  SelectorMode = "SelectorNone" // Everything
+	SelectorLabel SelectorMode = "SelectorLabel"
+	SelectorField SelectorMode = "SelectorField"
+	SelectorBoth  SelectorMode = "SelectorBoth"
+)
+
+func classifySelector(hasLabel, hasField bool) SelectorMode {
+	switch {
+	case hasLabel && hasField:
+		return SelectorBoth
+	case hasLabel:
+		return SelectorLabel
+	case hasField:
+		return SelectorField
+	default:
+		return SelectorNone
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_send_initial_events.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_send_initial_events.go
@@ -1,0 +1,37 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+// SendInitialEventsMode classifies ListOptions.SendInitialEvents.
+type SendInitialEventsMode string
+
+const (
+	SendInitialEventsUnset SendInitialEventsMode = "SendInitialEventsUnset"
+	SendInitialEventsTrue  SendInitialEventsMode = "SendInitialEventsTrue"
+	SendInitialEventsFalse SendInitialEventsMode = "SendInitialEventsFalse"
+)
+
+func classifySendInitialEvents(b *bool) SendInitialEventsMode {
+	switch {
+	case b == nil:
+		return SendInitialEventsUnset
+	case *b:
+		return SendInitialEventsTrue
+	default:
+		return SendInitialEventsFalse
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_terminal_error_outcome.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_terminal_error_outcome.go
@@ -1,0 +1,46 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+import (
+	"k8s.io/apiserver/pkg/storage"
+)
+
+// classifyTerminalErrorOutcome classifies the terminal error (or nil)
+// returned by a storage.Interface call into an Outcome.
+func classifyTerminalErrorOutcome(err error) Outcome {
+	switch {
+	case err == nil:
+		return OutcomeSuccess
+	case storage.IsNotFound(err):
+		return OutcomeNotFound
+	case storage.IsExist(err):
+		return OutcomeExists
+	case storage.IsConflict(err):
+		return OutcomeConflict
+	case storage.IsInvalidObj(err):
+		return OutcomeInvalidObj
+	case storage.IsUnreachable(err):
+		return OutcomeUnreachable
+	case storage.IsRequestTimeout(err):
+		return OutcomeTimeout
+	case storage.IsCorruptObject(err):
+		return OutcomeCorruptObj
+	default:
+		return OutcomeOtherError
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_watch.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/classify_watch.go
@@ -1,0 +1,36 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+import (
+	"k8s.io/apiserver/pkg/storage"
+)
+
+// ClassifyWatch classifies a storage.Interface.Watch call.
+func ClassifyWatch(opts storage.ListOptions, err error) State {
+	selector, _ := classifySelectionPredicate(opts.Predicate)
+	return State{
+		Verb:                 VerbWatch,
+		ResourceVersion:      classifyResourceVersionMode(opts.ResourceVersion),
+		ResourceVersionMatch: classifyResourceVersionMatchMode(opts.ResourceVersionMatch),
+		Recursive:            opts.Recursive,
+		Selector:             selector,
+		AllowWatchBookmarks:  opts.Predicate.AllowWatchBookmarks,
+		SendInitialEvents:    classifySendInitialEvents(opts.SendInitialEvents),
+		Outcome:              classifyTerminalErrorOutcome(err),
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/doc.go
@@ -1,0 +1,27 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package coverage classifies calls made through storage.Interface into a
+// small set of API states (ResourceVersion mode, ResourceVersionMatch,
+// pagination, selectors, preconditions, terminal error outcome) and reports
+// which of those states existing test suites actually exercise.
+//
+// Wrap decorates a storage.Interface so that Get, GetList, Watch and Delete
+// calls are classified and recorded, while every other method passes through
+// untouched. It has no dependency beyond storage/apimachinery/stdlib, so it
+// can be dropped around any storage.Interface implementation's test suite
+// without pulling in new test-only dependencies.
+package coverage

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/recorder.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/recorder.go
@@ -1,0 +1,50 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+import "sync"
+
+// Recorder counts how many times each State has been observed by a Wrap-ed
+// storage.Interface. It is safe for concurrent use.
+type Recorder struct {
+	mu   sync.Mutex
+	seen map[State]int
+}
+
+// NewRecorder returns an empty Recorder.
+func NewRecorder() *Recorder {
+	return &Recorder{seen: make(map[State]int)}
+}
+
+// Observe records one occurrence of state.
+func (r *Recorder) Observe(state State) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.seen[state]++
+}
+
+// Counts returns a snapshot of how many times each observed State occurred.
+// States never observed are absent from the result.
+func (r *Recorder) Counts() map[State]int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make(map[State]int, len(r.seen))
+	for k, v := range r.seen {
+		out[k] = v
+	}
+	return out
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/scorecard.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/scorecard.go
@@ -1,0 +1,66 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Scorecard reports, for a set of target States, which were observed at
+// least once and which were not.
+type Scorecard struct {
+	Total   int
+	Covered int
+	Missing []State
+}
+
+// Scorecard diffs the Recorder's observations against targetStates, typically
+// TargetStates(). Entries not observed at least once are reported in
+// Missing, in the same order they appear in targetStates.
+func (r *Recorder) Scorecard(targetStates []State) Scorecard {
+	counts := r.Counts()
+	sc := Scorecard{Total: len(targetStates)}
+	for _, state := range targetStates {
+		if counts[state] > 0 {
+			sc.Covered++
+		} else {
+			sc.Missing = append(sc.Missing, state)
+		}
+	}
+	return sc
+}
+
+// String renders a human-readable coverage report, e.g. for t.Log.
+func (sc Scorecard) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "coverage: %d/%d states covered\n", sc.Covered, sc.Total)
+	if len(sc.Missing) == 0 {
+		return strings.TrimSuffix(b.String(), "\n")
+	}
+	missing := make([]string, len(sc.Missing))
+	for i, s := range sc.Missing {
+		missing[i] = s.String()
+	}
+	sort.Strings(missing)
+	fmt.Fprintf(&b, "missing %d states:\n", len(missing))
+	for _, s := range missing {
+		fmt.Fprintf(&b, "  - %s\n", s)
+	}
+	return strings.TrimSuffix(b.String(), "\n")
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/scorecard_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/scorecard_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+import "testing"
+
+func TestScorecardReportsMissingStates(t *testing.T) {
+	rec := NewRecorder()
+	targetStates := []State{
+		{Verb: VerbGet, ResourceVersion: RVUnset, Outcome: OutcomeSuccess},
+		{Verb: VerbGet, ResourceVersion: RVZero, Outcome: OutcomeSuccess},
+	}
+	rec.Observe(targetStates[0])
+
+	sc := rec.Scorecard(targetStates)
+	if sc.Total != 2 || sc.Covered != 1 {
+		t.Fatalf("expected 1/2 covered, got %d/%d", sc.Covered, sc.Total)
+	}
+	if len(sc.Missing) != 1 || sc.Missing[0] != targetStates[1] {
+		t.Fatalf("expected %s to be reported missing, got %v", targetStates[1], sc.Missing)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/state.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/state.go
@@ -1,0 +1,95 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+import "fmt"
+
+// Verb identifies the storage.Interface method a State was classified from.
+type Verb string
+
+const (
+	VerbGet    Verb = "Get"
+	VerbList   Verb = "List"
+	VerbWatch  Verb = "Watch"
+	VerbDelete Verb = "Delete"
+)
+
+// Outcome classifies the terminal result of a storage.Interface call.
+type Outcome string
+
+const (
+	OutcomeSuccess     Outcome = "Success"
+	OutcomeNotFound    Outcome = "NotFound"
+	OutcomeExists      Outcome = "Exists"
+	OutcomeConflict    Outcome = "Conflict"
+	OutcomeInvalidObj  Outcome = "InvalidObj"
+	OutcomeUnreachable Outcome = "Unreachable"
+	OutcomeTimeout     Outcome = "Timeout"
+	OutcomeCorruptObj  Outcome = "CorruptObj"
+	OutcomeOtherError  Outcome = "OtherError"
+)
+
+// State is a single classified API state: a storage.Interface verb plus the
+// combination of request/response dimensions applicable to that verb. Only
+// the fields relevant to State.Verb are populated; the rest are left at
+// their zero value. State is comparable and safe to use as a map key.
+type State struct {
+	Verb Verb
+
+	// Get, List, Watch
+	ResourceVersion ResourceVersionMode
+
+	// List, Watch
+	ResourceVersionMatch ResourceVersionMatchMode
+	Recursive            bool
+	Selector             SelectorMode
+
+	// Get only
+	IgnoreNotFound bool
+
+	// List only
+	Pagination PaginationMode
+
+	// Watch only
+	AllowWatchBookmarks bool
+	SendInitialEvents   SendInitialEventsMode
+
+	// Delete only
+	Preconditions PreconditionMode
+
+	// all verbs
+	Outcome Outcome
+}
+
+// String renders the State as a stable, human-readable label listing only
+// the dimensions applicable to its Verb, for use in coverage reports.
+func (s State) String() string {
+	switch s.Verb {
+	case VerbGet:
+		return fmt.Sprintf("Get(rv=%s, ignoreNotFound=%t, outcome=%s)", s.ResourceVersion, s.IgnoreNotFound, s.Outcome)
+	case VerbList:
+		return fmt.Sprintf("List(rv=%s, rvMatch=%s, recursive=%t, pagination=%s, selector=%s, outcome=%s)",
+			s.ResourceVersion, s.ResourceVersionMatch, s.Recursive, s.Pagination, s.Selector, s.Outcome)
+	case VerbWatch:
+		return fmt.Sprintf("Watch(rv=%s, rvMatch=%s, recursive=%t, selector=%s, allowBookmarks=%t, sendInitialEvents=%s, outcome=%s)",
+			s.ResourceVersion, s.ResourceVersionMatch, s.Recursive, s.Selector, s.AllowWatchBookmarks, s.SendInitialEvents, s.Outcome)
+	case VerbDelete:
+		return fmt.Sprintf("Delete(preconditions=%s, outcome=%s)", s.Preconditions, s.Outcome)
+	default:
+		return fmt.Sprintf("%s(outcome=%s)", s.Verb, s.Outcome)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/target_delete_states.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/target_delete_states.go
@@ -1,0 +1,32 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+func deleteTargetStates() []State {
+	var states []State
+	// Baseline grid: every precondition shape, on success.
+	for _, preconditions := range []PreconditionMode{PreconditionNone, PreconditionUID, PreconditionResourceVersion, PreconditionBoth} {
+		states = append(states, State{Verb: VerbDelete, Preconditions: preconditions, Outcome: OutcomeSuccess})
+	}
+	// Outcome variety with no preconditions.
+	for _, outcome := range []Outcome{OutcomeNotFound, OutcomeUnreachable, OutcomeTimeout, OutcomeOtherError} {
+		states = append(states, State{Verb: VerbDelete, Preconditions: PreconditionNone, Outcome: outcome})
+	}
+	// A precondition mismatch, which storage reports as an invalid-object error.
+	states = append(states, State{Verb: VerbDelete, Preconditions: PreconditionBoth, Outcome: OutcomeInvalidObj})
+	return states
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/target_get_states.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/target_get_states.go
@@ -1,0 +1,34 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+func getTargetStates() []State {
+	var states []State
+	// Baseline grid: every ResourceVersion mode, with and without IgnoreNotFound.
+	for _, rv := range []ResourceVersionMode{RVUnset, RVZero, RVExact} {
+		for _, ignoreNotFound := range []bool{false, true} {
+			states = append(states, State{Verb: VerbGet, ResourceVersion: rv, IgnoreNotFound: ignoreNotFound, Outcome: OutcomeSuccess})
+		}
+	}
+	// Outcome variety at the default shape (RVUnset, IgnoreNotFound=false).
+	for _, outcome := range []Outcome{OutcomeNotFound, OutcomeUnreachable, OutcomeTimeout, OutcomeCorruptObj, OutcomeOtherError} {
+		states = append(states, State{Verb: VerbGet, ResourceVersion: RVUnset, IgnoreNotFound: false, Outcome: outcome})
+	}
+	// A "not older than" get for a key that no longer exists at that revision.
+	states = append(states, State{Verb: VerbGet, ResourceVersion: RVExact, IgnoreNotFound: false, Outcome: OutcomeNotFound})
+	return states
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/target_list_states.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/target_list_states.go
@@ -1,0 +1,71 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+func listTargetStates() []State {
+	var states []State
+	// Baseline grid: recursive list, every ResourceVersion x ResourceVersionMatch
+	// combination, no pagination, no selector.
+	for _, rv := range []ResourceVersionMode{RVUnset, RVZero, RVExact} {
+		for _, match := range []ResourceVersionMatchMode{RVMatchUnset, RVMatchNotOlderThan, RVMatchExact} {
+			states = append(states, State{
+				Verb: VerbList, ResourceVersion: rv, ResourceVersionMatch: match,
+				Recursive: true, Pagination: PaginationNone, Selector: SelectorNone, Outcome: OutcomeSuccess,
+			})
+		}
+	}
+	// Single-object get-via-list (Recursive=false).
+	states = append(states, State{
+		Verb: VerbList, ResourceVersion: RVUnset, ResourceVersionMatch: RVMatchUnset,
+		Recursive: false, Pagination: PaginationNone, Selector: SelectorNone, Outcome: OutcomeSuccess,
+	})
+	// Pagination variety at the default shape.
+	for _, pagination := range []PaginationMode{PaginationLimit, PaginationContinue} {
+		states = append(states, State{
+			Verb: VerbList, ResourceVersion: RVZero, ResourceVersionMatch: RVMatchUnset,
+			Recursive: true, Pagination: pagination, Selector: SelectorNone, Outcome: OutcomeSuccess,
+		})
+	}
+	// Selector variety at the default shape.
+	for _, selector := range []SelectorMode{SelectorLabel, SelectorField, SelectorBoth} {
+		states = append(states, State{
+			Verb: VerbList, ResourceVersion: RVUnset, ResourceVersionMatch: RVMatchUnset,
+			Recursive: true, Pagination: PaginationNone, Selector: selector, Outcome: OutcomeSuccess,
+		})
+	}
+	// Pagination combined with a selector, since predicate filtering interacts
+	// with continue-token semantics (matched items may span multiple pages).
+	states = append(states,
+		State{Verb: VerbList, ResourceVersion: RVZero, Recursive: true, Pagination: PaginationLimit, Selector: SelectorLabel, Outcome: OutcomeSuccess},
+		State{Verb: VerbList, ResourceVersion: RVUnset, Recursive: true, Pagination: PaginationContinue, Selector: SelectorBoth, Outcome: OutcomeSuccess},
+	)
+	// An exact resource version combined with a continue token: continue
+	// tokens normally carry their own revision, so this combination is
+	// expected to be rejected - worth tracking that it is.
+	states = append(states, State{
+		Verb: VerbList, ResourceVersion: RVExact, ResourceVersionMatch: RVMatchUnset,
+		Recursive: true, Pagination: PaginationContinue, Selector: SelectorNone, Outcome: OutcomeOtherError,
+	})
+	// Outcome variety at the default shape.
+	for _, outcome := range []Outcome{OutcomeUnreachable, OutcomeTimeout, OutcomeCorruptObj, OutcomeOtherError} {
+		states = append(states, State{
+			Verb: VerbList, ResourceVersion: RVUnset, ResourceVersionMatch: RVMatchUnset,
+			Recursive: true, Pagination: PaginationNone, Selector: SelectorNone, Outcome: outcome,
+		})
+	}
+	return states
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/target_states.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/target_states.go
@@ -1,0 +1,40 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+// TargetStates returns the catalog of API states (~80, per #141652 step 1)
+// that coverage.Wrap-based test suites are expected to exercise.
+//
+// This is a curated list, not a full cartesian product of every dimension:
+// crossing all of List's dimensions alone would yield well over a thousand
+// combinations, most of them redundant for coverage purposes (e.g. selector
+// shape rarely interacts with pagination shape in ways worth distinguishing).
+// Instead, each verb gets a baseline grid over its most important dimensions
+// (typically ResourceVersion x ResourceVersionMatch, held at Outcome=Success),
+// plus a handful of rows that vary one additional dimension - pagination,
+// selectors, preconditions, terminal error outcome - at a fixed baseline
+// shape. Add or remove rows here as review surfaces states worth tracking
+// separately, or states that turn out to be redundant. Each verb's rows live
+// in their own target_<verb>_states.go file.
+func TargetStates() []State {
+	var states []State
+	states = append(states, getTargetStates()...)
+	states = append(states, listTargetStates()...)
+	states = append(states, watchTargetStates()...)
+	states = append(states, deleteTargetStates()...)
+	return states
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/target_states_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/target_states_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+import "testing"
+
+func TestTargetStatesHasNoDuplicates(t *testing.T) {
+	seen := make(map[State]bool)
+	for _, state := range TargetStates() {
+		if seen[state] {
+			t.Errorf("duplicate state in target states: %s", state)
+		}
+		seen[state] = true
+	}
+	t.Logf("target states: %d distinct states", len(seen))
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/target_watch_states.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/target_watch_states.go
@@ -1,0 +1,64 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+func watchTargetStates() []State {
+	var states []State
+	// Baseline grid: recursive watch, every ResourceVersion x ResourceVersionMatch
+	// combination, no selector, no bookmarks, SendInitialEvents unset.
+	for _, rv := range []ResourceVersionMode{RVUnset, RVZero, RVExact} {
+		for _, match := range []ResourceVersionMatchMode{RVMatchUnset, RVMatchNotOlderThan, RVMatchExact} {
+			states = append(states, State{
+				Verb: VerbWatch, ResourceVersion: rv, ResourceVersionMatch: match, Recursive: true,
+				Selector: SelectorNone, SendInitialEvents: SendInitialEventsUnset, Outcome: OutcomeSuccess,
+			})
+		}
+	}
+	// Single-object watch (Recursive=false).
+	states = append(states, State{
+		Verb: VerbWatch, ResourceVersion: RVUnset, ResourceVersionMatch: RVMatchUnset,
+		Recursive: false, Selector: SelectorNone, SendInitialEvents: SendInitialEventsUnset, Outcome: OutcomeSuccess,
+	})
+	// Selector variety at the default shape.
+	for _, selector := range []SelectorMode{SelectorLabel, SelectorField, SelectorBoth} {
+		states = append(states, State{
+			Verb: VerbWatch, ResourceVersion: RVUnset, ResourceVersionMatch: RVMatchUnset,
+			Recursive: true, Selector: selector, SendInitialEvents: SendInitialEventsUnset, Outcome: OutcomeSuccess,
+		})
+	}
+	// AllowWatchBookmarks at the default shape, and combined with a selector
+	// since bookmark delivery interacts with predicate-filtered watches.
+	states = append(states,
+		State{Verb: VerbWatch, ResourceVersion: RVUnset, Recursive: true, Selector: SelectorNone, AllowWatchBookmarks: true, SendInitialEvents: SendInitialEventsUnset, Outcome: OutcomeSuccess},
+		State{Verb: VerbWatch, ResourceVersion: RVUnset, Recursive: true, Selector: SelectorBoth, AllowWatchBookmarks: true, SendInitialEvents: SendInitialEventsUnset, Outcome: OutcomeSuccess},
+	)
+	// SendInitialEvents variety, including combined with RVZero (a common
+	// real request shape for streaming a full initial snapshot).
+	states = append(states,
+		State{Verb: VerbWatch, ResourceVersion: RVUnset, Recursive: true, Selector: SelectorNone, SendInitialEvents: SendInitialEventsTrue, Outcome: OutcomeSuccess},
+		State{Verb: VerbWatch, ResourceVersion: RVUnset, Recursive: true, Selector: SelectorNone, SendInitialEvents: SendInitialEventsFalse, Outcome: OutcomeSuccess},
+		State{Verb: VerbWatch, ResourceVersion: RVZero, Recursive: true, Selector: SelectorNone, SendInitialEvents: SendInitialEventsTrue, Outcome: OutcomeSuccess},
+	)
+	// Outcome variety at the default shape.
+	for _, outcome := range []Outcome{OutcomeUnreachable, OutcomeTimeout, OutcomeCorruptObj, OutcomeOtherError} {
+		states = append(states, State{
+			Verb: VerbWatch, ResourceVersion: RVUnset, ResourceVersionMatch: RVMatchUnset,
+			Recursive: true, Selector: SelectorNone, SendInitialEvents: SendInitialEventsUnset, Outcome: outcome,
+		})
+	}
+	return states
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/wrap.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/wrap.go
@@ -1,0 +1,73 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apiserver/pkg/storage"
+)
+
+// wrapped decorates a storage.Interface, classifying Get/GetList/Watch/Delete
+// calls into the Recorder and delegating every method - including these four
+// - unchanged to the wrapped Interface. Embedding storage.Interface means any
+// method this file does not override still satisfies the interface exactly
+// as the wrapped implementation defines it, so Wrap stays non-invasive as
+// storage.Interface grows.
+type wrapped struct {
+	storage.Interface
+	rec *Recorder
+}
+
+var _ storage.Interface = (*wrapped)(nil)
+
+// Wrap returns a storage.Interface that behaves exactly like inner, while
+// recording the API state of every Get, GetList, Watch and Delete call into
+// rec. rec may be shared across multiple Wrap-ed instances to aggregate
+// coverage over a whole test suite.
+func Wrap(inner storage.Interface, rec *Recorder) storage.Interface {
+	return &wrapped{Interface: inner, rec: rec}
+}
+
+func (w *wrapped) Get(ctx context.Context, key string, opts storage.GetOptions, objPtr runtime.Object) error {
+	err := w.Interface.Get(ctx, key, opts, objPtr)
+	w.rec.Observe(ClassifyGet(opts, err))
+	return err
+}
+
+func (w *wrapped) GetList(ctx context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
+	err := w.Interface.GetList(ctx, key, opts, listObj)
+	w.rec.Observe(ClassifyList(opts, err))
+	return err
+}
+
+func (w *wrapped) Watch(ctx context.Context, key string, opts storage.ListOptions) (watch.Interface, error) {
+	wi, err := w.Interface.Watch(ctx, key, opts)
+	w.rec.Observe(ClassifyWatch(opts, err))
+	return wi, err
+}
+
+func (w *wrapped) Delete(
+	ctx context.Context, key string, out runtime.Object, preconditions *storage.Preconditions,
+	validateDeletion storage.ValidateObjectFunc, cachedExistingObject runtime.Object, opts storage.DeleteOptions,
+) error {
+	err := w.Interface.Delete(ctx, key, out, preconditions, validateDeletion, cachedExistingObject, opts)
+	w.rec.Observe(ClassifyDelete(preconditions, err))
+	return err
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/wrap_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/wrap_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apiserver/pkg/storage"
+)
+
+// fakeStorage implements storage.Interface, returning canned results/errors
+// for Get/GetList/Watch/Delete. Every other method is left unimplemented
+// (nil embedded Interface) since the tests below never call them - Wrap must
+// not need to touch them to satisfy the interface.
+type fakeStorage struct {
+	storage.Interface
+	err error
+}
+
+func (f *fakeStorage) Versioner() storage.Versioner {
+	return storage.APIObjectVersioner{}
+}
+
+func (f *fakeStorage) Get(ctx context.Context, key string, opts storage.GetOptions, objPtr runtime.Object) error {
+	return f.err
+}
+
+func (f *fakeStorage) GetList(ctx context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
+	return f.err
+}
+
+func (f *fakeStorage) Watch(ctx context.Context, key string, opts storage.ListOptions) (watch.Interface, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return watch.NewFake(), nil
+}
+
+func (f *fakeStorage) Delete(
+	ctx context.Context, key string, out runtime.Object, preconditions *storage.Preconditions,
+	validateDeletion storage.ValidateObjectFunc, cachedExistingObject runtime.Object, opts storage.DeleteOptions,
+) error {
+	return f.err
+}
+
+func TestWrapClassifiesCalls(t *testing.T) {
+	rec := NewRecorder()
+	w := Wrap(&fakeStorage{}, rec)
+
+	if err := w.Get(context.Background(), "/key", storage.GetOptions{ResourceVersion: "0"}, nil); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := w.GetList(context.Background(), "/prefix", storage.ListOptions{Recursive: true, Predicate: storage.SelectionPredicate{Limit: 10}}, nil); err != nil {
+		t.Fatalf("GetList: %v", err)
+	}
+	if _, err := w.Watch(context.Background(), "/prefix", storage.ListOptions{Recursive: true}); err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	if err := w.Delete(context.Background(), "/key", nil, nil, storage.ValidateAllObjectFunc, nil, storage.DeleteOptions{}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	want := []State{
+		{Verb: VerbGet, ResourceVersion: RVZero, IgnoreNotFound: false, Outcome: OutcomeSuccess},
+		{Verb: VerbList, ResourceVersion: RVUnset, ResourceVersionMatch: RVMatchUnset, Recursive: true, Pagination: PaginationLimit, Selector: SelectorNone, Outcome: OutcomeSuccess},
+		{Verb: VerbWatch, ResourceVersion: RVUnset, ResourceVersionMatch: RVMatchUnset, Recursive: true, Selector: SelectorNone, SendInitialEvents: SendInitialEventsUnset, Outcome: OutcomeSuccess},
+		{Verb: VerbDelete, Preconditions: PreconditionNone, Outcome: OutcomeSuccess},
+	}
+	counts := rec.Counts()
+	for _, state := range want {
+		if counts[state] != 1 {
+			t.Errorf("expected exactly one observation of %s, got %d (all counts: %v)", state, counts[state], counts)
+		}
+	}
+	if len(counts) != len(want) {
+		t.Errorf("expected %d distinct observed states, got %d: %v", len(want), len(counts), counts)
+	}
+}
+
+func TestWrapPassthroughDoesNotPanic(t *testing.T) {
+	inner := &fakeStorage{}
+	w := Wrap(inner, NewRecorder())
+	if w.Versioner() == nil {
+		t.Errorf("expected Versioner() to pass through to the inner storage.Interface")
+	}
+}
+
+func TestWrapRecordsOutcome(t *testing.T) {
+	rec := NewRecorder()
+	w := Wrap(&fakeStorage{err: storage.NewKeyNotFoundError("/key", 0)}, rec)
+
+	_ = w.Get(context.Background(), "/key", storage.GetOptions{}, nil)
+
+	want := State{Verb: VerbGet, ResourceVersion: RVUnset, IgnoreNotFound: false, Outcome: OutcomeNotFound}
+	if counts := rec.Counts(); counts[want] != 1 {
+		t.Errorf("expected %s to be observed once, got counts: %v", want, counts)
+	}
+}


### PR DESCRIPTION
Ref #141652 (Step 1: Storage Request Classification & Coverage Measurement)

This is a **draft / work in progress** implementing Step 1 only. Step 2 (the linearizability model) is being handled separately in #141729 — this PR does not touch `correctness/` or `test/integration/apiserver/storage/`.

## What's here

In `staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/`:

- A `State` type classifying storage.Interface calls along the dimensions the issue calls out: ResourceVersion mode, ResourceVersionMatch, pagination/continue, selector shape, preconditions, terminal error outcome.
- `ClassifyGet`/`ClassifyList`/`ClassifyWatch`/`ClassifyDelete` — classifiers built directly from the real `storage.GetOptions`/`ListOptions`/`Preconditions`/`SelectionPredicate` shapes and the real `storage.IsNotFound`/`IsExist`/etc. error checks.
- `Wrap(inner storage.Interface, rec *Recorder) storage.Interface` — a non-invasive decorator: only `Get`/`GetList`/`Watch`/`Delete` are overridden to classify + record; everything else passes through unchanged via struct embedding.
- `Recorder` + `Scorecard` — tally what got observed, diff against a target catalog, print a coverage report.
- `TargetStates()` — a curated catalog of 65 states across the four verbs.
- Zero non-stdlib, non-`k8s.io` imports.

## Open questions for reviewers

The issue text left two things unspecified, and I made a call on both rather than guess silently:

1. **"four core verbs (Get, List, Watch ..)"** — only three are named before it trails off. I picked **Delete** as the fourth, since it's the only other verb that takes `Preconditions` (an explicitly required dimension). Right now `Create`/`GuaranteedUpdate` calls pass through `Wrap` completely unclassified. If a different 4th verb was intended (e.g. `GuaranteedUpdate`, where real writes happen), let me know and I'll adjust.
2. **"~80 distinct API states"** — the current catalog (`TargetStates()`) has **65**. A literal cartesian product of every dimension would run into the hundreds+ (crossing all of List's dimensions alone), so this is a hand-curated subset, not a generated grid. Open to padding it closer to 80, or leaving it as a starting point for reviewers to extend.

## Test plan

- [x] `go build ./staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/...`
- [x] `go vet` clean
- [x] `go test -v` — all 5 tests pass
- [x] `gofmt -l` clean
- [x] `hack/verify-boilerplate.sh` clean
- [ ] Not yet wired into a real test suite (e.g. `etcd3`/`cacher` storage tests) to produce an actual scorecard — natural next step once the questions above are settled

This is my first contribution to kubernetes/kubernetes — appreciate any guidance on direction before I go further.

/cc @serathius @liggitt