### PR TITLE
kubelet/validation: reject inode-based eviction signals on Windows

### DIFF
--- a/pkg/kubelet/apis/config/validation/validation_windows.go
+++ b/pkg/kubelet/apis/config/validation/validation_windows.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/klog/v2"
 
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	evictionapi "k8s.io/kubernetes/pkg/kubelet/eviction/api"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
@@ -34,6 +35,25 @@ func validateKubeletOSConfiguration(kc *kubeletconfig.KubeletConfiguration) erro
 
 	if kc.CgroupsPerQOS {
 		klog.Warningf(message, "CgroupsPerQOS", "--cgroups-per-qos", kc.CgroupsPerQOS)
+	}
+
+	// Inode-based eviction signals cannot be enforced on Windows (NTFS has no POSIX
+	// inodes and winstats.GetDirFsInfo reports no inode counters); reject them
+	// explicitly instead of silently accepting a threshold that can never fire.
+	for _, signal := range []evictionapi.Signal{
+		evictionapi.SignalNodeFsInodesFree,
+		evictionapi.SignalImageFsInodesFree,
+		evictionapi.SignalContainerFsInodesFree,
+	} {
+		if _, ok := kc.EvictionHard[string(signal)]; ok {
+			return fmt.Errorf("invalid configuration: %s is not supported on Windows", signal)
+		}
+		if _, ok := kc.EvictionSoft[string(signal)]; ok {
+			return fmt.Errorf("invalid configuration: %s is not supported on Windows", signal)
+		}
+		if _, ok := kc.EvictionMinimumReclaim[string(signal)]; ok {
+			return fmt.Errorf("invalid configuration: %s is not supported on Windows", signal)
+		}
 	}
 
 	if kc.SingleProcessOOMKill != nil {

--- a/pkg/kubelet/apis/config/validation/validation_windows.go
+++ b/pkg/kubelet/apis/config/validation/validation_windows.go
@@ -37,22 +37,44 @@ func validateKubeletOSConfiguration(kc *kubeletconfig.KubeletConfiguration) erro
 		klog.Warningf(message, "CgroupsPerQOS", "--cgroups-per-qos", kc.CgroupsPerQOS)
 	}
 
-	// Inode-based eviction signals cannot be enforced on Windows (NTFS has no POSIX
-	// inodes and winstats.GetDirFsInfo reports no inode counters); reject them
-	// explicitly instead of silently accepting a threshold that can never fire.
-	for _, signal := range []evictionapi.Signal{
-		evictionapi.SignalNodeFsInodesFree,
-		evictionapi.SignalImageFsInodesFree,
-		evictionapi.SignalContainerFsInodesFree,
-	} {
-		if _, ok := kc.EvictionHard[string(signal)]; ok {
-			return fmt.Errorf("invalid configuration: %s is not supported on Windows", signal)
+	// Inode-based eviction signals cannot be enforced on Windows: NTFS has no POSIX
+	// inodes and winstats.GetDirFsInfo leaves the inode counters nil, so the eviction
+	// manager never creates an observation for them and they would never fire. Rather
+	// than failing kubelet startup (which would break otherwise-valid shared configs)
+	// or silently accepting them (which misleads operators into thinking inode eviction
+	// is active), warn and drop them. This mirrors how containerfs.inodesFree is handled
+	// in pkg/kubelet/eviction/helpers.go.
+	for _, v := range []struct {
+		name string
+		flag string
+	}{{
+		name: "EvictionHard",
+		flag: "--eviction-hard",
+	}, {
+		name: "EvictionSoft",
+		flag: "--eviction-soft",
+	}, {
+		name: "EvictionMinimumReclaim",
+		flag: "--eviction-minimum-reclaim",
+	}} {
+		m := map[string]string{}
+		switch v.name {
+		case "EvictionHard":
+			m = kc.EvictionHard
+		case "EvictionSoft":
+			m = kc.EvictionSoft
+		case "EvictionMinimumReclaim":
+			m = kc.EvictionMinimumReclaim
 		}
-		if _, ok := kc.EvictionSoft[string(signal)]; ok {
-			return fmt.Errorf("invalid configuration: %s is not supported on Windows", signal)
-		}
-		if _, ok := kc.EvictionMinimumReclaim[string(signal)]; ok {
-			return fmt.Errorf("invalid configuration: %s is not supported on Windows", signal)
+		for _, signal := range []evictionapi.Signal{
+			evictionapi.SignalNodeFsInodesFree,
+			evictionapi.SignalImageFsInodesFree,
+			evictionapi.SignalContainerFsInodesFree,
+		} {
+			if _, ok := m[string(signal)]; ok {
+				klog.Warningf("ignoring configuration option: inode eviction signal %s (%s) is not supported on Windows and will be ignored", signal, v.flag)
+				delete(m, string(signal))
+			}
 		}
 	}
 

--- a/pkg/kubelet/apis/config/validation/validation_windows_test.go
+++ b/pkg/kubelet/apis/config/validation/validation_windows_test.go
@@ -18,8 +18,82 @@ limitations under the License.
 
 package validation_test
 
+import (
+	"testing"
+
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	logsapi "k8s.io/component-base/logs/api/v1"
+	"k8s.io/kubernetes/pkg/kubelet/apis/config/validation"
+	evictionapi "k8s.io/kubernetes/pkg/kubelet/eviction/api"
+)
+
 var (
 	// These config options are not supported on Windows.
 	cgroupsPerQOS          = false
 	enforceNodeAllocatable = []string{}
 )
+
+// TestValidateKubeletConfigurationWindowsInodeEviction verifies that inode-based
+// eviction signals in EvictionHard/EvictionSoft/EvictionMinimumReclaim do not make
+// kubelet configuration validation fail on Windows (they cannot be enforced because
+// NTFS has no POSIX inodes), and that they are dropped from the maps with a warning.
+func TestValidateKubeletConfigurationWindowsInodeEviction(t *testing.T) {
+	featureGate := utilfeature.DefaultFeatureGate.DeepCopy()
+	logsapi.AddFeatureGates(featureGate)
+
+	kc := successConfig.DeepCopy()
+	kc.EvictionHard = map[string]string{
+		"memory.available":   "250Mi",
+		"nodefs.available":   "10%",
+		"nodefs.inodesFree":  "5%",
+		"imagefs.inodesFree": "5%",
+	}
+	kc.EvictionSoft = map[string]string{
+		"nodefs.available":       "10%",
+		"nodefs.inodesFree":      "5%",
+		"containerfs.inodesFree": "5%",
+	}
+	kc.EvictionMinimumReclaim = map[string]string{
+		"nodefs.available":   "5%",
+		"imagefs.inodesFree": "5%",
+	}
+
+	if err := validation.ValidateKubeletConfiguration(kc, featureGate); err != nil {
+		t.Fatalf("inode-based eviction signals should be tolerated on Windows, got validation error: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		signal evictionapi.Signal
+		m      map[string]string
+	}{{
+		name:   "hard nodefs.inodesFree",
+		signal: evictionapi.SignalNodeFsInodesFree,
+		m:      kc.EvictionHard,
+	}, {
+		name:   "hard imagefs.inodesFree",
+		signal: evictionapi.SignalImageFsInodesFree,
+		m:      kc.EvictionHard,
+	}, {
+		name:   "soft nodefs.inodesFree",
+		signal: evictionapi.SignalNodeFsInodesFree,
+		m:      kc.EvictionSoft,
+	}, {
+		name:   "soft containerfs.inodesFree",
+		signal: evictionapi.SignalContainerFsInodesFree,
+		m:      kc.EvictionSoft,
+	}, {
+		name:   "min reclaim imagefs.inodesFree",
+		signal: evictionapi.SignalImageFsInodesFree,
+		m:      kc.EvictionMinimumReclaim,
+	}} {
+		if _, ok := tc.m[string(tc.signal)]; ok {
+			t.Errorf("%s should be dropped from the eviction %s after validation", tc.signal, tc.name)
+		}
+	}
+
+	// The supported (non-inode) signals must be preserved.
+	if kc.EvictionHard["nodefs.available"] != "10%" || kc.EvictionHard["memory.available"] != "250Mi" {
+		t.Errorf("inode-drop must not remove supported eviction signals: %v", kc.EvictionHard)
+	}
+}

--- a/test/e2e_node_windows/services/kubelet.go
+++ b/test/e2e_node_windows/services/kubelet.go
@@ -118,14 +118,14 @@ func baseKubeConfiguration(ctx context.Context, cfgPath string) (*kubeletconfig.
 		kc.FileCheckFrequency = metav1.Duration{Duration: 10 * time.Second}
 		kc.PodCIDR = "10.100.0.0/24"
 		kc.EvictionPressureTransitionPeriod = metav1.Duration{Duration: 30 * time.Second}
+		// Inode-based eviction signals are not supported on Windows (NTFS has no
+		// POSIX inodes) and are rejected by kubelet config validation, so omit them.
 		kc.EvictionHard = map[string]string{
-			"memory.available":  "250Mi",
-			"nodefs.available":  "10%",
-			"nodefs.inodesFree": "5%",
+			"memory.available": "250Mi",
+			"nodefs.available": "10%",
 		}
 		kc.EvictionMinimumReclaim = map[string]string{
-			"nodefs.available":  "5%",
-			"nodefs.inodesFree": "5%",
+			"nodefs.available": "5%",
 		}
 
 		kc.ResolverConfig = ""

--- a/test/e2e_node_windows/services/kubelet.go
+++ b/test/e2e_node_windows/services/kubelet.go
@@ -118,14 +118,14 @@ func baseKubeConfiguration(ctx context.Context, cfgPath string) (*kubeletconfig.
 		kc.FileCheckFrequency = metav1.Duration{Duration: 10 * time.Second}
 		kc.PodCIDR = "10.100.0.0/24"
 		kc.EvictionPressureTransitionPeriod = metav1.Duration{Duration: 30 * time.Second}
-		// Inode-based eviction signals are not supported on Windows (NTFS has no
-		// POSIX inodes) and are rejected by kubelet config validation, so omit them.
 		kc.EvictionHard = map[string]string{
-			"memory.available": "250Mi",
-			"nodefs.available": "10%",
+			"memory.available":  "250Mi",
+			"nodefs.available":  "10%",
+			"nodefs.inodesFree": "5%",
 		}
 		kc.EvictionMinimumReclaim = map[string]string{
-			"nodefs.available": "5%",
+			"nodefs.available":  "5%",
+			"nodefs.inodesFree": "5%",
 		}
 
 		kc.ResolverConfig = ""


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Makes the kubelet **warn and drop inode-based eviction signals** on Windows instead of silently accepting or rejecting them.

On Linux, `nodefs.inodesFree` / `imagefs.inodesFree` / `containerfs.inodesFree` are real filesystem-pressure signals backed by POSIX inode counters. Windows has **no POSIX inodes**: `winstats.GetDirFsInfo` returns an `FsInfo` with no inode counters (NTFS), so the eviction manager never creates an observation for these signals and they can never fire. Previously `validateKubeletOSConfiguration` in `pkg/kubelet/apis/config/validation/validation_windows.go` accepted them, so a user setting `evictionHard.xxx.inodesFree` got a threshold that silently never triggered.

Rather than failing kubelet startup (which would break otherwise-valid shared configs that tune for Linux) or silently accepting the unusable threshold, the kubelet now, when any inode-based signal is present in `EvictionHard` / `EvictionSoft` / `EvictionMinimumReclaim`, logs a clear warning and drops that entry from the map. This mirrors the existing `containerfs.inodesFree` handling in `pkg/kubelet/eviction/helpers.go`.

#### Does this PR depend on any other PRs?
No.

#### Special notes / verification
- Windows-only behavior change (//go:build windows).
- Added `TestValidateKubeletConfigurationWindowsInodeEviction` in `validation_windows_test.go`: asserts validation succeeds when inode signals are configured and that they are dropped from the maps while supported signals are preserved.
- Verified under GOOS=windows: go test ./pkg/kubelet/apis/config/validation/ PASS; go vet pass; gofmt clean.

#### Does this PR introduce a user-facing change?
```release-note
kubelet: inode-based eviction signals (nodefs/imagefs/containerfs.inodesFree) are now ignored with a warning on Windows instead of being silently accepted; they cannot be enforced because NTFS has no POSIX inodes.
```

#### AI-generated content
This change and description were prepared with AI assistance and reviewed by an engineer before submission. No @mentions or 'fixes #' in commit; kubernetes boilerplate retained.
