### PR TITLE
scheduler: parameterize pod group scheduling attempts and latency metrics with type for compositepodgroup

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -6625,22 +6625,27 @@
     endpoint: /metrics
 - name: podgroup_schedule_attempts_total
   subsystem: scheduler
-  help: Number of attempts to schedule pod group, by the result and scheduler profile.
-    'unschedulable' means a pod group could not be scheduled, while 'error' means
-    an internal scheduler problem.
+  help: Number of attempts to schedule pod group, by the result, scheduler profile
+    and entity type ('podgroup' or 'compositepodgroup'). 'unschedulable' means a pod
+    group could not be scheduled, while 'error' means an internal scheduler problem.
   type: Counter
   stabilityLevel: ALPHA
   labels:
   - profile
   - result
+  - type
   componentEndpoints:
   - component: kube-scheduler
     endpoint: /metrics
 - name: podgroup_scheduling_algorithm_duration_seconds
   subsystem: scheduler
-  help: Pod group scheduling algorithm latency in seconds
+  help: Pod group scheduling algorithm latency in seconds, by scheduler profile and
+    entity type ('podgroup' or 'compositepodgroup').
   type: Histogram
   stabilityLevel: ALPHA
+  labels:
+  - profile
+  - type
   buckets:
   - 0.001
   - 0.002
@@ -6662,12 +6667,14 @@
     endpoint: /metrics
 - name: podgroup_scheduling_attempt_duration_seconds
   subsystem: scheduler
-  help: Pod group scheduling attempt latency in seconds, by scheduler profile.
+  help: Pod group scheduling attempt latency in seconds, by result, scheduler profile
+    and entity type ('podgroup' or 'compositepodgroup').
   type: Histogram
   stabilityLevel: ALPHA
   labels:
   - profile
   - result
+  - type
   buckets:
   - 0.001
   - 0.002

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -99,10 +99,11 @@ const (
 	QueueingHintResultError     = "Error"
 )
 
-// Entity label values used for queued_entities and queue_incoming_entities metrics.
+// Entity label values used for scheduling, queued_entities, and queue_incoming_entities metrics.
 const (
-	Pod      = "pod"
-	PodGroup = "podgroup"
+	Pod               = "pod"
+	PodGroup          = "podgroup"
+	CompositePodGroup = "compositepodgroup"
 )
 
 const (
@@ -188,9 +189,9 @@ var (
 	// This is the same metric that also gets recorded in the kube-controller-manager.
 	ResourceClaimCreatesTotal = resourceclaimmetrics.ResourceClaimCreate
 
-	podGroupScheduleAttempts           *metrics.CounterVec
-	podGroupSchedulingLatency          *metrics.HistogramVec
-	PodGroupSchedulingAlgorithmLatency *metrics.Histogram
+	PodGroupScheduleAttempts           *metrics.CounterVec
+	PodGroupSchedulingLatency          *metrics.HistogramVec
+	PodGroupSchedulingAlgorithmLatency *metrics.HistogramVec
 
 	// The below are only available when the TopologyAwareWorkloadScheduling feature gate is enabled.
 	GeneratedPlacementsTotal    *metrics.CounterVec
@@ -237,8 +238,8 @@ func Register() {
 		}
 		if utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload) {
 			RegisterMetrics(
-				podGroupScheduleAttempts,
-				podGroupSchedulingLatency,
+				PodGroupScheduleAttempts,
+				PodGroupSchedulingLatency,
 				PodGroupSchedulingAlgorithmLatency,
 				WorkloadPreemptionAttempts,
 				WorkloadPreemptionVictims,
@@ -591,30 +592,30 @@ func InitMetrics() {
 		},
 		[]string{"profile"})
 
-	// The below (podGroupScheduleAttempts, podGroupSchedulingLatency and PodGroupSchedulingAlgorithmLatency) are only available when the GenericWorkload feature gate is enabled.
-	podGroupScheduleAttempts = metrics.NewCounterVec(
+	// The below (PodGroupScheduleAttempts, PodGroupSchedulingLatency and PodGroupSchedulingAlgorithmLatency) are only available when the GenericWorkload feature gate is enabled.
+	PodGroupScheduleAttempts = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "podgroup_schedule_attempts_total",
-			Help:           "Number of attempts to schedule pod group, by the result and scheduler profile. 'unschedulable' means a pod group could not be scheduled, while 'error' means an internal scheduler problem.",
+			Help:           "Number of attempts to schedule pod group, by the result, scheduler profile and entity type ('podgroup' or 'compositepodgroup'). 'unschedulable' means a pod group could not be scheduled, while 'error' means an internal scheduler problem.",
 			StabilityLevel: metrics.ALPHA,
-		}, []string{"result", "profile"})
-	podGroupSchedulingLatency = metrics.NewHistogramVec(
+		}, []string{"result", "profile", "type"})
+	PodGroupSchedulingLatency = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "podgroup_scheduling_attempt_duration_seconds",
-			Help:           "Pod group scheduling attempt latency in seconds, by scheduler profile.",
+			Help:           "Pod group scheduling attempt latency in seconds, by result, scheduler profile and entity type ('podgroup' or 'compositepodgroup').",
 			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel: metrics.ALPHA,
-		}, []string{"result", "profile"})
-	PodGroupSchedulingAlgorithmLatency = metrics.NewHistogram(
+		}, []string{"result", "profile", "type"})
+	PodGroupSchedulingAlgorithmLatency = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "podgroup_scheduling_algorithm_duration_seconds",
-			Help:           "Pod group scheduling algorithm latency in seconds",
+			Help:           "Pod group scheduling algorithm latency in seconds, by scheduler profile and entity type ('podgroup' or 'compositepodgroup').",
 			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel: metrics.ALPHA,
-		})
+		}, []string{"profile", "type"})
 
 	// Workload preemption
 	WorkloadPreemptionAttempts = metrics.NewCounterVec(

--- a/pkg/scheduler/metrics/profile_metrics.go
+++ b/pkg/scheduler/metrics/profile_metrics.go
@@ -52,31 +52,36 @@ func observeScheduleAttemptAndLatency(result, profile string, duration float64) 
 
 // PodGroupScheduled can records a successful pod group scheduling attempt and the duration
 // since `start`.
-func PodGroupScheduled(profile string, duration float64) {
-	observePodGroupScheduleAttemptAndLatency(ScheduledResult, profile, duration)
+func PodGroupScheduled(profile, entityType string, duration float64) {
+	observePodGroupScheduleAttemptAndLatency(ScheduledResult, profile, entityType, duration)
 }
 
 // PodGroupUnschedulable can records a pod group scheduling attempt for an unschedulable pod group
 // and the duration since `start`.
-func PodGroupUnschedulable(profile string, duration float64) {
-	observePodGroupScheduleAttemptAndLatency(UnschedulableResult, profile, duration)
+func PodGroupUnschedulable(profile, entityType string, duration float64) {
+	observePodGroupScheduleAttemptAndLatency(UnschedulableResult, profile, entityType, duration)
 }
 
 // PodGroupWaitingOnPreemption can records a pod group scheduling attempt for an unschedulable pod group
 // waiting on preemption, and the duration since `start`.
-func PodGroupWaitingOnPreemption(profile string, duration float64) {
-	observePodGroupScheduleAttemptAndLatency(WaitingOnPreemptionResult, profile, duration)
+func PodGroupWaitingOnPreemption(profile, entityType string, duration float64) {
+	observePodGroupScheduleAttemptAndLatency(WaitingOnPreemptionResult, profile, entityType, duration)
 }
 
 // PodGroupScheduleError records a pod group scheduling attempt that had an error, and the
 // duration since `start`.
-func PodGroupScheduleError(profile string, duration float64) {
-	observePodGroupScheduleAttemptAndLatency(ErrorResult, profile, duration)
+func PodGroupScheduleError(profile, entityType string, duration float64) {
+	observePodGroupScheduleAttemptAndLatency(ErrorResult, profile, entityType, duration)
 }
 
-func observePodGroupScheduleAttemptAndLatency(result, profile string, duration float64) {
-	podGroupSchedulingLatency.WithLabelValues(result, profile).Observe(duration)
-	podGroupScheduleAttempts.WithLabelValues(result, profile).Inc()
+func observePodGroupScheduleAttemptAndLatency(result, profile, entityType string, duration float64) {
+	PodGroupSchedulingLatency.WithLabelValues(result, profile, entityType).Observe(duration)
+	PodGroupScheduleAttempts.WithLabelValues(result, profile, entityType).Inc()
+}
+
+// PodGroupAlgorithmLatency records the scheduling algorithm duration for a pod group.
+func PodGroupAlgorithmLatency(profile, entityType string, duration float64) {
+	PodGroupSchedulingAlgorithmLatency.WithLabelValues(profile, entityType).Observe(duration)
 }
 
 // RecordGeneratedPlacements records the number of candidate placements generated for a

--- a/pkg/scheduler/metrics/profile_metrics_test.go
+++ b/pkg/scheduler/metrics/profile_metrics_test.go
@@ -90,3 +90,88 @@ func TestObservePlacementEvaluation(t *testing.T) {
 		}
 	}
 }
+
+func TestObservePodGroupScheduleAttemptAndLatency(t *testing.T) {
+	InitMetrics()
+	registry := metrics.NewKubeRegistry()
+	registry.MustRegister(PodGroupScheduleAttempts, PodGroupSchedulingLatency)
+
+	PodGroupScheduled("test-profile", PodGroup, 0.5)
+	PodGroupScheduled("test-profile", CompositePodGroup, 0.6)
+	PodGroupUnschedulable("test-profile", PodGroup, 0.2)
+	PodGroupUnschedulable("test-profile", CompositePodGroup, 0.25)
+	PodGroupWaitingOnPreemption("test-profile", PodGroup, 0.3)
+	PodGroupWaitingOnPreemption("test-profile", CompositePodGroup, 0.35)
+	PodGroupScheduleError("test-profile", PodGroup, 0.1)
+	PodGroupScheduleError("test-profile", CompositePodGroup, 0.15)
+
+	want := `
+		# HELP scheduler_podgroup_schedule_attempts_total [ALPHA] Number of attempts to schedule pod group, by the result, scheduler profile and entity type ('podgroup' or 'compositepodgroup'). 'unschedulable' means a pod group could not be scheduled, while 'error' means an internal scheduler problem.
+		# TYPE scheduler_podgroup_schedule_attempts_total counter
+		scheduler_podgroup_schedule_attempts_total{profile="test-profile",result="error",type="compositepodgroup"} 1
+		scheduler_podgroup_schedule_attempts_total{profile="test-profile",result="error",type="podgroup"} 1
+		scheduler_podgroup_schedule_attempts_total{profile="test-profile",result="scheduled",type="compositepodgroup"} 1
+		scheduler_podgroup_schedule_attempts_total{profile="test-profile",result="scheduled",type="podgroup"} 1
+		scheduler_podgroup_schedule_attempts_total{profile="test-profile",result="unschedulable",type="compositepodgroup"} 1
+		scheduler_podgroup_schedule_attempts_total{profile="test-profile",result="unschedulable",type="podgroup"} 1
+		scheduler_podgroup_schedule_attempts_total{profile="test-profile",result="waiting_on_preemption",type="compositepodgroup"} 1
+		scheduler_podgroup_schedule_attempts_total{profile="test-profile",result="waiting_on_preemption",type="podgroup"} 1
+	`
+	if err := testutil.GatherAndCompare(registry, strings.NewReader(want), "scheduler_podgroup_schedule_attempts_total"); err != nil {
+		t.Errorf("unexpected podgroup_schedule_attempts_total metric output:\n%v", err)
+	}
+
+	for _, tc := range []struct {
+		profile    string
+		result     string
+		entityType string
+		wantCount  uint64
+	}{
+		{"test-profile", ScheduledResult, PodGroup, 1},
+		{"test-profile", ScheduledResult, CompositePodGroup, 1},
+		{"test-profile", UnschedulableResult, PodGroup, 1},
+		{"test-profile", UnschedulableResult, CompositePodGroup, 1},
+		{"test-profile", WaitingOnPreemptionResult, PodGroup, 1},
+		{"test-profile", WaitingOnPreemptionResult, CompositePodGroup, 1},
+		{"test-profile", ErrorResult, PodGroup, 1},
+		{"test-profile", ErrorResult, CompositePodGroup, 1},
+	} {
+		gotCount, err := testutil.GetHistogramMetricCount(PodGroupSchedulingLatency.WithLabelValues(tc.result, tc.profile, tc.entityType))
+		if err != nil {
+			t.Errorf("Failed to get sample count for podgroup_scheduling_attempt_duration_seconds{profile=%q,result=%q,type=%q}: %v", tc.profile, tc.result, tc.entityType, err)
+			continue
+		}
+		if gotCount != tc.wantCount {
+			t.Errorf("podgroup_scheduling_attempt_duration_seconds{profile=%q,result=%q,type=%q}: got %d samples, want %d", tc.profile, tc.result, tc.entityType, gotCount, tc.wantCount)
+		}
+	}
+}
+
+func TestPodGroupAlgorithmLatency(t *testing.T) {
+	InitMetrics()
+	registry := metrics.NewKubeRegistry()
+	registry.MustRegister(PodGroupSchedulingAlgorithmLatency)
+
+	PodGroupAlgorithmLatency("test-profile", PodGroup, 0.1)
+	PodGroupAlgorithmLatency("test-profile", CompositePodGroup, 0.2)
+	PodGroupAlgorithmLatency("test-profile-2", CompositePodGroup, 0.3)
+
+	for _, tc := range []struct {
+		profile    string
+		entityType string
+		wantCount  uint64
+	}{
+		{"test-profile", PodGroup, 1},
+		{"test-profile", CompositePodGroup, 1},
+		{"test-profile-2", CompositePodGroup, 1},
+	} {
+		gotCount, err := testutil.GetHistogramMetricCount(PodGroupSchedulingAlgorithmLatency.WithLabelValues(tc.profile, tc.entityType))
+		if err != nil {
+			t.Errorf("Failed to get sample count for podgroup_scheduling_algorithm_duration_seconds{profile=%q,type=%q}: %v", tc.profile, tc.entityType, err)
+			continue
+		}
+		if gotCount != tc.wantCount {
+			t.Errorf("podgroup_scheduling_algorithm_duration_seconds{profile=%q,type=%q}: got %d samples, want %d", tc.profile, tc.entityType, gotCount, tc.wantCount)
+		}
+	}
+}

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -385,7 +385,7 @@ func (sched *Scheduler) podGroupCycle(ctx context.Context, schedFwk framework.Fr
 		completePGResults = map[fwk.EntityKey]*podGroupAlgorithmResult{rootPodGroupInfo.PodGroupInfo.GetKey(): result}
 	}
 
-	metrics.PodGroupSchedulingAlgorithmLatency.Observe(metrics.SinceInSeconds(start))
+	metrics.PodGroupAlgorithmLatency(schedFwk.ProfileName(), string(rootPodGroupInfo.Type()), metrics.SinceInSeconds(start))
 
 	// Run pod group post filter plugins if scheduling failed. If any of the plugins is successful,
 	// we need to put the pods from pod group back into the scheduling queue.
@@ -824,18 +824,19 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 		sched.updatePodGroupCondition(ctx, pgi, condition)
 	}
 
+	entityType := string(rootPodGroupInfo.Type())
 	rootResult := podGroupResults[rootPodGroupInfo.PodGroupInfo.GetKey()]
 	switch {
 	case rootResult.status.IsSuccess():
-		metrics.PodGroupScheduled(schedFwk.ProfileName(), metrics.SinceInSeconds(start))
+		metrics.PodGroupScheduled(schedFwk.ProfileName(), entityType, metrics.SinceInSeconds(start))
 	case rootResult.status.IsRejected():
 		if rootResult.waitingOnPreemption {
-			metrics.PodGroupWaitingOnPreemption(schedFwk.ProfileName(), metrics.SinceInSeconds(start))
+			metrics.PodGroupWaitingOnPreemption(schedFwk.ProfileName(), entityType, metrics.SinceInSeconds(start))
 		} else {
-			metrics.PodGroupUnschedulable(schedFwk.ProfileName(), metrics.SinceInSeconds(start))
+			metrics.PodGroupUnschedulable(schedFwk.ProfileName(), entityType, metrics.SinceInSeconds(start))
 		}
 	default:
-		metrics.PodGroupScheduleError(schedFwk.ProfileName(), metrics.SinceInSeconds(start))
+		metrics.PodGroupScheduleError(schedFwk.ProfileName(), entityType, metrics.SinceInSeconds(start))
 	}
 
 	if err := sched.SchedulingQueue.AddAttemptedPodGroupIfNeeded(logger, rootPodGroupInfo, sched.SchedulingQueue.SchedulingCycle(), rootStatus); err != nil {

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -7398,3 +7398,232 @@ func TestPodGroupCycle_PodStatusConditions(t *testing.T) {
 		}
 	}
 }
+
+func TestScheduleOnePodGroup_AttemptAndLatencyMetrics(t *testing.T) {
+	testRegistry := componentmetrics.NewKubeRegistry()
+	testRegistry.MustRegister(
+		metrics.PodGroupScheduleAttempts,
+		metrics.PodGroupSchedulingLatency,
+		metrics.PodGroupSchedulingAlgorithmLatency,
+	)
+
+	tests := []struct {
+		name                string
+		isCPG               bool
+		wantType            string
+		status              *fwk.Status
+		waitingOnPreemption bool
+		wantResult          string
+	}{
+		{
+			name:       "podgroup scheduled successfully",
+			isCPG:      false,
+			wantType:   metrics.PodGroup,
+			status:     fwk.NewStatus(fwk.Success),
+			wantResult: metrics.ScheduledResult,
+		},
+		{
+			name:       "compositepodgroup scheduled successfully",
+			isCPG:      true,
+			wantType:   metrics.CompositePodGroup,
+			status:     fwk.NewStatus(fwk.Success),
+			wantResult: metrics.ScheduledResult,
+		},
+		{
+			name:       "podgroup unschedulable",
+			isCPG:      false,
+			wantType:   metrics.PodGroup,
+			status:     fwk.NewStatus(fwk.Unschedulable),
+			wantResult: metrics.UnschedulableResult,
+		},
+		{
+			name:       "compositepodgroup unschedulable",
+			isCPG:      true,
+			wantType:   metrics.CompositePodGroup,
+			status:     fwk.NewStatus(fwk.Unschedulable),
+			wantResult: metrics.UnschedulableResult,
+		},
+		{
+			name:                "podgroup waiting on preemption",
+			isCPG:               false,
+			wantType:            metrics.PodGroup,
+			status:              fwk.NewStatus(fwk.Unschedulable),
+			waitingOnPreemption: true,
+			wantResult:          metrics.WaitingOnPreemptionResult,
+		},
+		{
+			name:                "compositepodgroup waiting on preemption",
+			isCPG:               true,
+			wantType:            metrics.CompositePodGroup,
+			status:              fwk.NewStatus(fwk.Unschedulable),
+			waitingOnPreemption: true,
+			wantResult:          metrics.WaitingOnPreemptionResult,
+		},
+		{
+			name:       "podgroup error",
+			isCPG:      false,
+			wantType:   metrics.PodGroup,
+			status:     fwk.NewStatus(fwk.Error, "internal error"),
+			wantResult: metrics.ErrorResult,
+		},
+		{
+			name:       "compositepodgroup error",
+			isCPG:      true,
+			wantType:   metrics.CompositePodGroup,
+			status:     fwk.NewStatus(fwk.Error, "internal error"),
+			wantResult: metrics.ErrorResult,
+		},
+	}
+
+	gateSetups := []struct {
+		name       string
+		cpgEnabled bool
+		features   featuregatetesting.FeatureOverrides
+	}{
+		{
+			name:       "Generic",
+			cpgEnabled: false,
+			features: featuregatetesting.FeatureOverrides{
+				features.GenericWorkload: true,
+			},
+		},
+		{
+			name:       "CPG",
+			cpgEnabled: true,
+			// CompositePodGroup depends on GenericWorkload and TopologyAwareWorkloadScheduling.
+			features: featuregatetesting.FeatureOverrides{
+				features.GenericWorkload:                 true,
+				features.TopologyAwareWorkloadScheduling: true,
+				features.CompositePodGroup:               true,
+			},
+		},
+	}
+
+	for _, setup := range gateSetups {
+		t.Run(setup.name, func(t *testing.T) {
+			for _, tt := range tests {
+				if tt.isCPG && !setup.cpgEnabled {
+					continue
+				}
+				t.Run(tt.name, func(t *testing.T) {
+					featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, setup.features)
+
+					metrics.PodGroupScheduleAttempts.Reset()
+					metrics.PodGroupSchedulingLatency.Reset()
+					metrics.PodGroupSchedulingAlgorithmLatency.Reset()
+
+					logger, ctx := ktesting.NewTestContext(t)
+					testNode := st.MakeNode().Name("node1").Obj()
+					p1 := st.MakePod().Name("p1").Namespace("default").UID("p1").SchedulerName("test-scheduler").Obj()
+
+					var qpgi *framework.QueuedPodGroupInfo
+					if tt.isCPG {
+						cpg := st.MakeCompositePodGroup().Name("root-cpg").Namespace("default").Obj()
+						pg := st.MakePodGroup().Name("child-pg").Namespace("default").ParentCompositePodGroup("root-cpg").Obj()
+						p1.Spec.SchedulingGroup = &v1.PodSchedulingGroup{PodGroupName: &pg.Name}
+						qpgi = &framework.QueuedPodGroupInfo{
+							PodGroupInfo: &framework.PodGroupInfo{
+								GenericPodGroup: framework.NewGenericCompositePodGroup(cpg),
+								Children: []*framework.PodGroupInfo{
+									{
+										GenericPodGroup: framework.NewGenericPodGroup(pg),
+										UnscheduledPods: []*v1.Pod{p1},
+									},
+								},
+							},
+							QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{
+								fwk.PodGroupKey("default", "child-pg"): {{PodInfo: &framework.PodInfo{Pod: p1}}},
+							},
+						}
+					} else {
+						pg := st.MakePodGroup().Name("pg").Namespace("default").Obj()
+						p1.Spec.SchedulingGroup = &v1.PodSchedulingGroup{PodGroupName: &pg.Name}
+						qpgi = &framework.QueuedPodGroupInfo{
+							PodGroupInfo: &framework.PodGroupInfo{
+								GenericPodGroup: framework.NewGenericPodGroup(pg),
+								UnscheduledPods: []*v1.Pod{p1},
+							},
+							QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{
+								fwk.PodGroupKey("default", "pg"): {{PodInfo: &framework.PodInfo{Pod: p1}}},
+							},
+						}
+					}
+
+					client := clientsetfake.NewSimpleClientset(testNode, p1)
+					schedFwk, err := tf.NewFramework(ctx, []tf.RegisterPluginFunc{
+						tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+						tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+					}, "test-scheduler",
+						frameworkruntime.WithClientSet(client),
+						frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
+						frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
+						frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
+					)
+					if err != nil {
+						t.Fatalf("Failed to create framework: %v", err)
+					}
+
+					cache := internalcache.New(ctx, nil, true, true)
+					cache.AddNode(logger, testNode)
+
+					sched := &Scheduler{
+						Profiles:         profile.Map{"test-scheduler": schedFwk},
+						SchedulingQueue:  internalqueue.NewTestQueue(ctx, nil),
+						Cache:            cache,
+						client:           client,
+						nodeInfoSnapshot: internalcache.NewEmptySnapshot(),
+						FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
+						},
+					}
+
+					// submitPodGroupAlgorithmResult finishes the cycle and records attempt and latency metrics
+					podGroupCycleState := framework.NewCycleState()
+					pgResult := &podGroupAlgorithmResult{
+						status:              tt.status,
+						podGroupInfo:        qpgi.PodGroupInfo,
+						waitingOnPreemption: tt.waitingOnPreemption,
+					}
+					if !tt.isCPG {
+						placementCycleState := framework.NewCycleState()
+						placementCycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
+						podCtx := initPodSchedulingContext(ctx, p1, placementCycleState)
+						pgResult.podResults = []algorithmResult{
+							{
+								status:         tt.status,
+								podCtx:         podCtx,
+								podInfo:        qpgi.QueuedPodInfos[qpgi.PodGroupInfo.GetKey()][0],
+								scheduleResult: ScheduleResult{SuggestedHost: testNode.Name},
+							},
+						}
+					}
+					resultsMap := map[fwk.EntityKey]*podGroupAlgorithmResult{
+						qpgi.PodGroupInfo.GetKey(): pgResult,
+					}
+					sched.submitPodGroupAlgorithmResult(ctx, schedFwk, podGroupCycleState, qpgi, resultsMap, time.Now(), tt.status)
+
+					// Also test algorithm latency metric helper directly with profile and type
+					metrics.PodGroupAlgorithmLatency(schedFwk.ProfileName(), string(qpgi.Type()), 0.1)
+
+					// Verify podgroup_schedule_attempts_total
+					assertCounterValueFromGatherer(t, testRegistry, "scheduler_podgroup_schedule_attempts_total", "type", tt.wantType, 1)
+					assertCounterValueFromGatherer(t, testRegistry, "scheduler_podgroup_schedule_attempts_total", "result", tt.wantResult, 1)
+
+					// Verify podgroup_scheduling_attempt_duration_seconds sample count
+					labels := map[string]string{
+						"result":  tt.wantResult,
+						"profile": "test-scheduler",
+						"type":    tt.wantType,
+					}
+					assertHistogramSampleCountFromGatherer(t, testRegistry, "scheduler_podgroup_scheduling_attempt_duration_seconds", labels, 1)
+
+					// Verify podgroup_scheduling_algorithm_duration_seconds sample count
+					algoLabels := map[string]string{
+						"profile": "test-scheduler",
+						"type":    tt.wantType,
+					}
+					assertHistogramSampleCountFromGatherer(t, testRegistry, "scheduler_podgroup_scheduling_algorithm_duration_seconds", algoLabels, 1)
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Parameterize pod group scheduling attempts, scheduling latency, and algorithm latency metrics with entity type ("podgroup" vs "compositepodgroup") and profile. Specifically:
- Export PodGroupScheduleAttempts and PodGroupSchedulingLatency with [result, profile, type] labels.
- Convert PodGroupSchedulingAlgorithmLatency to HistogramVec with [profile, type] labels.

#### Which issue(s) this PR is related to:
KEP: [KEP-6012](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/6012-composite-podgroup-api#readme)

#### Special notes for your reviewer:
/sig scheduling
/wg workload-aware-scheduling

#### Does this PR introduce a user-facing change?
```release-note
Extends pod group scheduling attempts and latency metrics with type to support `CompositePodGroup`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

#### AI usage disclosure:
YES, AI supported