### PR TITLE
apiserver: batch streamed list response writes with an always-on buffer

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -17,6 +17,7 @@ limitations under the License.
 package responsewriters
 
 import (
+	"bufio"
 	"compress/gzip"
 	"context"
 	"encoding/json"
@@ -24,6 +25,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -148,7 +150,23 @@ func SerializeObject(mediaType string, encoder runtime.Encoder, hw http.Response
 
 var gzipPool = NewGzipWriterPoolOrDie()
 
+// batchBufferPool holds the buffers that batch a response's writes on their
+// way to the http.ResponseWriter. Streamed list responses are written one
+// item at a time, and each write that reaches net/http costs a chunk frame
+// (HTTP/1.1) or a cross-goroutine frame handoff (HTTP/2); batching them into
+// batchBufferBytes writes removes most of that cost.
+// TODO: engage lazily so small responses don't hold a pooled buffer.
+var batchBufferPool = &sync.Pool{
+	New: func() interface{} {
+		return bufio.NewWriterSize(nil, batchBufferBytes)
+	},
+}
+
 const (
+	// batchBufferBytes is the size of the writes a batched response makes to
+	// the http.ResponseWriter (128KiB is the smallest size past which larger
+	// batches stop helping).
+	batchBufferBytes = 128 * 1024
 	// defaultGzipThresholdBytes is compared to the size of the first write from the stream
 	// (usually the entire object), and if the size is smaller no gzipping will be performed
 	// if the client requests it.
@@ -167,7 +185,10 @@ type deferredResponseWriter struct {
 	buffer      []byte
 	hasWritten  bool
 	hw          http.ResponseWriter
-	w           io.Writer
+	// batch sits directly above hw once the response is committed (below the
+	// gzip writer, if any) and batches the writes that reach hw.
+	batch *bufio.Writer
+	w     io.Writer
 	// totalBytes is the number of bytes written to `w` and does not include buffered bytes
 	totalBytes int
 	// lastWriteErr holds the error result (if any) of the last write attempt to `w`
@@ -234,17 +255,19 @@ func (w *deferredResponseWriter) unbufferedWrite(p []byte) (n int, err error) {
 
 	hw := w.hw
 	header := hw.Header()
+	w.batch = batchBufferPool.Get().(*bufio.Writer)
+	w.batch.Reset(hw)
 	switch {
 	case w.contentEncoding == "gzip" && len(p) > defaultGzipThresholdBytes:
 		header.Set("Content-Encoding", "gzip")
 		header.Add("Vary", "Accept-Encoding")
 
 		gw := gzipPool.Get().(*gzip.Writer)
-		gw.Reset(hw)
+		gw.Reset(w.batch)
 
 		w.w = gw
 	default:
-		w.w = hw
+		w.w = w.batch
 	}
 
 	span := tracing.SpanFromContext(w.ctx)
@@ -280,17 +303,30 @@ func (w *deferredResponseWriter) Close() (err error) {
 		if !w.hasBuffered {
 			return nil
 		}
-		// never reached defaultGzipThresholdBytes, no need to do the gzip writer cleanup
-		_, err := w.unbufferedWrite(w.buffer)
+		// never reached defaultGzipThresholdBytes
+		_, err = w.unbufferedWrite(w.buffer)
 		w.buffer = nil
-		return err
 	}
 
 	switch t := w.w.(type) {
 	case *gzip.Writer:
-		err = t.Close()
+		if cerr := t.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
 		t.Reset(nil)
 		gzipPool.Put(t)
+	}
+	if w.batch != nil {
+		if ferr := w.batch.Flush(); ferr != nil && err == nil {
+			err = ferr
+		}
+		w.batch.Reset(nil)
+		batchBufferPool.Put(w.batch)
+		w.batch = nil
+	}
+	w.w = nil
+	if err != nil && w.lastWriteErr == nil {
+		w.lastWriteErr = err
 	}
 	return err
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig api-machinery

#### What this PR does / why we need it:

Alternative to #141809 for comparison (see also #141835): the same batching of streamed LIST response writes, in its simplest form. Once a response is committed, a pooled 128KiB `bufio.Writer` sits directly above the `http.ResponseWriter` (below the gzip writer, when compressing), so the transport sees 128KiB writes instead of one write per item. No lazy engagement: every in-flight response holds a pooled buffer, and a large response's first bytes leave once 128KiB have reached the buffer instead of immediately — under gzip that is 128KiB of compressed output, e.g. time-to-first-byte for a 2.4MB gzip'd list goes from ~6ms to ~11ms (a TODO marks where laziness would go). `writers.go` +40/−7, no other changes; the existing `TestDeferredResponseWriter_Write` round-trips identity and gzip bodies through the buffer.

`BenchmarkSerializeObject` (#141586), master vs this PR, 6 runs each, `benchstat` medians (± confidence interval, Mann-Whitney p; `~` = no significant difference).

Go 1.26.6:

```
count   encoding compress protocol        master       patched    delta
   100  Json     identity HTTP/1.1  7.20ms ±  2%  6.43ms ±  4%  -10.69%  p=0.002
   100  Json     identity HTTP/2    8.33ms ±  1%  7.89ms ±  1%   -5.21%  p=0.002
   100  Json     gzip     HTTP/1.1  9.67ms ±  3%  9.46ms ±  2%        ~  p=0.065
   100  Json     gzip     HTTP/2    9.99ms ±  1%  9.49ms ±  1%   -5.03%  p=0.002
   100  Protobuf identity HTTP/1.1  1.94ms ±  8%  1.37ms ±  2%  -29.18%  p=0.002
   100  Protobuf identity HTTP/2    4.52ms ±  1%  2.33ms ±  1%  -48.47%  p=0.002
   100  Protobuf gzip     HTTP/1.1  2.92ms ±  2%  2.97ms ±  1%        ~  p=0.394
   100  Protobuf gzip     HTTP/2    3.19ms ±  1%  3.09ms ±  1%   -3.15%  p=0.002

  1000  Json     identity HTTP/1.1  68.8ms ±  4%  62.6ms ± 13%   -9.10%  p=0.041
  1000  Json     identity HTTP/2    81.4ms ±  1%  77.1ms ±  2%   -5.33%  p=0.002
  1000  Json     gzip     HTTP/1.1  89.1ms ±  0%  89.8ms ±  3%        ~  p=0.394
  1000  Json     gzip     HTTP/2    96.8ms ±  2%  89.4ms ± 10%   -7.65%  p=0.041
  1000  Protobuf identity HTTP/1.1  18.1ms ±  4%  12.3ms ±  5%  -32.08%  p=0.002
  1000  Protobuf identity HTTP/2    43.8ms ±  5%  21.9ms ±  4%  -50.08%  p=0.002
  1000  Protobuf gzip     HTTP/1.1  25.1ms ±  5%  25.0ms ±  3%        ~  p=0.485
  1000  Protobuf gzip     HTTP/2    27.0ms ±  3%  25.2ms ±  2%   -6.67%  p=0.002

 10000  Json     identity HTTP/1.1   696ms ±  2%   616ms ±  2%  -11.42%  p=0.002
 10000  Json     identity HTTP/2     811ms ±  3%   787ms ±  3%   -3.02%  p=0.015
 10000  Json     gzip     HTTP/1.1   886ms ±  2%   869ms ±  2%   -1.89%  p=0.002
 10000  Json     gzip     HTTP/2     957ms ±  8%   892ms ±  7%   -6.77%  p=0.015
 10000  Protobuf identity HTTP/1.1   209ms ±  6%   146ms ±  4%  -29.89%  p=0.002
 10000  Protobuf identity HTTP/2     484ms ±  1%   245ms ±  3%  -49.36%  p=0.002
 10000  Protobuf gzip     HTTP/1.1   278ms ±  2%   266ms ±  4%   -3.97%  p=0.026
 10000  Protobuf gzip     HTTP/2     305ms ±  2%   272ms ±  4%  -10.82%  p=0.002

100000  Json     identity HTTP/1.1  6942ms ±  2%  6252ms ±  2%   -9.94%  p=0.002
100000  Json     identity HTTP/2    8134ms ±  1%  7637ms ±  1%   -6.10%  p=0.002
100000  Json     gzip     HTTP/1.1  8935ms ±  2%  8666ms ±  1%   -3.01%  p=0.002
100000  Json     gzip     HTTP/2    9638ms ±  2%  8801ms ±  1%   -8.69%  p=0.002
100000  Protobuf identity HTTP/1.1  2152ms ±  3%  1521ms ±  1%  -29.36%  p=0.002
100000  Protobuf identity HTTP/2    4856ms ±  2%  2493ms ±  5%  -48.67%  p=0.002
100000  Protobuf gzip     HTTP/1.1  2813ms ±  1%  2693ms ±  2%   -4.29%  p=0.002
100000  Protobuf gzip     HTTP/2    3083ms ±  1%  2767ms ±  4%  -10.26%  p=0.002

geomean                                  157.9ms       132.8ms  -15.87%
```

Go 1.27.0 (json/v2 default, faster gzip):

```
count   encoding compress protocol        master       patched    delta
   100  Json     identity HTTP/1.1  6.05ms ±  2%  5.60ms ±  3%   -7.48%  p=0.002
   100  Json     identity HTTP/2    7.45ms ±  4%  6.04ms ±  1%  -18.92%  p=0.002
   100  Json     gzip     HTTP/1.1  6.58ms ±  4%  6.75ms ±  2%   +2.59%  p=0.041
   100  Json     gzip     HTTP/2    7.20ms ±  4%  6.77ms ±  7%   -5.94%  p=0.041
   100  Protobuf identity HTTP/1.1  1.83ms ±  4%  1.40ms ±  2%  -23.44%  p=0.002
   100  Protobuf identity HTTP/2    4.45ms ±  1%  2.00ms ±  1%  -55.01%  p=0.002
   100  Protobuf gzip     HTTP/1.1  2.15ms ±  4%  2.19ms ±  0%        ~  p=0.065
   100  Protobuf gzip     HTTP/2    2.42ms ±  0%  2.32ms ±  1%   -4.42%  p=0.002

  1000  Json     identity HTTP/1.1  60.3ms ±  5%  54.2ms ±  6%  -10.24%  p=0.002
  1000  Json     identity HTTP/2    71.8ms ±  7%  56.7ms ±  2%  -21.07%  p=0.002
  1000  Json     gzip     HTTP/1.1  62.0ms ±  3%  60.3ms ±  3%        ~  p=0.093
  1000  Json     gzip     HTTP/2    65.5ms ±  2%  61.2ms ±  6%   -6.51%  p=0.015
  1000  Protobuf identity HTTP/1.1  16.9ms ±  7%  12.7ms ±  2%  -24.62%  p=0.002
  1000  Protobuf identity HTTP/2    42.9ms ±  2%  18.0ms ±  1%  -58.10%  p=0.002
  1000  Protobuf gzip     HTTP/1.1  16.9ms ± 10%  16.5ms ± 11%        ~  p=0.180
  1000  Protobuf gzip     HTTP/2    19.2ms ±  1%  16.8ms ±  2%  -12.23%  p=0.002

 10000  Json     identity HTTP/1.1   587ms ±  2%   535ms ±  1%   -8.82%  p=0.002
 10000  Json     identity HTTP/2     744ms ±  5%   599ms ±  5%  -19.50%  p=0.002
 10000  Json     gzip     HTTP/1.1   604ms ±  1%   613ms ±  5%        ~  p=0.132
 10000  Json     gzip     HTTP/2     674ms ±  5%   594ms ±  3%  -11.93%  p=0.002
 10000  Protobuf identity HTTP/1.1   205ms ±  4%   156ms ±  3%  -23.89%  p=0.002
 10000  Protobuf identity HTTP/2     478ms ±  1%   202ms ±  2%  -57.82%  p=0.002
 10000  Protobuf gzip     HTTP/1.1   200ms ±  2%   213ms ± 14%        ~  p=0.394
 10000  Protobuf gzip     HTTP/2     227ms ±  5%   201ms ± 12%  -11.36%  p=0.009

100000  Json     identity HTTP/1.1  5908ms ±  1%  5327ms ±  4%   -9.84%  p=0.002
100000  Json     identity HTTP/2    7355ms ±  1%  5702ms ±  4%  -22.47%  p=0.002
100000  Json     gzip     HTTP/1.1  6059ms ±  1%  5937ms ±  4%        ~  p=0.065
100000  Json     gzip     HTTP/2    6633ms ±  3%  6020ms ±  5%   -9.24%  p=0.002
100000  Protobuf identity HTTP/1.1  2024ms ±  2%  1542ms ±  1%  -23.81%  p=0.002
100000  Protobuf identity HTTP/2    4755ms ±  2%  2026ms ±  3%  -57.38%  p=0.002
100000  Protobuf gzip     HTTP/1.1  2010ms ±  1%  1895ms ±  1%   -5.72%  p=0.002
100000  Protobuf gzip     HTTP/2    2325ms ±  2%  1931ms ±  2%  -16.95%  p=0.002

geomean                                  127.4ms       103.6ms  -18.71%
```

#### Which issue(s) this PR is related to:

Follow-up to #141586; alternative to #141809.

#### Special notes for your reviewer:

Same semantics note as #141809: a client disconnect mid-stream is noticed within one 128KiB buffer rather than within one item, and when it lands in the final buffer the error surfaces from `Close` rather than `Encode`.

This PR was written in part with the assistance of generative AI.

#### Does this PR introduce a user-facing change?

```release-note
kube-apiserver: streamed LIST responses are written to the connection in batches rather than one item at a time, reducing CPU and wall-clock time for large LISTs over both HTTP/2 and HTTP/1.1. Response bytes are unchanged.
```
