### PR TITLE
kubectl: Reject malformed service port mappings

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go
@@ -386,6 +386,9 @@ func NewCmdCreateServiceExternalName(f cmdutil.Factory, ioStreams genericiooptio
 
 func parsePorts(portString string) (int32, intstr.IntOrString, error) {
 	portStringSlice := strings.Split(portString, ":")
+	if len(portStringSlice) > 2 {
+		return 0, intstr.FromInt32(0), fmt.Errorf("invalid port mapping %q: expected port or port:targetPort", portString)
+	}
 
 	port, err := utilsnet.ParsePort(portStringSlice[0], true)
 	if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service_test.go
@@ -137,6 +137,13 @@ func TestCreateServices(t *testing.T) {
 			expectErr:   true,
 		},
 		{
+			name:        "invalid-port-mapping-extra-field",
+			tcp:         []string{"8080:80:extra"},
+			clusterip:   "None",
+			serviceType: v1.ServiceTypeClusterIP,
+			expectErr:   true,
+		},
+		{
 			expectErr: true,
 		},
 		{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Rejects `kubectl create service --tcp` values containing more than the supported `port` or `port:targetPort` fields. Previously, an input such as `8080:80:extra` was accepted: the parser used the first two fields while the full malformed value became the generated Service port name.

Adds a regression case to the existing service creation test table.

#### Which issue(s) this PR fixes:

Fixes kubernetes/kubectl#1879

#### Special notes for your reviewer:

AI assistance was used to inspect the parsing path, identify the malformed-input case, draft the regression test, and prepare the PR text. I reviewed the resulting change and test output.

Tests:

```console
go test ./staging/src/k8s.io/kubectl/pkg/cmd/create -run '^TestCreateService' -count=1
go test ./staging/src/k8s.io/kubectl/pkg/cmd/create -run '^TestCreateServices$/invalid-port-mapping-extra-field$' -count=1
```

The full create-package suite was also run. The service tests pass, but two unrelated existing tests fail on Windows because they expect the Unix text `no such file or directory` instead of Windows' `The system cannot find the file specified.`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
