### PR TITLE
apiserver: write responses through a single buffer ahead of the gzip decision

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -17,6 +17,7 @@ limitations under the License.
 package responsewriters
 
 import (
+	"bufio"
 	"compress/gzip"
 	"context"
 	"encoding/json"
@@ -24,6 +25,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -149,25 +151,38 @@ func SerializeObject(mediaType string, encoder runtime.Encoder, hw http.Response
 var gzipPool = NewGzipWriterPoolOrDie()
 
 const (
-	// defaultGzipThresholdBytes is compared to the size of the first write from the stream
-	// (usually the entire object), and if the size is smaller no gzipping will be performed
-	// if the client requests it.
+	// defaultGzipThresholdBytes is the response size above which the response
+	// is gzipped, if the client accepts gzip.
 	defaultGzipThresholdBytes = 128 * 1024
-	// Use the length of the first write to recognize streaming implementations.
-	// When streaming JSON first write is "{", while Kubernetes protobuf starts unique 4 byte header.
-	firstWriteStreamingThresholdBytes = 4
+	// responseBufferBytes is the size of the buffer every response is written
+	// through, which batches the per-item writes of streamed list responses
+	// into writes of this size. It equals defaultGzipThresholdBytes so that
+	// the buffer also makes the gzip decision: a response that overflows it
+	// exceeds the threshold, and one that fits is flushed once, at Close,
+	// uncompressed.
+	responseBufferBytes = defaultGzipThresholdBytes
 )
+
+// responseBufferPool holds the buffers responses are written through.
+// TODO: engage lazily so small responses don't hold a pooled buffer.
+var responseBufferPool = &sync.Pool{
+	New: func() interface{} {
+		return bufio.NewWriterSize(nil, responseBufferBytes)
+	},
+}
 
 type deferredResponseWriter struct {
 	mediaType       string
 	statusCode      int
 	contentEncoding string
 
-	hasBuffered bool
-	buffer      []byte
-	hasWritten  bool
-	hw          http.ResponseWriter
-	w           io.Writer
+	// buf takes every write; its first flush commits the response (see
+	// commit) and from then on it batches writes on their way to w.
+	buf        *bufio.Writer
+	final      bool // set by Close before it flushes buf: no writes follow
+	hasWritten bool // the response is committed
+	hw         http.ResponseWriter
+	w          io.Writer // below buf once committed: hw, or a gzip writer over hw
 	// totalBytes is the number of bytes written to `w` and does not include buffered bytes
 	totalBytes int
 	// lastWriteErr holds the error result (if any) of the last write attempt to `w`
@@ -177,51 +192,31 @@ type deferredResponseWriter struct {
 }
 
 func (w *deferredResponseWriter) Write(p []byte) (n int, err error) {
-	switch {
-	case w.hasWritten:
-		// already written, cannot buffer
-		return w.unbufferedWrite(p)
-
-	case w.contentEncoding != "gzip":
-		// non-gzip, no need to buffer
-		return w.unbufferedWrite(p)
-
-	case !w.hasBuffered && len(p) > defaultGzipThresholdBytes:
-		// not yet buffered, first write is long enough to trigger gzip, no need to buffer
-		return w.unbufferedWrite(p)
-
-	case !w.hasBuffered && len(p) > firstWriteStreamingThresholdBytes:
-		// not yet buffered, first write is longer than expected for streaming scenarios that would require buffering, no need to buffer
-		return w.unbufferedWrite(p)
-
-	default:
-		if !w.hasBuffered {
-			w.hasBuffered = true
-			// Start at 80 bytes to avoid rapid reallocation of the buffer.
-			// The minimum size of a 0-item serialized list object is 80 bytes:
-			// {"kind":"List","apiVersion":"v1","metadata":{"resourceVersion":"1"},"items":[]}\n
-			w.buffer = make([]byte, 0, max(80, len(p)))
-		}
-		w.buffer = append(w.buffer, p...)
-		var err error
-		if len(w.buffer) > defaultGzipThresholdBytes {
-			// we've accumulated enough to trigger gzip, write and clear buffer
-			_, err = w.unbufferedWrite(w.buffer)
-			w.buffer = nil
-		}
-		return len(p), err
+	if w.buf == nil {
+		w.buf = responseBufferPool.Get().(*bufio.Writer)
+		w.buf.Reset(committer{w})
 	}
+	return w.buf.Write(p)
 }
 
+// discardBufferedResponse drops what has been written so far, if the response
+// is not committed yet, so that an error response can be written instead.
 func (w *deferredResponseWriter) discardBufferedResponse() {
-	if w.hasWritten {
+	if w.hasWritten || w.buf == nil {
 		return
 	}
-	w.hasBuffered = false
-	w.buffer = nil
+	w.buf.Reset(committer{w})
 }
 
-func (w *deferredResponseWriter) unbufferedWrite(p []byte) (n int, err error) {
+// committer is the writer below buf: it receives buf's flushes.
+type committer struct{ w *deferredResponseWriter }
+
+func (c committer) Write(p []byte) (int, error) { return c.w.commit(p) }
+
+// commit receives buf's flushes. The first one commits the response (decides
+// gzip, writes status and headers); p and every later flush go to the chosen
+// writer.
+func (w *deferredResponseWriter) commit(p []byte) (n int, err error) {
 	defer func() {
 		w.totalBytes += n
 		w.lastWriteErr = err
@@ -232,10 +227,15 @@ func (w *deferredResponseWriter) unbufferedWrite(p []byte) (n int, err error) {
 	}
 	w.hasWritten = true
 
+	// buf holds exactly defaultGzipThresholdBytes, so it flushes before Close
+	// only if the response exceeds the gzip threshold; if the first flush is
+	// Close's, the whole response fit under it.
+	exceedsGzipThreshold := !w.final
+
 	hw := w.hw
 	header := hw.Header()
 	switch {
-	case w.contentEncoding == "gzip" && len(p) > defaultGzipThresholdBytes:
+	case w.contentEncoding == "gzip" && exceedsGzipThreshold:
 		header.Set("Content-Encoding", "gzip")
 		header.Add("Vary", "Accept-Encoding")
 
@@ -276,21 +276,27 @@ func (w *deferredResponseWriter) Close() (err error) {
 		}
 	}()
 
-	if !w.hasWritten {
-		if !w.hasBuffered {
-			return nil
-		}
-		// never reached defaultGzipThresholdBytes, no need to do the gzip writer cleanup
-		_, err := w.unbufferedWrite(w.buffer)
-		w.buffer = nil
-		return err
+	if w.buf == nil {
+		return nil // nothing was written
 	}
-
-	switch t := w.w.(type) {
-	case *gzip.Writer:
-		err = t.Close()
-		t.Reset(nil)
-		gzipPool.Put(t)
+	w.final = true
+	err = w.buf.Flush() // commits the response, if it fit in buf
+	if err == nil && !w.hasWritten {
+		_, err = w.commit(nil) // an empty body still gets its status and headers
+	}
+	w.buf.Reset(nil)
+	responseBufferPool.Put(w.buf)
+	w.buf = nil
+	if gw, ok := w.w.(*gzip.Writer); ok {
+		if cerr := gw.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+		gw.Reset(nil)
+		gzipPool.Put(gw)
+	}
+	w.w = nil
+	if err != nil && w.lastWriteErr == nil {
+		w.lastWriteErr = err
 	}
 	return err
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
@@ -442,9 +442,11 @@ func TestDeferredResponseWriter_Write(t *testing.T) {
 		{
 			name:       "two small chunk writes",
 			chunks:     [][]byte{smallChunk, smallChunk},
-			expectGzip: false,
+			expectGzip: true,
 			expectHeaders: http.Header{
-				"Content-Type": []string{"text/plain"},
+				"Content-Type":     []string{"text/plain"},
+				"Content-Encoding": []string{"gzip"},
+				"Vary":             []string{"Accept-Encoding"},
 			},
 		},
 		{
@@ -488,9 +490,11 @@ func TestDeferredResponseWriter_Write(t *testing.T) {
 		{
 			name:       "one small chunk and one large chunk write",
 			chunks:     [][]byte{smallChunk, largeChunk},
-			expectGzip: false,
+			expectGzip: true,
 			expectHeaders: http.Header{
-				"Content-Type": []string{"text/plain"},
+				"Content-Type":     []string{"text/plain"},
+				"Content-Encoding": []string{"gzip"},
+				"Vary":             []string{"Accept-Encoding"},
 			},
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig api-machinery

#### What this PR does / why we need it:

Alternative to #141809 for comparison (see also #141834), following the suggestion to reuse the buffer `deferredResponseWriter` already keeps for the gzip decision. Every response is written through one pooled 128KiB `bufio.Writer`; its first flush commits the response (gzip if the client accepts it and the response exceeds 128KiB), and every later flush reaches the writer below as a 128KiB write. The first-write-size heuristic for recognizing streamed encoders goes away, since the gzip decision is now made on the response's size (two `TestDeferredResponseWriter_Write` cases that fed a non-streaming first write followed by more data now expect gzip). `writers.go` is net even (+70/−69).

The buffer sits above the gzip writer, and `compress/flate` emits ~240-byte writes downstream regardless of its input write sizes, so gzip'd responses reach the transport as they do today and only identity responses gain:

`BenchmarkSerializeObject` (#141586), master vs this PR, 6 runs each, `benchstat` medians (± confidence interval, Mann-Whitney p; `~` = no significant difference).

Go 1.26.6:

```
count   encoding compress protocol        master       patched    delta
   100  Json     identity HTTP/1.1  7.20ms ±  2%  6.57ms ±  3%   -8.69%  p=0.002
   100  Json     identity HTTP/2    8.33ms ±  1%  7.89ms ±  2%   -5.18%  p=0.002
   100  Json     gzip     HTTP/1.1  9.67ms ±  3%  9.41ms ±  5%        ~  p=0.132
   100  Json     gzip     HTTP/2    9.99ms ±  1%  9.88ms ±  2%        ~  p=0.180
   100  Protobuf identity HTTP/1.1  1.94ms ±  8%  1.35ms ±  1%  -30.08%  p=0.002
   100  Protobuf identity HTTP/2    4.52ms ±  1%  2.33ms ±  2%  -48.43%  p=0.002
   100  Protobuf gzip     HTTP/1.1  2.92ms ±  2%  2.69ms ±  1%   -8.06%  p=0.002
   100  Protobuf gzip     HTTP/2    3.19ms ±  1%  3.00ms ±  2%   -6.07%  p=0.002

  1000  Json     identity HTTP/1.1  68.8ms ±  4%  63.7ms ±  3%   -7.39%  p=0.002
  1000  Json     identity HTTP/2    81.4ms ±  1%  76.6ms ±  1%   -5.91%  p=0.002
  1000  Json     gzip     HTTP/1.1  89.1ms ±  0%  89.1ms ±  8%        ~  p=0.818
  1000  Json     gzip     HTTP/2    96.8ms ±  2%  96.4ms ±  1%        ~  p=0.699
  1000  Protobuf identity HTTP/1.1  18.1ms ±  4%  12.1ms ±  4%  -33.09%  p=0.002
  1000  Protobuf identity HTTP/2    43.8ms ±  5%  21.4ms ±  2%  -51.08%  p=0.002
  1000  Protobuf gzip     HTTP/1.1  25.1ms ±  5%  24.7ms ±  5%        ~  p=0.394
  1000  Protobuf gzip     HTTP/2    27.0ms ±  3%  26.7ms ±  1%        ~  p=0.065

 10000  Json     identity HTTP/1.1   696ms ±  2%   617ms ±  3%  -11.38%  p=0.002
 10000  Json     identity HTTP/2     811ms ±  3%   778ms ±  5%        ~  p=0.093
 10000  Json     gzip     HTTP/1.1   886ms ±  2%   886ms ±  1%        ~  p=0.937
 10000  Json     gzip     HTTP/2     957ms ±  8%   961ms ±  8%        ~  p=0.589
 10000  Protobuf identity HTTP/1.1   209ms ±  6%   148ms ±  5%  -29.42%  p=0.002
 10000  Protobuf identity HTTP/2     484ms ±  1%   246ms ±  3%  -49.10%  p=0.002
 10000  Protobuf gzip     HTTP/1.1   278ms ±  2%   278ms ±  4%        ~  p=0.937
 10000  Protobuf gzip     HTTP/2     305ms ±  2%   301ms ±  1%   -1.33%  p=0.009

100000  Json     identity HTTP/1.1  6942ms ±  2%  6174ms ±  1%  -11.07%  p=0.002
100000  Json     identity HTTP/2    8134ms ±  1%  7625ms ±  2%   -6.25%  p=0.002
100000  Json     gzip     HTTP/1.1  8935ms ±  2%  8878ms ±  1%        ~  p=0.180
100000  Json     gzip     HTTP/2    9638ms ±  2%  9595ms ±  1%        ~  p=0.180
100000  Protobuf identity HTTP/1.1  2152ms ±  3%  1525ms ±  3%  -29.14%  p=0.002
100000  Protobuf identity HTTP/2    4856ms ±  2%  2475ms ±  1%  -49.03%  p=0.002
100000  Protobuf gzip     HTTP/1.1  2813ms ±  1%  2804ms ±  3%        ~  p=0.818
100000  Protobuf gzip     HTTP/2    3083ms ±  1%  3044ms ±  1%   -1.27%  p=0.009

geomean                                  157.9ms       134.8ms  -14.62%
```

Go 1.27.0 (json/v2 default, faster gzip):

```
count   encoding compress protocol        master       patched    delta
   100  Json     identity HTTP/1.1  6.05ms ±  2%  5.76ms ± 10%        ~  p=0.065
   100  Json     identity HTTP/2    7.45ms ±  4%  6.21ms ±  1%  -16.55%  p=0.002
   100  Json     gzip     HTTP/1.1  6.58ms ±  4%  6.44ms ±  2%   -2.18%  p=0.009
   100  Json     gzip     HTTP/2    7.20ms ±  4%  7.17ms ±  3%        ~  p=0.394
   100  Protobuf identity HTTP/1.1  1.83ms ±  4%  1.40ms ±  1%  -23.70%  p=0.002
   100  Protobuf identity HTTP/2    4.45ms ±  1%  1.99ms ±  1%  -55.30%  p=0.002
   100  Protobuf gzip     HTTP/1.1  2.15ms ±  4%  1.97ms ±  4%   -8.70%  p=0.002
   100  Protobuf gzip     HTTP/2    2.42ms ±  0%  2.27ms ±  2%   -6.53%  p=0.002

  1000  Json     identity HTTP/1.1  60.3ms ±  5%  54.4ms ±  3%   -9.83%  p=0.002
  1000  Json     identity HTTP/2    71.8ms ±  7%  56.8ms ±  1%  -21.00%  p=0.002
  1000  Json     gzip     HTTP/1.1  62.0ms ±  3%  61.2ms ±  0%        ~  p=0.093
  1000  Json     gzip     HTTP/2    65.5ms ±  2%  68.2ms ±  4%   +4.16%  p=0.026
  1000  Protobuf identity HTTP/1.1  16.9ms ±  7%  12.6ms ± 11%  -25.56%  p=0.002
  1000  Protobuf identity HTTP/2    42.9ms ±  2%  17.9ms ±  2%  -58.29%  p=0.002
  1000  Protobuf gzip     HTTP/1.1  16.9ms ± 10%  17.1ms ±  2%        ~  p=0.589
  1000  Protobuf gzip     HTTP/2    19.2ms ±  1%  19.4ms ±  4%        ~  p=0.132

 10000  Json     identity HTTP/1.1   587ms ±  2%   537ms ±  8%   -8.48%  p=0.002
 10000  Json     identity HTTP/2     744ms ±  5%   577ms ±  1%  -22.47%  p=0.002
 10000  Json     gzip     HTTP/1.1   604ms ±  1%   615ms ±  6%   +1.79%  p=0.015
 10000  Json     gzip     HTTP/2     674ms ±  5%   650ms ±  3%        ~  p=0.093
 10000  Protobuf identity HTTP/1.1   205ms ±  4%   153ms ±  3%  -25.37%  p=0.002
 10000  Protobuf identity HTTP/2     478ms ±  1%   206ms ±  4%  -56.95%  p=0.002
 10000  Protobuf gzip     HTTP/1.1   200ms ±  2%   209ms ±  5%   +4.30%  p=0.002
 10000  Protobuf gzip     HTTP/2     227ms ±  5%   231ms ±  3%        ~  p=0.240

100000  Json     identity HTTP/1.1  5908ms ±  1%  5325ms ±  0%   -9.87%  p=0.002
100000  Json     identity HTTP/2    7355ms ±  1%  5731ms ±  3%  -22.08%  p=0.002
100000  Json     gzip     HTTP/1.1  6059ms ±  1%  6131ms ±  2%   +1.19%  p=0.041
100000  Json     gzip     HTTP/2    6633ms ±  3%  6614ms ±  2%        ~  p=0.699
100000  Protobuf identity HTTP/1.1  2024ms ±  2%  1557ms ±  5%  -23.06%  p=0.002
100000  Protobuf identity HTTP/2    4755ms ±  2%  2016ms ±  4%  -57.61%  p=0.002
100000  Protobuf gzip     HTTP/1.1  2010ms ±  1%  2046ms ±  1%   +1.79%  p=0.009
100000  Protobuf gzip     HTTP/2    2325ms ±  2%  2292ms ±  1%   -1.42%  p=0.009

geomean                                  127.4ms       106.1ms  -16.70%
```

#### Which issue(s) this PR is related to:

Follow-up to #141586; alternative to #141809.

#### Special notes for your reviewer:

Semantics: nothing reaches the connection until 128KiB have been written or the response is closed, so an encode error inside the first 128KiB can still become an error status (today an identity streamed response is committed on its first byte); every in-flight response holds a pooled 128KiB buffer (a TODO marks lazy engagement); a client disconnect is noticed within one buffer rather than one item.

This PR was written in part with the assistance of generative AI.

#### Does this PR introduce a user-facing change?

```release-note
kube-apiserver: responses are written to the connection through a 128KiB buffer, so streamed LIST responses are sent in batches rather than one item at a time, reducing CPU and wall-clock time for large uncompressed LISTs over both HTTP/2 and HTTP/1.1. Response bytes are unchanged.
```
