### PR TITLE
resource: warn on empty DeviceTaintRule selector

### DIFF
--- a/pkg/registry/resource/devicetaintrule/strategy.go
+++ b/pkg/registry/resource/devicetaintrule/strategy.go
@@ -80,6 +80,22 @@ func (*deviceTaintRuleStrategy) Validate(ctx context.Context, obj runtime.Object
 }
 
 func (*deviceTaintRuleStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+	rule := obj.(*resource.DeviceTaintRule)
+	return warningsForDeviceTaintRule(rule)
+}
+
+// warningsForDeviceTaintRule returns a warning when spec.deviceSelector is
+// present but empty (driver, pool, and device all unset). Such a selector
+// matches every device from every driver in the cluster, which is easy to
+// trigger by mistake. See https://github.com/kubernetes/kubernetes/issues/141422.
+func warningsForDeviceTaintRule(rule *resource.DeviceTaintRule) []string {
+	sel := rule.Spec.DeviceSelector
+	if sel != nil && sel.Driver == nil && sel.Pool == nil && sel.Device == nil {
+		return []string{
+			field.NewPath("spec", "deviceSelector").String() +
+				": an empty selector matches every device from every driver in the cluster",
+		}
+	}
 	return nil
 }
 
@@ -123,7 +139,8 @@ func (*deviceTaintRuleStrategy) ValidateUpdate(ctx context.Context, obj, old run
 }
 
 func (*deviceTaintRuleStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
-	return nil
+	rule := obj.(*resource.DeviceTaintRule)
+	return warningsForDeviceTaintRule(rule)
 }
 
 func (*deviceTaintRuleStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {

--- a/pkg/registry/resource/devicetaintrule/strategy_test.go
+++ b/pkg/registry/resource/devicetaintrule/strategy_test.go
@@ -356,3 +356,56 @@ func TestStatusStrategyUpdate(t *testing.T) {
 		})
 	}
 }
+
+// TestDeviceTaintRuleEmptySelectorWarning covers
+// https://github.com/kubernetes/kubernetes/issues/141422: an empty but
+// non-nil deviceSelector matches every device from every driver, which is
+// easy to trigger by mistake and has no other signal at apply time.
+func TestDeviceTaintRuleEmptySelectorWarning(t *testing.T) {
+	ctx := genericapirequest.NewDefaultContext()
+	driver := "example.com"
+
+	testcases := map[string]struct {
+		selector      *resource.DeviceTaintSelector
+		expectWarning bool
+	}{
+		"nil-selector-matches-nothing": {
+			selector:      nil,
+			expectWarning: false,
+		},
+		"empty-selector-matches-everything": {
+			selector:      &resource.DeviceTaintSelector{},
+			expectWarning: true,
+		},
+		"selector-with-driver-is-scoped": {
+			selector:      &resource.DeviceTaintSelector{Driver: &driver},
+			expectWarning: false,
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			ruleObj := obj.DeepCopy()
+			ruleObj.Spec.DeviceSelector = tc.selector
+
+			createWarnings := Strategy.WarningsOnCreate(ctx, ruleObj)
+			updateWarnings := Strategy.WarningsOnUpdate(ctx, ruleObj, ruleObj)
+
+			if tc.expectWarning {
+				if len(createWarnings) == 0 {
+					t.Error("expected a warning from WarningsOnCreate, got none")
+				}
+				if len(updateWarnings) == 0 {
+					t.Error("expected a warning from WarningsOnUpdate, got none")
+				}
+			} else {
+				if len(createWarnings) != 0 {
+					t.Errorf("unexpected warnings from WarningsOnCreate: %q", createWarnings)
+				}
+				if len(updateWarnings) != 0 {
+					t.Errorf("unexpected warnings from WarningsOnUpdate: %q", updateWarnings)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

A `DeviceTaintRule.spec.deviceSelector` that is present but has no `driver`, `pool`, or `device`
set matches every device from every driver in the cluster. This is easy to trigger by mistake, and
combined with a `NoSchedule` or `NoExecute` taint, has no other signal at apply/update time today.

This adds a non-blocking `Warning` response header (via `WarningsOnCreate`/`WarningsOnUpdate`, the
same mechanism `PodSecurity` admission uses via `warning.AddWarning`.

Confirmed both paths land in the identical call in `staging/src/k8s.io/apiserver/pkg/registry/rest/create.go`) whenever this
empty-but-present selector shape is created or updated, regardless of the taint's effect. It doesn't block the request, require confirmation, or change validation/enforcement.
It only makes the impact visible to `kubectl` at apply time instead of only via the existing `effect: None` trial-run
workflow (which remains the recommended way to preview eviction impact before switching to
`NoExecute`).

Live-verified on a real `v1.37.0` cluster, swapping a patched `kube-apiserver` binary onto a running control plane and back (before/after, same cluster):

| Case | Before | After |
|---|---|---|
| `deviceSelector` omitted (nil) | created, no warning | created, no warning |
| `deviceSelector: {}` (empty) | created, **no warning** | created, **`Warning: spec.deviceSelector: an empty selector matches every device from every driver in the cluster`** |
| `deviceSelector: {driver: ...}` (scoped) | created, no warning | created, no warning |

Also confirmed the update path fires the same warning: patching an existing nil-selector rule's `deviceSelector` to `{}` via `kubectl patch` triggers it too, not just `create`.


##### For example:

```
# Fresh rule
$ kubectl apply -f warn-test-fresh-empty.yaml 
Warning: spec.deviceSelector: an empty selector matches every device from every driver in the cluster
devicetaintrule.resource.k8s.io/warn-test-fresh-empty created

# Update rule from nil to empty
$ kubectl apply -f warn-test-apply-update.yaml   # deviceSelector: {} added
Warning: spec.deviceSelector: an empty selector matches every device from every driver in the cluster
devicetaintrule.resource.k8s.io/warn-test-apply-update configured

```

#### Which issue(s) this PR is related to:
Related to #141422

#### Special notes for your reviewer:

Raised as a soft follow-up question in a comment on #141422 first; `@pohly` said "Yes, please
proceed." He also flagged one thing worth calling out explicitly: `kubectl ... --warnings-as-errors`
will newly report a non-zero exit code for an intentional "select all" rule, even though the object
is still created successfully. Confirmed this is the same tradeoff `PodSecurity`'s own `warn`-level
violations already carry today (its own benchmark test counts warnings through the identical
`WarningCount()` path) — not a new class of risk, just extending an existing, already-shipped
pattern to a new resource type.

#### Does this PR introduce a user-facing change?
```release-note
`kubectl` now prints a warning when creating or updating a `DeviceTaintRule` whose `deviceSelector`
is present but empty, since that selector matches every device from every driver in the cluster.
Scripts using `kubectl ... --warnings-as-errors` against an intentional "select all" rule will see a
non-zero exit code where they previously didn't, even though the object is still created
successfully — the same behavior `PodSecurity` `warn`-level violations already have.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

#### AI usage disclosure:
YES. Used to help scope the fix location (pkg/registry/resource/devicetaintrule/strategy.go's
existing WarningsOnCreate/WarningsOnUpdate hooks), draft the implementation and unit test, and match
the repo's warning-message style convention (checked against pkg/api/pod/warnings.go). All changes
reviewed, tested (unit tests + live kind-cluster verification), and understood by the author before
submitting.
