### PR TITLE
Retry etcd testserver startup on port conflict

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_testing_utils_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_testing_utils_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/server/v3/embed"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -111,9 +112,9 @@ func computePodKey(obj *example.Pod) string {
 }
 
 func newCorev1EtcdTestStorage(t testing.TB) (*etcd3testing.EtcdTestServer, storage.Interface) {
-	cfg := testserver.NewTestConfig(t)
-	cfg.QuotaBackendBytes = 4 << 30 // 4 GiB (default 2 GiB is too small for 150k pods)
-	server := &etcd3testing.EtcdTestServer{V3Client: testserver.RunEtcd(t, cfg)}
+	server := &etcd3testing.EtcdTestServer{V3Client: testserver.RunEtcd(t, func(cfg *embed.Config) {
+		cfg.QuotaBackendBytes = 4 << 30 // 4 GiB (default 2 GiB is too small for 150k pods)
+	})}
 	versioner := storage.APIObjectVersioner{}
 	compactor := etcd3.NewCompactor(server.V3Client.Client, 0, clock.RealClock{}, nil)
 	t.Cleanup(compactor.Stop)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/compact_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/compact_test.go
@@ -34,7 +34,7 @@ const (
 )
 
 func TestCompact(t *testing.T) {
-	client := testserver.RunEtcd(t, nil).Client
+	client := testserver.RunEtcd(t).Client
 	ctx := context.Background()
 	clock := testingclock.NewFakeClock(time.Now())
 	c := NewCompactor(client, time.Minute, clock, nil)
@@ -111,7 +111,7 @@ func assertNotCompacted(t *testing.T, ctx context.Context, client *clientv3.Clie
 }
 
 func TestCompactIntervalZero(t *testing.T) {
-	client := testserver.RunEtcd(t, nil).Client
+	client := testserver.RunEtcd(t).Client
 	clock := testingclock.NewFakeClock(time.Now())
 	c := NewCompactor(client, 0, clock, nil)
 	t.Cleanup(c.Stop)
@@ -152,7 +152,7 @@ func clockNoWaiters(t *testing.T, clock *testingclock.FakeClock) {
 // - C2 compacts on time 0. It will fail as this time was compacted. But it will get latest logical time, which should be larger by one.
 // - C3 compacts on time 1. It will succeed.
 func TestCompactConflict(t *testing.T) {
-	client := testserver.RunEtcd(t, nil).Client
+	client := testserver.RunEtcd(t).Client
 	ctx := context.Background()
 
 	putResp, err := client.Put(ctx, "/somekey", "data")

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -852,10 +852,10 @@ type setupOptions struct {
 
 type setupOption func(*setupOptions)
 
-func withClientConfig(config *embed.Config) setupOption {
+func withClientConfig(f func(config *embed.Config)) setupOption {
 	return func(options *setupOptions) {
 		options.client = func(t testing.TB) *kubernetes.Client {
-			return testserver.RunEtcd(t, config)
+			return testserver.RunEtcd(t, f)
 		}
 	}
 }
@@ -892,7 +892,7 @@ func withCodec(codec runtime.Codec) setupOption {
 
 func withDefaults(options *setupOptions) {
 	options.client = func(t testing.TB) *kubernetes.Client {
-		return testserver.RunEtcd(t, nil)
+		return testserver.RunEtcd(t)
 	}
 	options.codec = apitesting.TestCodec(codecs, examplev1.SchemeGroupVersion)
 	options.newFunc = newPod

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testing/test_server.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testing/test_server.go
@@ -37,7 +37,7 @@ func (e *EtcdTestServer) Terminate(t testing.TB) {
 // NewUnsecuredEtcd3TestClientServer creates a new client and server for testing
 func NewUnsecuredEtcd3TestClientServer(t testing.TB) (*EtcdTestServer, *storagebackend.Config) {
 	server := &EtcdTestServer{}
-	server.V3Client = testserver.RunEtcd(t, nil)
+	server.V3Client = testserver.RunEtcd(t)
 	config := &storagebackend.Config{
 		Type:   "etcd3",
 		Prefix: PathPrefix(),

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testserver/test_server.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testserver/test_server.go
@@ -17,12 +17,14 @@ limitations under the License.
 package testserver
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
 	"os"
 	"strconv"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -92,12 +94,26 @@ func RunEtcd(t testing.TB, tweakConfig ...func(cfg *embed.Config)) *kubernetes.C
 	// lock until we successfully start the server on the ports we chose
 	autoPortLock.Lock()
 	defer autoPortLock.Unlock()
-	cfg := newTestConfig(t)
-	for _, f := range tweakConfig {
-		f(cfg)
-	}
+	var (
+		cfg *embed.Config
+		e   *embed.Etcd
+		err error
+	)
+	// reattempt up to three times if the port was taken
+	maxAttempts := 3
+	for attempt := range maxAttempts {
+		cfg = newTestConfig(t)
+		for _, f := range tweakConfig {
+			f(cfg)
+		}
 
-	e, err := embed.StartEtcd(cfg)
+		e, err = embed.StartEtcd(cfg)
+		if errors.Is(err, syscall.EADDRINUSE) && attempt < maxAttempts {
+			t.Logf("error starting embedded etcd, retrying: %v", err)
+			continue
+		}
+		break
+	}
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testserver/test_server.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testserver/test_server.go
@@ -31,6 +31,7 @@ import (
 	"go.etcd.io/etcd/server/v3/embed"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
+
 	storagetesting "k8s.io/apiserver/pkg/storage/testing"
 )
 
@@ -49,14 +50,14 @@ func getAvailablePorts(count int) ([]int, error) {
 	return ports, nil
 }
 
-// NewTestConfig returns a configuration for an embedded etcd server.
+// newTestConfig returns a configuration for an embedded etcd server.
 // The configuration is based on embed.NewConfig(), with the following adjustments:
 //   - sets UnsafeNoFsync = true to improve test performance (only reasonable in a test-only
 //     single-member server we never intend to restart or keep data from)
 //   - uses free ports for client and peer listeners
 //   - cleans up the data directory on test termination
 //   - silences server logs other than errors
-func NewTestConfig(t testing.TB) *embed.Config {
+func newTestConfig(t testing.TB) *embed.Config {
 	cfg := embed.NewConfig()
 
 	cfg.UnsafeNoFsync = true
@@ -82,17 +83,18 @@ func NewTestConfig(t testing.TB) *embed.Config {
 
 var autoPortLock sync.Mutex
 
-// RunEtcd starts an embedded etcd server with the provided config
-// (or NewTestConfig(t) if nil), and returns a client connected to the server.
+// RunEtcd starts an embedded etcd server with a test configuration run through
+// any provided configuration tweak functions, and returns a client connected to the server.
 // The server is terminated when the test ends.
-func RunEtcd(t testing.TB, cfg *embed.Config) *kubernetes.Client {
+func RunEtcd(t testing.TB, tweakConfig ...func(cfg *embed.Config)) *kubernetes.Client {
 	t.Helper()
 
-	if cfg == nil {
-		// if we have to autopick free ports, lock until we successfully start the server on the ports we chose
-		autoPortLock.Lock()
-		defer autoPortLock.Unlock()
-		cfg = NewTestConfig(t)
+	// lock until we successfully start the server on the ports we chose
+	autoPortLock.Lock()
+	defer autoPortLock.Unlock()
+	cfg := newTestConfig(t)
+	for _, f := range tweakConfig {
+		f(cfg)
 	}
 
 	e, err := embed.StartEtcd(cfg)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testserver/test_server_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testserver/test_server_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testserver
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"go.etcd.io/etcd/server/v3/embed"
+)
+
+// TestRunEtcdRecoversFromTakenPort claims a port that was selected for etcd
+// before it gets a chance to bind, reproducing what happens when another
+// process takes the port first, and verifies that RunEtcd recovers instead of
+// failing the test. Both listeners are covered because etcd binds the peer
+// listener before the client one, so either can be the one that loses the race.
+func TestRunEtcdRecoversFromTakenPort(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		addr func(cfg *embed.Config) string
+	}{
+		{name: "client", addr: func(cfg *embed.Config) string { return cfg.ListenClientUrls[0].Host }},
+		{name: "peer", addr: func(cfg *embed.Config) string { return cfg.ListenPeerUrls[0].Host }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			called := int64(0)
+			client := RunEtcd(t, func(cfg *embed.Config) {
+				if called == 0 {
+					// grab the allocated port on the first attempt
+					taken := tc.addr(cfg)
+					l, err := net.Listen("tcp", taken)
+					if err != nil {
+						t.Fatalf("failed to claim %s: %v", taken, err)
+					}
+					t.Cleanup(func() { _ = l.Close() })
+				}
+				called++
+			})
+
+			if called < 2 {
+				t.Fatalf("expected config to be constructed at least twice, got %d", called)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			if _, err := client.KV.Get(ctx, "/registry"); err != nil {
+				t.Fatalf("etcd did not serve requests after moving to a new port: %v", err)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/server/v3/embed"
 	"google.golang.org/grpc"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
@@ -44,7 +45,6 @@ import (
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/etcd3/metrics"
-	"k8s.io/apiserver/pkg/storage/etcd3/testserver"
 	etcdfeature "k8s.io/apiserver/pkg/storage/feature"
 	storagetesting "k8s.io/apiserver/pkg/storage/testing"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -104,9 +104,9 @@ func TestWatch(t *testing.T) {
 		storagetesting.RunTestWatchInitializationSignal(ctx, t, store)
 	})
 	t.Run("ProgressNotify", func(t *testing.T) {
-		clusterConfig := testserver.NewTestConfig(t)
-		clusterConfig.WatchProgressNotifyInterval = time.Second
-		ctx, store, client := testSetup(t, withClientConfig(clusterConfig))
+		ctx, store, client := testSetup(t, withClientConfig(func(clusterConfig *embed.Config) {
+			clusterConfig.WatchProgressNotifyInterval = time.Second
+		}))
 
 		storagetesting.RunOptionalTestProgressNotify(ctx, t, store, increaseRVFunc(client.Client))
 	})
@@ -117,9 +117,9 @@ func TestWatch(t *testing.T) {
 		storagetesting.RunTestWatchWithUnsafeDelete(ctx, t, &storeWithTransformerOverride{Interface: store, store: store}, corruptErr)
 	})
 	t.Run("WatchDispatchBookmarkEvents", func(t *testing.T) {
-		clusterConfig := testserver.NewTestConfig(t)
-		clusterConfig.WatchProgressNotifyInterval = time.Second
-		ctx, store, _ := testSetup(t, withClientConfig(clusterConfig))
+		ctx, store, _ := testSetup(t, withClientConfig(func(clusterConfig *embed.Config) {
+			clusterConfig.WatchProgressNotifyInterval = time.Second
+		}))
 
 		storagetesting.RunTestWatchDispatchBookmarkEvents(ctx, t, store, false)
 	})

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory_test.go
@@ -28,6 +28,7 @@ import (
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/kubernetes"
+
 	"k8s.io/apiserver/pkg/storage/etcd3/testserver"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
 )
@@ -59,8 +60,7 @@ func (mockKV) Txn(ctx context.Context) clientv3.Txn {
 }
 
 func TestCreateHealthcheck(t *testing.T) {
-	etcdConfig := testserver.NewTestConfig(t)
-	client := testserver.RunEtcd(t, etcdConfig)
+	client := testserver.RunEtcd(t)
 	newETCD3ClientFn := newETCD3Client
 	defer func() {
 		newETCD3Client = newETCD3ClientFn
@@ -149,8 +149,7 @@ func TestCreateHealthcheck(t *testing.T) {
 }
 
 func TestCreateReadycheck(t *testing.T) {
-	etcdConfig := testserver.NewTestConfig(t)
-	client := testserver.RunEtcd(t, etcdConfig)
+	client := testserver.RunEtcd(t)
 	newETCD3ClientFn := newETCD3Client
 	defer func() {
 		newETCD3Client = newETCD3ClientFn
@@ -250,8 +249,7 @@ func TestCreateReadycheck(t *testing.T) {
 }
 
 func TestRateLimitHealthcheck(t *testing.T) {
-	etcdConfig := testserver.NewTestConfig(t)
-	client := testserver.RunEtcd(t, etcdConfig)
+	client := testserver.RunEtcd(t)
 	newETCD3ClientFn := newETCD3Client
 	defer func() {
 		newETCD3Client = newETCD3ClientFn
@@ -359,8 +357,7 @@ func TestRateLimitHealthcheck(t *testing.T) {
 }
 
 func TestTimeTravelHealthcheck(t *testing.T) {
-	etcdConfig := testserver.NewTestConfig(t)
-	client := testserver.RunEtcd(t, etcdConfig)
+	client := testserver.RunEtcd(t)
 	newETCD3ClientFn := newETCD3Client
 	defer func() {
 		newETCD3Client = newETCD3ClientFn

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/tls_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/tls_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"go.etcd.io/etcd/client/pkg/v3/transport"
+	"go.etcd.io/etcd/server/v3/embed"
 	noopoteltrace "go.opentelemetry.io/otel/trace/noop"
 
 	apitesting "k8s.io/apimachinery/pkg/api/apitesting"
@@ -54,21 +55,20 @@ func TestTLSConnection(t *testing.T) {
 	certFile, keyFile, caFile := configureTLSCerts(t)
 	defer os.RemoveAll(filepath.Dir(certFile))
 
-	// override server config to be TLS-enabled
-	etcdConfig := testserver.NewTestConfig(t)
-	etcdConfig.ClientTLSInfo = transport.TLSInfo{
-		CertFile:      certFile,
-		KeyFile:       keyFile,
-		TrustedCAFile: caFile,
-	}
-	for i := range etcdConfig.ListenClientUrls {
-		etcdConfig.ListenClientUrls[i].Scheme = "https"
-	}
-	for i := range etcdConfig.AdvertiseClientUrls {
-		etcdConfig.AdvertiseClientUrls[i].Scheme = "https"
-	}
-
-	client := testserver.RunEtcd(t, etcdConfig)
+	client := testserver.RunEtcd(t, func(etcdConfig *embed.Config) {
+		// override server config to be TLS-enabled
+		etcdConfig.ClientTLSInfo = transport.TLSInfo{
+			CertFile:      certFile,
+			KeyFile:       keyFile,
+			TrustedCAFile: caFile,
+		}
+		for i := range etcdConfig.ListenClientUrls {
+			etcdConfig.ListenClientUrls[i].Scheme = "https"
+		}
+		for i := range etcdConfig.AdvertiseClientUrls {
+			etcdConfig.AdvertiseClientUrls[i].Scheme = "https"
+		}
+	})
 	cfg := storagebackend.Config{
 		Type: storagebackend.StorageTypeETCD3,
 		Transport: storagebackend.TransportConfig{

--- a/test/utils/apiserver/testapiserver.go
+++ b/test/utils/apiserver/testapiserver.go
@@ -47,8 +47,7 @@ type TestAPIServer struct {
 // process. All resources get released automatically when the test
 // completes. If startup fails, the test gets aborted.
 func StartAPITestServer(t *testing.T) TestAPIServer {
-	cfg := etcdserver.NewTestConfig(t)
-	etcdClient := etcdserver.RunEtcd(t, cfg)
+	etcdClient := etcdserver.RunEtcd(t)
 	storageConfig := storagebackend.NewDefaultConfig(path.Join(uuid.New().String(), "registry"), nil)
 	storageConfig.Transport.ServerList = etcdClient.Endpoints()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Alternative to https://github.com/kubernetes/kubernetes/pull/141679, used the approach and one test from that PR, added @jackfrancis as co-author

* Reworks etcd testserver startup to take configuration tweak functions instead of a passed-in configuration
* Always starts with default testconfig
* Retries up to 3 times on addrinuse error to solve 

```release-note
NONE
```
