### PR TITLE
Fix empty reserved-memory flag handling

### DIFF
--- a/pkg/util/flag/flags.go
+++ b/pkg/util/flag/flags.go
@@ -175,17 +175,13 @@ func (v *ReservedMemoryVar) Set(s string) error {
 	}
 
 	if s == "" {
-		v.Value = nil
+		*v.Value = nil
 		return nil
 	}
 
 	if !v.initialized || *v.Value == nil {
 		*v.Value = make([]kubeletconfig.MemoryReservation, 0)
 		v.initialized = true
-	}
-
-	if s == "" {
-		return nil
 	}
 
 	numaNodeReservations := strings.Split(s, ";")

--- a/pkg/util/flag/flags_test.go
+++ b/pkg/util/flag/flags_test.go
@@ -308,6 +308,32 @@ func TestReservedMemoryVar(t *testing.T) {
 	}
 }
 
+func TestReservedMemoryVarClear(t *testing.T) {
+	reservedMemory := []kubeletconfig.MemoryReservation{
+		{
+			NumaNode: 0,
+			Limits: v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		},
+	}
+	value := &ReservedMemoryVar{Value: &reservedMemory}
+
+	if err := value.Set(""); err != nil {
+		t.Fatalf("unexpected error clearing reserved memory: %v", err)
+	}
+	if reservedMemory != nil {
+		t.Fatalf("expected reserved memory to be nil after clearing, got %v", reservedMemory)
+	}
+
+	if err := value.Set("0:memory=1Gi"); err != nil {
+		t.Fatalf("unexpected error setting reserved memory after clearing: %v", err)
+	}
+	if len(reservedMemory) != 1 {
+		t.Fatalf("expected one reserved memory entry after resetting, got %d", len(reservedMemory))
+	}
+}
+
 func TestTaintsVar(t *testing.T) {
 	cases := []struct {
 		f   string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

`ReservedMemoryVar.Set("")` currently assigns `nil` to `ReservedMemoryVar.Value` instead of clearing the caller-owned `[]MemoryReservation`.

As a result:

- the caller's reserved-memory slice keeps its previous contents;
- the wrapper loses its pointer;
- a subsequent non-empty `Set` call fails with: `no target (nil pointer to *[]MemoryReservation)`.

This change clears the pointed-to slice with `*v.Value = nil` and removes an unreachable empty-string branch.

A regression test verifies that reserved memory can be cleared and then set again.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

N/A


#### Special notes for your reviewer:

The change is limited to the empty-value handling of `ReservedMemoryVar`.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->

YES - Kiro was used to make the code and test changes, review and run the package tests. 

The author is responsible for reviewing and submitting the changes.