### PR TITLE
kubectl: add --examples flag to print only a command's examples

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -24,6 +24,7 @@ import (
 	"sync/atomic"
 
 	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -179,6 +180,13 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 		// Hook before and after Run initialize and write profiles to disk,
 		// respectively.
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// Behave like --help: returning pflag.ErrHelp makes cobra invoke
+			// the help function instead of running the command. The "help"
+			// command is excluded so it can resolve its target command itself.
+			if templates.ShowExamplesRequested(cmd) && cmd.Name() != "help" {
+				return flag.ErrHelp
+			}
+
 			rest.SetDefaultWarningHandler(warningHandler)
 
 			if cmd.Name() == cobra.ShellCompRequestCmd {
@@ -220,6 +228,10 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 	addProfilingFlags(flags)
 
 	flags.BoolVar(&warningsAsErrors, "warnings-as-errors", warningsAsErrors, "Treat warnings received from the server as errors and exit with a non-zero exit code")
+	var showExamples bool
+	flags.BoolVar(&showExamples, templates.ShowExamplesFlag, false, "If true, print only the examples section of the command's help and exit")
+	flags.BoolVar(&showExamples, templates.ShowExamplesFlagAlias, false, "Alias for --"+templates.ShowExamplesFlag)
+	flags.MarkHidden(templates.ShowExamplesFlagAlias) // nolint:errcheck
 
 	pref := kuberc.NewPreferences()
 	if !cmdutil.KubeRC.IsDisabled() {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
@@ -30,6 +30,7 @@ import (
 
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/kubectl/pkg/cmd/plugin"
+	"k8s.io/kubectl/pkg/util/templates"
 )
 
 func TestNormalizationFuncGlobalExistence(t *testing.T) {
@@ -394,4 +395,81 @@ func (h *testPluginHandler) Execute(executablePath string, cmdArgs, env []string
 	h.withArgs = cmdArgs
 	h.withEnv = env
 	return nil
+}
+
+func TestShowExamplesFlag(t *testing.T) {
+	// The flag is exercised under both of its spellings; every case must
+	// behave identically for --examples and its alias --example.
+	tests := []struct {
+		name    string
+		args    []string // "FLAG" is replaced by the spelling under test
+		want    []string
+		notWant []string
+	}{
+		{
+			name:    "subcommand with required flags prints only examples",
+			args:    []string{"create", "deployment", "FLAG"},
+			want:    []string{"# Create a deployment named my-dep that runs the busybox image\nkubectl create deployment my-dep --image=busybox\n\n# Create a deployment with a command\nkubectl create deployment my-dep --image=busybox -- date\n"},
+			notWant: []string{"Options:", "Usage:", "Create a deployment with the specified name.", "\n  kubectl", "\n  # "},
+		},
+		{
+			name:    "flag before the subcommand",
+			args:    []string{"FLAG", "get"},
+			want:    []string{"kubectl get pods"},
+			notWant: []string{"Options:", "Usage:"},
+		},
+		{
+			name:    "flag with explicit value and other flags",
+			args:    []string{"get", "-n", "kube-system", "FLAG=true"},
+			want:    []string{"kubectl get pods"},
+			notWant: []string{"Options:", "Usage:"},
+		},
+		{
+			name:    "parent command prints only examples",
+			args:    []string{"create", "FLAG"},
+			want:    []string{"kubectl create -f ./pod.json"},
+			notWant: []string{"Available Commands", "Options:"},
+		},
+		{
+			name:    "help command resolves its target and prints only examples",
+			args:    []string{"help", "create", "deployment", "FLAG"},
+			want:    []string{"kubectl create deployment my-dep --image=busybox"},
+			notWant: []string{"Options:", "Usage:", "kubectl help has no examples"},
+		},
+		{
+			name:    "command without examples prints a hint",
+			args:    []string{"FLAG"},
+			want:    []string{"kubectl has no examples"},
+			notWant: []string{"Basic Commands"},
+		},
+	}
+	for _, flagName := range []string{"--" + templates.ShowExamplesFlag, "--" + templates.ShowExamplesFlagAlias} {
+		for _, tt := range tests {
+			t.Run(flagName+"/"+tt.name, func(t *testing.T) {
+				args := make([]string, len(tt.args))
+				for i, a := range tt.args {
+					args[i] = strings.Replace(a, "FLAG", flagName, 1)
+				}
+				ioStreams, _, out, _ := genericiooptions.NewTestIOStreams()
+				root := NewKubectlCommand(KubectlOptions{Arguments: append([]string{"kubectl"}, args...), IOStreams: ioStreams})
+				root.SetOut(out)
+				root.SetErr(out)
+				root.SetArgs(args)
+				if err := root.Execute(); err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				got := out.String()
+				for _, w := range tt.want {
+					if !strings.Contains(got, w) {
+						t.Errorf("expected output to contain %q, got:\n%s", w, got)
+					}
+				}
+				for _, nw := range tt.notWant {
+					if strings.Contains(got, nw) {
+						t.Errorf("expected output NOT to contain %q, got:\n%s", nw, got)
+					}
+				}
+			})
+		}
+	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/util/templates/templater.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/templates/templater.go
@@ -29,6 +29,34 @@ import (
 	"k8s.io/kubectl/pkg/util/term"
 )
 
+// ShowExamplesFlag is the name of the global flag that, when set, makes a
+// command print only the examples section of its help text and exit.
+const ShowExamplesFlag = "examples"
+
+// ShowExamplesFlagAlias is a hidden singular alias of ShowExamplesFlag.
+const ShowExamplesFlagAlias = "example"
+
+// ShowExamplesRequested reports whether the --examples flag (or its alias
+// --example) was set on the command tree cmd belongs to. The flag is a
+// persistent flag on the root command, so its value is shared by every
+// command in the tree.
+func ShowExamplesRequested(cmd *cobra.Command) bool {
+	f := cmd.Root().PersistentFlags().Lookup(ShowExamplesFlag)
+	return f != nil && f.Value.String() == "true"
+}
+
+// exampleCommands reformats a command's Example text for direct copying: the
+// indentation added for the --help layout is removed so every line, including
+// the descriptive '# ...' comments, starts at column 0. Blank lines between
+// examples are preserved.
+func exampleCommands(example string) string {
+	lines := strings.Split(strings.TrimRightFunc(example, unicode.IsSpace), "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimSpace(line)
+	}
+	return strings.Join(lines, "\n")
+}
+
 type FlagExposer interface {
 	ExposeFlags(cmd *cobra.Command, flags ...string) FlagExposer
 }
@@ -38,11 +66,12 @@ func ActsAsRootCommand(cmd *cobra.Command, filters []string, groups ...CommandGr
 		panic("nil root command")
 	}
 	templater := &templater{
-		RootCmd:       cmd,
-		UsageTemplate: MainUsageTemplate(),
-		HelpTemplate:  MainHelpTemplate(),
-		CommandGroups: groups,
-		Filtered:      filters,
+		RootCmd:          cmd,
+		UsageTemplate:    MainUsageTemplate(),
+		HelpTemplate:     MainHelpTemplate(),
+		ExamplesTemplate: ExamplesHelpTemplate(),
+		CommandGroups:    groups,
+		Filtered:         filters,
 	}
 	cmd.SetFlagErrorFunc(templater.FlagErrorFunc())
 	cmd.SilenceUsage = true
@@ -61,9 +90,10 @@ func UseOptionsTemplates(cmd *cobra.Command) {
 }
 
 type templater struct {
-	UsageTemplate string
-	HelpTemplate  string
-	RootCmd       *cobra.Command
+	UsageTemplate    string
+	HelpTemplate     string
+	ExamplesTemplate string
+	RootCmd          *cobra.Command
 	CommandGroups
 	Filtered []string
 }
@@ -87,9 +117,13 @@ func (templater *templater) ExposeFlags(cmd *cobra.Command, flags ...string) Fla
 
 func (templater *templater) HelpFunc() func(*cobra.Command, []string) {
 	return func(c *cobra.Command, s []string) {
+		helpTemplate := templater.HelpTemplate
+		if len(templater.ExamplesTemplate) > 0 && ShowExamplesRequested(c) {
+			helpTemplate = templater.ExamplesTemplate
+		}
 		t := template.New("help")
 		t.Funcs(templater.templateFuncs())
-		template.Must(t.Parse(templater.HelpTemplate))
+		template.Must(t.Parse(helpTemplate))
 		out := term.NewResponsiveWriter(c.OutOrStdout())
 		err := t.Execute(out, c)
 		if err != nil {
@@ -112,6 +146,7 @@ func (templater *templater) templateFuncs(exposedFlags ...string) template.FuncM
 	return template.FuncMap{
 		"trim":                strings.TrimSpace,
 		"trimRight":           func(s string) string { return strings.TrimRightFunc(s, unicode.IsSpace) },
+		"exampleCommands":     exampleCommands,
 		"trimLeft":            func(s string) string { return strings.TrimLeftFunc(s, unicode.IsSpace) },
 		"gt":                  cobra.Gt,
 		"eq":                  cobra.Eq,

--- a/staging/src/k8s.io/kubectl/pkg/util/templates/templater_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/templates/templater_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import "testing"
+
+func TestExampleCommands(t *testing.T) {
+	tests := []struct {
+		name    string
+		example string
+		want    string
+	}{
+		{
+			name:    "empty",
+			example: "",
+			want:    "",
+		},
+		{
+			name: "indentation is removed, comments and blank lines are kept",
+			example: Examples(`
+		# Create a pod using the data in pod.json
+		kubectl create -f ./pod.json
+
+		# Create a pod based on the JSON passed into stdin
+		cat pod.json | kubectl create -f -`),
+			want: "# Create a pod using the data in pod.json\nkubectl create -f ./pod.json\n\n# Create a pod based on the JSON passed into stdin\ncat pod.json | kubectl create -f -",
+		},
+		{
+			name:    "commands only",
+			example: "  kubectl get pods\n  kubectl get pods -o wide\n",
+			want:    "kubectl get pods\nkubectl get pods -o wide",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := exampleCommands(tt.example); got != tt.want {
+				t.Errorf("exampleCommands() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/util/templates/templates.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/templates/templates.go
@@ -75,6 +75,15 @@ func MainHelpTemplate() string {
 	return `{{with or .Long .Short }}{{. | trim}}{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
 }
 
+// ExamplesHelpTemplate is the template for 'help' used by most commands when
+// only the examples were requested via the --examples flag. It prints the
+// examples without the indentation used in the --help layout, so every
+// command starts at column 0 and can be copied directly.
+func ExamplesHelpTemplate() string {
+	return `{{if .HasExample}}{{exampleCommands .Example}}{{else}}{{.CommandPath}} has no examples. See '{{.CommandPath}} --help' for usage.{{end}}
+`
+}
+
 // MainUsageTemplate if the template for 'usage' used by most commands.
 func MainUsageTemplate() string {
 	sections := []string{


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/sig cli

**What this PR does / why we need it**:

Adds a global `--examples` flag (hidden alias `--example`) to kubectl that prints only the Examples section of a command's help, unindented so commands can be copied directly, and exits. Users no longer have to scroll through the full `--help` output (Options, Usage, ...) to find the invocation shape.

```
$ kubectl create deployment --examples
# Create a deployment named my-dep that runs the busybox image
kubectl create deployment my-dep --image=busybox

# Create a deployment with a command
kubectl create deployment my-dep --image=busybox -- date
...
```

- Works for any command with examples, including parent commands (`kubectl create --examples`), via `kubectl help <cmd> --examples`, and with the flag before or after the subcommand.
- Commands without examples print `<cmd> has no examples. See '<cmd> --help' for usage.`
- Takes the same code path as `--help`: the root `PersistentPreRunE` returns `pflag.ErrHelp`, which cobra handles by invoking the help func. This runs before required-flag validation, so it works for commands with required flags (e.g. `create deployment --image`). The `help` command is excluded so it can resolve its target itself.
- `--help` output is unchanged.
- Unit tests cover both spellings across all of the above paths.

**Which issue(s) this PR is related to**:

Fixes kubernetes/kubectl#1876

**Special notes for your reviewer**:

The hidden singular alias `--example` is a three-line removal if not wanted.

**Does this PR introduce a user-facing change?**

```release-note
kubectl: added a global `--examples` flag that prints only the examples section of a command's help, unindented for copying (e.g. `kubectl create deployment --examples`).
```
