### PR TITLE
deployment: reject out-of-range revision annotation values to avoid int64 overflow

### DIFF
--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -224,7 +224,17 @@ func Revision(obj runtime.Object) (int64, error) {
 	if !ok {
 		return 0, nil
 	}
-	return strconv.ParseInt(v, 10, 64)
+	revision, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	if revision < 0 {
+		return 0, fmt.Errorf("invalid negative revision %d", revision)
+	}
+	if revision >= math.MaxInt64 {
+		return 0, fmt.Errorf("invalid revision %d: would overflow", revision)
+	}
+	return revision, nil
 }
 
 // SetNewReplicaSetAnnotations sets new replica set's annotations appropriately by updating its revision and

--- a/pkg/controller/deployment/util/deployment_util_test.go
+++ b/pkg/controller/deployment/util/deployment_util_test.go
@@ -1220,6 +1220,28 @@ func TestAnnotationUtils(t *testing.T) {
 	//Tear Down
 }
 
+func TestRevisionOverflowAndNegative(t *testing.T) {
+	rsMax := generateRS(generateDeployment("nginx"))
+	rsMax.Annotations = map[string]string{RevisionAnnotation: fmt.Sprintf("%d", math.MaxInt64)}
+	if _, err := Revision(&rsMax); err == nil {
+		t.Errorf("Revision(math.MaxInt64) should return an error")
+	}
+
+	rsNegative := generateRS(generateDeployment("nginx"))
+	rsNegative.Annotations = map[string]string{RevisionAnnotation: "-1"}
+	if _, err := Revision(&rsNegative); err == nil {
+		t.Errorf("Revision(-1) should return an error")
+	}
+
+	logger, _ := ktesting.NewTestContext(t)
+	rsMax2 := generateRS(generateDeployment("nginx2"))
+	rsMax2.Annotations = map[string]string{RevisionAnnotation: fmt.Sprintf("%d", math.MaxInt64)}
+	rsMax2.Name = "rs-max"
+	if got := MaxRevision(logger, []*apps.ReplicaSet{&rsMax2}); got != 0 {
+		t.Errorf("MaxRevision should ignore math.MaxInt64 revision, got %d", got)
+	}
+}
+
 func TestReplicasAnnotationsNeedUpdate(t *testing.T) {
 
 	desiredReplicas := fmt.Sprintf("%d", int32(10))


### PR DESCRIPTION
## What this PR does / why we need it

`Revision()` in `pkg/controller/deployment/util/deployment_util.go` parsed the `deployment.kubernetes.io/revision` annotation with `strconv.ParseInt` and returned the value unchecked. When an adopted ReplicaSet carries `math.MaxInt64`, the controller computes the next revision as `maxOldRevision + 1` in `pkg/controller/deployment/sync.go`, which overflows `int64` to `math.MinInt64` and corrupts the Deployment's revision history.

This validates the parsed value in `Revision()`: values `< 0` or `>= math.MaxInt64` are rejected as errors. `MaxRevision`, `LastRevision`, `ReplicaSetsByRevision.Less` and the rollback path already skip or fall back when `Revision()` returns an error, so the malformed annotation is simply ignored when computing the next revision.

## Which issue(s) this PR fixes

Fixes #141853

## Special notes for your reviewer

- The fix lives in `Revision()` because it is the single parsing point for the revision annotation on the controller side.
- All controller call sites already tolerate a `Revision()` error: `MaxRevision` / `LastRevision` log at V(4) and skip the ReplicaSet, `ReplicaSetsByRevision.Less` falls back to creation-timestamp ordering, and `rollback.go` logs at V(4) and continues.
- kubectl (`rollout history` / `status` / `undo`) uses its own copy of `Revision()` in `k8s.io/kubectl/pkg/util/deployment`, which this PR does not touch. kubectl only reads and displays revisions, it never computes `max+1`, so it does not overflow.
- Boundary: rejecting `>= math.MaxInt64` leaves `math.MaxInt64 - 1` as the largest usable revision, and `(math.MaxInt64 - 1) + 1` does not overflow.

## Does this PR introduce a user-facing change?

```release-note
Fixed a silent int64 overflow in the Deployment controller's revision calculation when a ReplicaSet carries an out-of-range `deployment.kubernetes.io/revision` annotation. Such values are now ignored, as unparseable ones already were.
```

## Tests

- Added `TestRevisionOverflowAndNegative` in `pkg/controller/deployment/util/deployment_util_test.go`: asserts that `Revision()` errors on `math.MaxInt64` and on a negative value, and that `MaxRevision` ignores a `math.MaxInt64` revision (returns 0).
- `go test ./pkg/controller/deployment/util -run TestRevisionOverflowAndNegative -v` passes.
