### PR TITLE
[PodLevelResources] include pod-level resources in resize events

### DIFF
--- a/pkg/kubelet/events/resize.go
+++ b/pkg/kubelet/events/resize.go
@@ -32,11 +32,14 @@ type containerAllocation struct {
 }
 
 type podResourceSummary struct {
-	// TODO: resources v1.ResourceRequirements, add pod-level resources here once resizing pod-level resources is supported
-	InitContainers []containerAllocation `json:"initContainers,omitempty"`
-	Containers     []containerAllocation `json:"containers,omitempty"`
-	Generation     int64                 `json:"generation"`
-	Error          string                `json:"error,omitempty"`
+	// Resources is the pod-level resource requirements (pod.Spec.Resources) when set.
+	// Included for InPlacePodLevelResourcesVerticalScaling so resize events report
+	// the full pod allocation, not just container resources.
+	Resources      *v1.ResourceRequirements `json:"resources,omitempty"`
+	InitContainers []containerAllocation    `json:"initContainers,omitempty"`
+	Containers     []containerAllocation    `json:"containers,omitempty"`
+	Generation     int64                    `json:"generation"`
+	Error          string                   `json:"error,omitempty"`
 }
 
 // PodResizeCompletedMsg generates the pod resize completed event message.
@@ -71,6 +74,11 @@ func podResizeMessage(logger klog.Logger, pod *v1.Pod, generation int64, errorMs
 // Returns the desired resources from the podspec.
 func makeResourceSummaryFromSpec(logger klog.Logger, pod *v1.Pod, generation int64, errorMessage string) (string, error) {
 	specResources := &podResourceSummary{Generation: generation, Error: errorMessage}
+	// Include pod-level resources if present so ResizeStarted/Completed events
+	// capture the pod envelope alongside container allocations.
+	if pod.Spec.Resources != nil && (len(pod.Spec.Resources.Requests) > 0 || len(pod.Spec.Resources.Limits) > 0) {
+		specResources.Resources = pod.Spec.Resources.DeepCopy()
+	}
 	for container, containerType := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
 		allocation := containerAllocation{
 			Name:      container.Name,

--- a/pkg/kubelet/events/resize_test.go
+++ b/pkg/kubelet/events/resize_test.go
@@ -33,6 +33,7 @@ func TestPodResizeCompletedMsg(t *testing.T) {
 	tests := []struct {
 		name               string
 		containers         []testContainer
+		podResources       *testResources
 		observedGeneration int64
 		expected           string
 	}{{
@@ -61,6 +62,25 @@ func TestPodResizeCompletedMsg(t *testing.T) {
 		}},
 		observedGeneration: 3,
 		expected:           `Pod resize completed: {"containers":[{"name":"c0","resources":{}}],"generation":3}`,
+	}, {
+		name: "with pod-level resources",
+		containers: []testContainer{{
+			resources: testResources{50, 50, 50, 50},
+		}},
+		podResources:       &testResources{200, 400, 200, 400},
+		observedGeneration: 2,
+		expected:           `Pod resize completed: {"resources":{"limits":{"cpu":"400m","memory":"400"},"requests":{"cpu":"200m","memory":"200"}},"containers":[{"name":"c0","resources":{"limits":{"cpu":"50m","memory":"50"},"requests":{"cpu":"50m","memory":"50"}}}],"generation":2}`,
+	}, {
+		name: "with pod-level resources and several containers",
+		containers: []testContainer{{
+			resources: testResources{cpuReq: 100, cpuLim: 200},
+			sidecar:   true,
+		}, {
+			resources: testResources{memReq: 100, memLim: 200},
+		}},
+		podResources:       &testResources{200, 400, 200, 400},
+		observedGeneration: 2,
+		expected:           `Pod resize completed: {"resources":{"limits":{"cpu":"400m","memory":"400"},"requests":{"cpu":"200m","memory":"200"}},"initContainers":[{"name":"c0","resources":{"limits":{"cpu":"200m"},"requests":{"cpu":"100m"}}}],"containers":[{"name":"c1","resources":{"limits":{"memory":"200"},"requests":{"memory":"100"}}}],"generation":2}`,
 	}}
 
 	for _, test := range tests {
@@ -81,6 +101,10 @@ func TestPodResizeCompletedMsg(t *testing.T) {
 					pod.Spec.Containers = append(pod.Spec.Containers, container)
 				}
 			}
+			if test.podResources != nil {
+				req := mkRequirements(*test.podResources)
+				pod.Spec.Resources = &req
+			}
 
 			msg := PodResizeCompletedMsg(logger, pod, test.observedGeneration)
 			assert.Equal(t, test.expected, msg)
@@ -94,6 +118,7 @@ func TestPodResizeStartedMsg(t *testing.T) {
 		name               string
 		allocated          []testContainer
 		actual             []testContainer
+		podResources       *testResources
 		observedGeneration int64
 		expected           string
 	}{
@@ -117,6 +142,13 @@ func TestPodResizeStartedMsg(t *testing.T) {
 			},
 			observedGeneration: 2,
 			expected:           `Pod resize started: {"initContainers":[{"name":"c0","resources":{"limits":{"cpu":"200m"},"requests":{"cpu":"100m"}}}],"containers":[{"name":"c1","resources":{"limits":{"memory":"200"},"requests":{"memory":"100"}}},{"name":"c2","resources":{"requests":{"cpu":"200m","memory":"100"}}}],"generation":2}`,
+		}, {
+			name:               "with pod-level resources",
+			allocated:          []testContainer{{resources: testResources{20, 20, 20, 20}}},
+			actual:             []testContainer{{resources: testResources{50, 50, 50, 50}}},
+			podResources:       &testResources{200, 400, 200, 400},
+			observedGeneration: 2,
+			expected:           `Pod resize started: {"resources":{"limits":{"cpu":"400m","memory":"400"},"requests":{"cpu":"200m","memory":"200"}},"containers":[{"name":"c0","resources":{"limits":{"cpu":"20m","memory":"20"},"requests":{"cpu":"20m","memory":"20"}}}],"generation":2}`,
 		},
 	}
 
@@ -152,6 +184,10 @@ func TestPodResizeStartedMsg(t *testing.T) {
 					allocatedPod.Spec.Containers = append(allocatedPod.Spec.Containers, allocated)
 				}
 			}
+			if test.podResources != nil {
+				req := mkRequirements(*test.podResources)
+				allocatedPod.Spec.Resources = &req
+			}
 
 			msg := PodResizeStartedMsg(logger, allocatedPod, test.observedGeneration)
 			assert.Equal(t, test.expected, msg)
@@ -165,6 +201,7 @@ func TestPodResizeErrorMsg(t *testing.T) {
 		name               string
 		allocated          []testContainer
 		actual             []testContainer
+		podResources       *testResources
 		observedGeneration int64
 		errMsg             string
 		expected           string
@@ -191,6 +228,14 @@ func TestPodResizeErrorMsg(t *testing.T) {
 			observedGeneration: 2,
 			errMsg:             "some error occurred",
 			expected:           `Pod resize error: {"initContainers":[{"name":"c0","resources":{"limits":{"cpu":"200m"},"requests":{"cpu":"100m"}}}],"containers":[{"name":"c1","resources":{"limits":{"memory":"200"},"requests":{"memory":"100"}}},{"name":"c2","resources":{"requests":{"cpu":"200m","memory":"100"}}}],"generation":2,"error":"some error occurred"}`,
+		}, {
+			name:               "with pod-level resources",
+			allocated:          []testContainer{{resources: testResources{20, 20, 20, 20}}},
+			actual:             []testContainer{{resources: testResources{50, 50, 50, 50}}},
+			podResources:       &testResources{200, 400, 200, 400},
+			observedGeneration: 2,
+			errMsg:             "some error occurred",
+			expected:           `Pod resize error: {"resources":{"limits":{"cpu":"400m","memory":"400"},"requests":{"cpu":"200m","memory":"200"}},"containers":[{"name":"c0","resources":{"limits":{"cpu":"20m","memory":"20"},"requests":{"cpu":"20m","memory":"20"}}}],"generation":2,"error":"some error occurred"}`,
 		},
 	}
 
@@ -226,6 +271,10 @@ func TestPodResizeErrorMsg(t *testing.T) {
 					allocatedPod.Spec.Containers = append(allocatedPod.Spec.Containers, allocated)
 				}
 			}
+			if test.podResources != nil {
+				req := mkRequirements(*test.podResources)
+				allocatedPod.Spec.Resources = &req
+			}
 
 			msg := PodResizeErrorMsg(logger, allocatedPod, test.observedGeneration, test.errMsg)
 			assert.Equal(t, test.expected, msg)
@@ -239,6 +288,7 @@ func TestPodResizePendingMsg(t *testing.T) {
 		name               string
 		desired            []testContainer
 		allocated          []testContainer
+		podResources       *testResources
 		reason             string
 		message            string
 		observedGeneration int64
@@ -268,6 +318,15 @@ func TestPodResizePendingMsg(t *testing.T) {
 			reason:             "Infeasible",
 			message:            "In-place resize of containers with swap is not supported",
 			expected:           `Pod resize Infeasible: {"initContainers":[{"name":"c0","resources":{"limits":{"cpu":"200m"},"requests":{"cpu":"100m"}}}],"containers":[{"name":"c1","resources":{"limits":{"memory":"200"},"requests":{"memory":"100"}}},{"name":"c2","resources":{"requests":{"cpu":"200m","memory":"100"}}}],"generation":2,"error":"In-place resize of containers with swap is not supported"}`,
+		}, {
+			name:               "with pod-level resources",
+			desired:            []testContainer{{resources: testResources{20, 20, 20, 20}}},
+			allocated:          []testContainer{{resources: testResources{50, 50, 50, 50}}},
+			podResources:       &testResources{200, 400, 200, 400},
+			observedGeneration: 2,
+			reason:             "Deferred",
+			message:            "Node didn't have enough resource: memory",
+			expected:           `Pod resize Deferred: {"resources":{"limits":{"cpu":"400m","memory":"400"},"requests":{"cpu":"200m","memory":"200"}},"containers":[{"name":"c0","resources":{"limits":{"cpu":"20m","memory":"20"},"requests":{"cpu":"20m","memory":"20"}}}],"generation":2,"error":"Node didn't have enough resource: memory"}`,
 		},
 	}
 
@@ -302,6 +361,10 @@ func TestPodResizePendingMsg(t *testing.T) {
 				} else {
 					pod.Spec.Containers = append(pod.Spec.Containers, desired)
 				}
+			}
+			if test.podResources != nil {
+				req := mkRequirements(*test.podResources)
+				pod.Spec.Resources = &req
 			}
 
 			msg := PodResizePendingMsg(logger, pod, test.reason, test.message, test.observedGeneration)


### PR DESCRIPTION
## What type of PR is this?
/kind bug
/sig node
/area kubelet

## What this PR does / why we need it:
This PR fixes in-place pod resize events to include pod-level resources when `InPlacePodLevelResourcesVerticalScaling` is enabled.

Previously, `podResourceSummary` in `pkg/kubelet/events/resize.go` only captured container-level resources (`spec.containers[].resources` and `spec.initContainers[].resources`) and `generation`. When a pod defined `spec.resources` (PodLevelResources), a successful pod-level resize would update `pod.Spec.Resources` and `pod.Status.Resources`, but the emitted `ResizeStarted` and `ResizeCompleted` events still only contained:

```json
{"containers":[{"name":"c1","resources":{"limits":{"cpu":"20m","memory":"200Mi"},"requests":{"cpu":"20m","memory":"200Mi"}}}],"generation":2}
```

This made the allocation reported in events incomplete and inconsistent with the effective pod allocation.

This change updates the event payload to:

* Replace the `TODO: resources v1.ResourceRequirements` with a proper `Resources *v1.ResourceRequirements json:"resources,omitempty"` field on `podResourceSummary` (mirrors `PodSpec.Resources` / `PodStatus.Resources`).
* Populate it from `pod.Spec.Resources` (deep-copy) when non-nil and non-empty in `makeResourceSummaryFromSpec`, so all resize event helpers (`PodResizeStartedMsg`, `PodResizeCompletedMsg`, `PodResizeErrorMsg`, `PodResizePendingMsg`) now emit:
```json
{"resources":{"limits":{"cpu":"400m","memory":"400Mi"},"requests":{"cpu":"200m","memory":"200Mi"}},"containers":[{"name":"c1","resources":{"limits":{"cpu":"50m","memory":"50Mi"},"requests":{"cpu":"50m","memory":"50Mi"}}}],"generation":2}
```
* Keep backward compatibility via `omitempty` — pods without pod-level resources continue to emit the old shape with no `resources` field.
* Add implementation comments explaining why pod-level resources are included for `InPlacePodLevelResourcesVerticalScaling`.

This PR also adds regression tests covering all event types to ensure allocation reporting depends on both pod-level and container-level resources, not just containers.

## Which issue(s) this PR is related to:
Fixes #141606

## Special notes for your reviewer:
Unit tests
Extended `pkg/kubelet/events/resize_test.go` for all 4 message types:

* `TestPodResizeCompletedMsg` — added `with pod-level resources` and `with pod-level resources and several containers` cases
* `TestPodResizeStartedMsg` — added `with pod-level resources` case (pod-level 200m/400m vs container 20m)
* `TestPodResizeErrorMsg` — added `with pod-level resources` case
* `TestPodResizePendingMsg` — added `with pod-level resources` case

All tests passed successfully (including new pod-level cases for Started/Completed/Error/Pending).

## End-to-end validation
I built Kubernetes from this commit and created new binaries for:

* kubelet
* kubeadm
* kubectl

The test cluster was created using the newly built binaries from this PR on `k8s-topology-a` (192.168.56.10, `containerd://2.2.1`, `v1.38.0-alpha.0.408_c3af316a72bcbe-dirty`) with:

```yaml
featureGates:
  PodLevelResources: true
  InPlacePodLevelResourcesVerticalScaling: true
```

Test 1 — pod-level only patch:
```yaml
spec:
  containers: [{name: c1, resources: {requests: {cpu: 50m, memory: 50Mi}, limits: {cpu: 50m, memory: 50Mi}}}]
  resources: {requests: {cpu: 200m, memory: 200Mi}, limits: {cpu: 400m, memory: 400Mi}}
# patch: spec.resources -> {cpu: 300m/500m, memory: 300Mi/500Mi}
```
Events now correctly show:
```
ResizeStarted: {"resources":{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"300m","memory":"300Mi"}},"containers":[{"name":"c1","resources":{"limits":{"cpu":"50m","memory":"50Mi"},"requests":{"cpu":"50m","memory":"50Mi"}}}],"generation":2}
ResizeCompleted: same
```

Test 2 — no pod-level, container-level patch:
```yaml
spec:
  containers: [{name: c1, resources: {requests: {cpu: 50m, memory: 50Mi}}}]
# patch: containers[0].resources -> {cpu: 100m, memory: 100Mi}
```
Events correctly keep old shape (no `resources` field):
```
ResizeStarted: {"containers":[{"name":"c1","resources":{"limits":{"cpu":"100m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}}],"generation":2}
```

Test 3 — pod + container, patch pod-level:
Same as Test 1 with both levels present — events correctly show both `resources` and `containers` together.

Verified via `kubectl get events --field-selector reason=ResizeStarted/ResizeCompleted` and `kubectl describe pod`.

## Does this PR introduce a user-facing change?
```release-note
Fixed in-place pod resize events to include pod-level resources (spec.resources) when InPlacePodLevelResourcesVerticalScaling is enabled. ResizeStarted and ResizeCompleted events now correctly report the full pod allocation including the pod-level envelope.
```

## Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
KEP-5419: Pod Level Resources Support With In Place Pod Vertical Scaling (https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/5419-pod-level-resources-in-place-resize/README.md)
