### PR TITLE
scheduler: fix flaky sleep/timeout race in api_dispatcher call queue …

### DIFF
--- a/pkg/scheduler/backend/api_dispatcher/call_queue_test.go
+++ b/pkg/scheduler/backend/api_dispatcher/call_queue_test.go
@@ -19,6 +19,7 @@ package apidispatcher
 import (
 	"errors"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -357,37 +358,43 @@ func TestCallQueuePop(t *testing.T) {
 	})
 
 	t.Run("Pop blocks when queue is empty and unblocks after add", func(t *testing.T) {
-		cq := newCallQueue(mockRelevances)
-		poppedCallCh := make(chan *queuedAPICall)
+		synctest.Test(t, func(t *testing.T) {
+			cq := newCallQueue(mockRelevances)
+			poppedCallCh := make(chan *queuedAPICall)
 
-		go func() {
-			poppedCall, popErr := cq.pop()
-			if popErr != nil {
-				t.Errorf("Unexpected error while popping call: %v", popErr)
+			go func() {
+				poppedCall, popErr := cq.pop()
+				if popErr != nil {
+					t.Errorf("Unexpected error while popping call: %v", popErr)
+				}
+				poppedCallCh <- poppedCall
+			}()
+
+			// synctest.Wait blocks until every goroutine in the bubble is
+			// durably blocked -- which for the goroutine above means it has
+			// actually reached cq.cond.Wait(), not merely been scheduled.
+			// This is exact (tracked by the runtime), not a timing guess, so
+			// there is no window for add() below to run first. If pop()
+			// never actually blocks (e.g. a bug makes it return early), or
+			// never unblocks after add(), the bubble deadlocks and this test
+			// fails immediately instead of hanging or racing a timeout.
+			synctest.Wait()
+
+			call := &queuedAPICall{
+				APICall: &mockAPICall{
+					uid:      uid1,
+					callType: mockCallTypeLow,
+				},
 			}
-			poppedCallCh <- poppedCall
-		}()
+			if err := cq.add(call); err != nil {
+				t.Errorf("Unexpected error while adding call: %v", err)
+			}
 
-		time.Sleep(100 * time.Millisecond)
-
-		call := &queuedAPICall{
-			APICall: &mockAPICall{
-				uid:      uid1,
-				callType: mockCallTypeLow,
-			},
-		}
-		if err := cq.add(call); err != nil {
-			t.Errorf("Unexpected error while adding call: %v", err)
-		}
-
-		select {
-		case poppedCall := <-poppedCallCh:
+			poppedCall := <-poppedCallCh
 			if diff := cmp.Diff(call, poppedCall, queuedAPICallCmpOpts...); diff != "" {
 				t.Errorf("Popped call does not match added call (-want +got):\n%s", diff)
 			}
-		case <-time.After(100 * time.Millisecond):
-			t.Fatal("Pop() should have returned an added call, but it timed out")
-		}
+		})
 	})
 }
 
@@ -572,28 +579,26 @@ func TestCallQueueClose(t *testing.T) {
 	})
 
 	t.Run("Pop unblocks and returns nil when controller is closed", func(t *testing.T) {
-		cq := newCallQueue(mockRelevances)
-		poppedCallCh := make(chan *queuedAPICall)
+		synctest.Test(t, func(t *testing.T) {
+			cq := newCallQueue(mockRelevances)
+			poppedCallCh := make(chan *queuedAPICall)
 
-		go func() {
-			poppedCall, popErr := cq.pop()
-			if popErr != nil {
-				t.Errorf("Unexpected error while popping call: %v", popErr)
-			}
-			poppedCallCh <- poppedCall
-		}()
+			go func() {
+				poppedCall, popErr := cq.pop()
+				if popErr != nil {
+					t.Errorf("Unexpected error while popping call: %v", popErr)
+				}
+				poppedCallCh <- poppedCall
+			}()
 
-		time.Sleep(100 * time.Millisecond)
+			synctest.Wait()
 
-		cq.close()
+			cq.close()
 
-		select {
-		case poppedCall := <-poppedCallCh:
+			poppedCall := <-poppedCallCh
 			if poppedCall != nil {
 				t.Errorf("Expected popped call to be nil, but got %v", poppedCall)
 			}
-		case <-time.After(100 * time.Millisecond):
-			t.Fatal("Pop() should have been unblocked by close(), but it remained blocked")
-		}
+		})
 	})
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind flake
/sig scheduling

#### What this PR does / why we need it:

`TestCallQueue` (subtest `Pop blocks when queue is empty and unblocks after
add`) and `TestCallQueueClose` (subtest `Pop unblocks and returns nil when
controller is closed`) synchronized with a background goroutine using a
hardcoded `time.Sleep(100 * time.Millisecond)`, then raced that same 100ms
window again via `time.After()` to detect completion.

On a loaded or CPU-throttled CI runner, the combined round trip of goroutine
scheduling + `pop()` unblocking + channel send + `select` wake-up can exceed
100ms with no bug present in the code under test. This can produce spurious
failures such as:

```text
Pop() should have returned an added call, but it timed out
```
or:
```text
Pop() should have been unblocked by close(), but it remained blocked
```

This is the same class of test flake SIG Scheduling has addressed before in
this package family (#74611), and matches the timing fix made in client-go
for kubernetes/kubernetes#125581.

**Fix:** both subtests now run inside `testing/synctest.Test(t, ...)` and use
`synctest.Wait()` in place of the sleep/timeout pair. `synctest.Wait()`
blocks until every goroutine in the bubble is durably blocked — for the
`pop()` goroutine, that specifically means it has reached `cq.cond.Wait()`,
tracked exactly by the Go runtime rather than inferred from timing. This
needs no production code changes and no wall-clock timeouts at all: if
`pop()` never blocks, or never unblocks after `add()`/`close()`, the bubble
deadlocks and the test fails immediately instead of racing or hanging.
`go.mod` is on `go 1.26.0`, so `synctest` is available with no experiment
flag.

(An earlier version of this PR used a `popStarted` channel plus a
`testBeforeWait` hook in `call_queue.go` to achieve the same synchronization.
Per review, that's been replaced with `synctest` — production code is now
fully untouched.)

#### Which issue(s) this PR is related to:

Related to #141836

#### Special notes for your reviewer:

Verified locally with:
```text
go test ./pkg/scheduler/backend/api_dispatcher/... -run TestCallQueue -count=200 -v
```
<TODO: paste your actual local run output/summary here, e.g. `200/200 passed`>

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs, usage docs, etc.:

```docs
```

#### AI usage disclosure:

yes, AI was used to help draft and refine the PR description