### PR TITLE
Fix: DRA Registration Failure at the Unix Socket Boundary

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
@@ -56,7 +56,7 @@ const (
 	// KubeletRegistryDir is the default for [RegistrarDirectoryPath]
 	KubeletRegistryDir = "/var/lib/kubelet/plugins_registry"
 
-	// unixPathMax is the maximum length of an AF_UNIX socket path on Linux.
+	// unixPathMax is the size of the AF_UNIX sun_path field on Linux.
 	unixPathMax = 108
 
 	// rollingUpdateUIDHashBytes is how much of the SHA-256 digest of a pod UID
@@ -74,7 +74,7 @@ const (
 
 // RollingUpdateRegistrarSocketFile returns a kubelet plugin registration socket
 // basename for rolling updates. The full path path.Join(registryDir, basename)
-// must fit within unixPathMax bytes.
+// must be shorter than unixPathMax bytes to leave room for the terminating NUL.
 //
 // The basename is chosen in order of preference:
 //  1. <driver name>-<pod UID>-reg.sock
@@ -90,7 +90,7 @@ func RollingUpdateRegistrarSocketFile(registryDir, driverName string, podUID typ
 		"dra-" + base64.RawURLEncoding.EncodeToString(driverUIDHash[:rollingUpdateRegistrarSocketHashBytes]) + "-reg.sock",
 	}
 	for _, basename := range candidates {
-		if len(path.Join(registryDir, basename)) <= unixPathMax {
+		if len(path.Join(registryDir, basename)) < unixPathMax {
 			return basename
 		}
 	}

--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin_registration_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin_registration_test.go
@@ -29,8 +29,26 @@ func TestRollingUpdateRegistrarSocketFile_lengthBound(t *testing.T) {
 	podUID := types.UID("ad4af911-5bcd-47c5-a554-f35cea869472")
 	name := RollingUpdateRegistrarSocketFile(KubeletRegistryDir, driver, podUID)
 	full := path.Join(KubeletRegistryDir, name)
-	if len(full) > unixPathMax {
-		t.Fatalf("registration socket path len %d exceeds %d: %q", len(full), unixPathMax, full)
+	if len(full) >= unixPathMax {
+		t.Fatalf("registration socket path len %d must be less than %d: %q", len(full), unixPathMax, full)
+	}
+}
+
+func TestRollingUpdateRegistrarSocketFile_rejectsExactLengthLimit(t *testing.T) {
+	driver := "acme-accelerator.example.com"
+	podUID := types.UID("11111111-2222-3333-4444-555555555555")
+	fullUID := driver + "-" + string(podUID) + "-reg.sock"
+	full := path.Join(KubeletRegistryDir, fullUID)
+	if len(full) != unixPathMax {
+		t.Fatalf("test setup: registration socket path len is %d, expected %d: %q", len(full), unixPathMax, full)
+	}
+
+	got := RollingUpdateRegistrarSocketFile(KubeletRegistryDir, driver, podUID)
+	if got == fullUID {
+		t.Fatalf("expected fallback from %d-byte full UID path, got %q", unixPathMax, got)
+	}
+	if len(path.Join(KubeletRegistryDir, got)) >= unixPathMax {
+		t.Fatalf("registration socket path len must be less than %d: %q", unixPathMax, got)
 	}
 }
 
@@ -80,13 +98,13 @@ func TestRollingUpdateRegistrarSocketFile_respectsCustomRegistryDir(t *testing.T
 	podUID := types.UID("11111111-2222-3333-4444-555555555555")
 
 	fullUID := driver + "-" + string(podUID) + "-reg.sock"
-	if len(path.Join(registryDir, fullUID)) <= unixPathMax {
+	if len(path.Join(registryDir, fullUID)) < unixPathMax {
 		t.Fatalf("test setup: expected full UID form to exceed limit with custom registry dir")
 	}
 
 	got := RollingUpdateRegistrarSocketFile(registryDir, driver, podUID)
-	if len(path.Join(registryDir, got)) > unixPathMax {
-		t.Fatalf("expected path within limit, got len %d: %q", len(path.Join(registryDir, got)), got)
+	if len(path.Join(registryDir, got)) >= unixPathMax {
+		t.Fatalf("expected path below limit, got len %d: %q", len(path.Join(registryDir, got)), got)
 	}
 	if got == fullUID {
 		t.Fatalf("expected fallback from full UID form, got %q", got)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

[The Linux unix(7) manual](https://man7.org/linux/man-pages/man7/unix.7.html) defines the UNIX domain socket address structure as:

```
struct sockaddr_un {
    sa_family_t sun_family;
    char        sun_path[108];
};
```

It also states:

```
The pathname in sun_path should be null-terminated.
The length of the pathname, including the terminating null byte, should not exceed the size of sun_path.
```

Therefore, a pathname-based AF_UNIX socket can use at most 107 bytes for the path itself, with the remaining byte reserved for the terminating `\0`.

Go enforces this limit when creating pathname-based AF_UNIX sockets: a socket path must be shorter than 108 bytes.

The DRA driver registration code contains an off-by-one error when validating the length of the full registration socket path. 

```
if len(path.Join(registryDir, basename)) <= unixPathMax 
```

It incorrectly accepts a path whose length is exactly 108 bytes, even though Go cannot use that path to create the socket. 

The validation must accept only paths shorter than 108 bytes.

```
if len(path.Join(registryDir, basename)) < unixPathMax 
```

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed rare out-of-tree DRA rolling-update failures with 108-byte Unix socket paths.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
