### PR TITLE
Keep Zero-Exponent BinarySI Values on Integer Serialization Path

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -458,7 +458,7 @@ func (q *Quantity) CanonicalizeBytes(out []byte) (result, suffix []byte) {
 		// format must be BinarySI
 		number, exponent := rounded.AsCanonicalBase1024Bytes(out)
 		suffix, ok := quantitySuffixer.constructBytes(2, exponent*10, format)
-		if !ok {
+		if !ok && exponent != 0 {
 			// BinarySI only defines suffixes up to "Ei" (2^60). For a larger
 			// exponent there is no suffix, so fall back to decimal exponent
 			// notation ("e") instead of dropping the suffix, which would

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -838,6 +838,24 @@ func TestBinarySIPastEiArithmeticRoundTrip(t *testing.T) {
 		t.Errorf("String round trip changed the value: %s vs %s", q.String(), reparsed.String())
 	}
 }
+
+func TestBinarySIZeroExponentString(t *testing.T) {
+	table := []struct {
+		in   Quantity
+		want string
+	}{
+		{intQuantity(2000, 0, BinarySI), "2000"},
+		{intQuantity(-2000, 0, BinarySI), "-2000"},
+		{decQuantity(2000, 0, BinarySI), "2000"},
+		{decQuantity(-2000, 0, BinarySI), "-2000"},
+	}
+	for _, item := range table {
+		if e, a := item.want, item.in.String(); e != a {
+			t.Errorf("String() = %q, want %q", a, e)
+		}
+	}
+}
+
 func TestQuantityStringBelowNano(t *testing.T) {
 	// DecimalSI has no suffix below "n" (10^-9), so these values take the same
 	// exponent-notation fallback as the >"E" cases above. They are not reachable


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

PR #140459 aimed to prevent magnitude loss when `resource.Quantity` exceeds supported suffix range.  For example, it corrected serialization of `1000E` from corrupted `1` to `1e21`, and ensured a BinarySI value produced by `1Ei × 1024` is serialized as exact `1180591620717411303424` instead of `1`.

However, new BinarySI fallback also treats exponent-zero values, which require no suffix, as suffix overflows. 
As result, it changes existing canonical output for ordinary values, such as `2000` to `2e3`. 

This behavior is unrelated to original overflow fix.
The more important is that, representation is API-observable through JSON, YAML, and unstructured serialization.  Changing it breaks output stability and can cause unnecessary GitOps diffs or compatibility issues for clients relying on existing canonical representation.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix: Keep Zero-Exponent BinarySI Values on Integer Serialization Path
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
