### PR TITLE
[release-1.36] kubelet: avoid watching unsupported DRA health streams

### DIFF
--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -26,6 +26,9 @@ import (
 	"strconv"
 	"time"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1040,6 +1043,12 @@ func (m *Manager) HandleWatchResourcesStream(ctx context.Context, stream draheal
 			if errors.Is(err, io.EOF) {
 				logger.V(4).Info("Stream ended with EOF")
 				return nil
+			}
+			// The driver advertises the health service but does not support
+			// health reporting. Not an error, the caller stops watching.
+			if status.Code(err) == codes.Unimplemented {
+				logger.V(4).Info("Driver does not support WatchResources", "reason", err)
+				return err
 			}
 			// Other errors are unexpected, log & return.
 			logger.Error(err, "Error receiving from WatchResources stream")

--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -34,7 +34,9 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
@@ -59,6 +61,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/dra/state"
 	"k8s.io/kubernetes/pkg/kubelet/cm/resourceupdates"
 	"k8s.io/kubernetes/test/utils/ktesting"
+	"k8s.io/kubernetes/test/utils/ktesting/initoption"
 )
 
 const (
@@ -2291,6 +2294,31 @@ func TestHandleWatchResourcesStream(t *testing.T) {
 		}
 		assert.True(t, finalErr == nil || errors.Is(finalErr, io.EOF), "Expected nil or io.EOF, got %v", finalErr)
 	})
+}
+
+func TestHandleWatchResourcesStreamUnimplemented(t *testing.T) {
+	tCtx := ktesting.Init(t, initoption.BufferLogs(true))
+	manager, err := NewManager(tCtx.Logger(), nil, t.TempDir())
+	require.NoError(t, err)
+
+	responses := make(chan struct {
+		Resp *drahealthv1alpha1.NodeWatchResourcesResponse
+		Err  error
+	}, 1)
+	responses <- struct {
+		Resp *drahealthv1alpha1.NodeWatchResourcesResponse
+		Err  error
+	}{Err: status.Error(codes.Unimplemented, "device health reporting is not supported by this driver")}
+
+	stream := &mockWatchResourcesClient{
+		RecvChan: responses,
+		Ctx:      tCtx,
+	}
+	err = manager.HandleWatchResourcesStream(tCtx, stream, driverName)
+	require.Equal(t, codes.Unimplemented, status.Code(err))
+
+	logOutput := tCtx.Logger().GetSink().(ktesting.Underlier).GetBuffer().String()
+	assert.NotContains(t, logOutput, "Error receiving from WatchResources stream", "Unimplemented health reporting should not be logged as an error")
 }
 
 // TestUpdateAllocatedResourcesStatus verifies that the manager can correctly

--- a/pkg/kubelet/cm/dra/plugin/dra_plugin.go
+++ b/pkg/kubelet/cm/dra/plugin/dra_plugin.go
@@ -48,15 +48,25 @@ var servicesSupportedByKubelet = []string{
 	drapbv1beta1.DRAPluginService,
 }
 
+// All DRAResourceHealth API versions supported by the kubelet.
+// Sorted by most recent first, oldest last. The kubelet picks the first one
+// that the plugin also advertises.
+var healthServicesSupportedByKubelet = []string{
+	drahealthv1alpha1.DRAResourceHealth_ServiceDesc.ServiceName,
+}
+
 // DRAPlugin contains information about one registered plugin of a DRA driver.
 // It implements the kubelet operations for preparing/unpreparing by calling
 // a gRPC interface that is implemented by the plugin.
 type DRAPlugin struct {
-	driverName        string
-	conn              *grpc.ClientConn
-	endpoint          string
-	chosenService     string // e.g. drapbv1.DRAPluginService
-	clientCallTimeout time.Duration
+	driverName    string
+	conn          *grpc.ClientConn
+	endpoint      string
+	chosenService string // e.g. drapbv1.DRAPluginService
+	// chosenHealthService is the negotiated DRAResourceHealth gRPC service,
+	// or "" if the plugin does not provide the optional health service.
+	chosenHealthService string
+	clientCallTimeout   time.Duration
 
 	mutex         sync.Mutex
 	backgroundCtx context.Context

--- a/pkg/kubelet/cm/dra/plugin/dra_plugin_manager.go
+++ b/pkg/kubelet/cm/dra/plugin/dra_plugin_manager.go
@@ -25,8 +25,10 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	grpcstats "google.golang.org/grpc/stats"
+	"google.golang.org/grpc/status"
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
@@ -327,11 +329,16 @@ func (pm *DRAPluginManager) RegisterPlugin(driverName string, endpoint string, s
 		return fmt.Errorf("invalid supported gRPC versions of DRA driver plugin %s at endpoint %s: %w", driverName, endpoint, err)
 	}
 
+	// The DRAResourceHealth service is optional. Pick the most recent version
+	// that both the plugin and the kubelet support, or "" if the plugin does
+	// not advertise it.
+	chosenHealthService := pickHealthService(supportedServices)
+
 	timeout := ptr.Deref(pluginClientTimeout, defaultClientCallTimeout)
 
 	// Storing endpoint of newly registered DRA DRAPlugin into the map, where the DRA driver name will be the key
 	// under which the manager will be able to get a plugin when it needs to call it.
-	if err := pm.add(driverName, endpoint, chosenService, timeout); err != nil {
+	if err := pm.add(driverName, endpoint, chosenService, chosenHealthService, timeout); err != nil {
 		// No wrapping, the error already contains details.
 		return err
 	}
@@ -339,16 +346,29 @@ func (pm *DRAPluginManager) RegisterPlugin(driverName string, endpoint string, s
 	return nil
 }
 
-func (pm *DRAPluginManager) add(driverName string, endpoint string, chosenService string, clientCallTimeout time.Duration) error {
+// pickHealthService returns the most recent DRAResourceHealth gRPC service that
+// is supported by both the plugin and the kubelet, or "" if the plugin does not
+// advertise the optional health service.
+func pickHealthService(supportedServices []string) string {
+	for _, service := range healthServicesSupportedByKubelet {
+		if slices.Contains(supportedServices, service) {
+			return service
+		}
+	}
+	return ""
+}
+
+func (pm *DRAPluginManager) add(driverName string, endpoint string, chosenService string, chosenHealthService string, clientCallTimeout time.Duration) error {
 	pm.mutex.Lock()
 	defer pm.mutex.Unlock()
 
 	p := &DRAPlugin{
-		driverName:        driverName,
-		endpoint:          endpoint,
-		chosenService:     chosenService,
-		clientCallTimeout: clientCallTimeout,
-		backgroundCtx:     pm.backgroundCtx,
+		driverName:          driverName,
+		endpoint:            endpoint,
+		chosenService:       chosenService,
+		chosenHealthService: chosenHealthService,
+		clientCallTimeout:   clientCallTimeout,
+		backgroundCtx:       pm.backgroundCtx,
 	}
 	if pm.store == nil {
 		pm.store = make(map[string][]*monitoredPlugin)
@@ -384,7 +404,7 @@ func (pm *DRAPluginManager) add(driverName string, endpoint string, chosenServic
 	}
 	p.conn = conn
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.ResourceHealthStatus) && pm.streamHandler != nil {
+	if utilfeature.DefaultFeatureGate.Enabled(features.ResourceHealthStatus) && pm.streamHandler != nil && p.chosenHealthService != "" {
 		pm.wg.Add(1)
 		go func() {
 			defer pm.wg.Done()
@@ -403,7 +423,13 @@ func (pm *DRAPluginManager) add(driverName string, endpoint string, chosenServic
 
 				err = pm.streamHandler.HandleWatchResourcesStream(ctx, stream, driverName)
 				logger.V(2).Info("WatchResources health stream has ended", "error", err)
-
+				if status.Code(err) == codes.Unimplemented {
+					// The driver advertises the health service but does not
+					// support health reporting. Stop watching instead of
+					// retrying; a driver which gains support re-registers.
+					logger.V(2).Info("Driver does not support WatchResources health stream, stopping")
+					streamCancel()
+				}
 			}, 5*time.Second)
 		}()
 	}

--- a/pkg/kubelet/cm/dra/plugin/dra_plugin_manager_test.go
+++ b/pkg/kubelet/cm/dra/plugin/dra_plugin_manager_test.go
@@ -17,13 +17,122 @@ limitations under the License.
 package plugin
 
 import (
+	"context"
 	"fmt"
 	"math/rand/v2"
+	"path"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	drahealthv1alpha1 "k8s.io/kubelet/pkg/apis/dra-health/v1alpha1"
+	drapbv1 "k8s.io/kubelet/pkg/apis/dra/v1"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/utils/ktesting"
 )
+
+func TestPickHealthService(t *testing.T) {
+	for name, tc := range map[string]struct {
+		supportedServices []string
+		want              string
+	}{
+		"none": {
+			supportedServices: []string{"v1beta1.DRAPlugin"},
+			want:              "",
+		},
+		"empty": {
+			supportedServices: nil,
+			want:              "",
+		},
+		"v1alpha1": {
+			supportedServices: []string{"v1beta1.DRAPlugin", drahealthv1alpha1.DRAResourceHealth_ServiceDesc.ServiceName},
+			want:              drahealthv1alpha1.DRAResourceHealth_ServiceDesc.ServiceName,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := pickHealthService(tc.supportedServices); got != tc.want {
+				t.Errorf("pickHealthService(%v) = %q, want %q", tc.supportedServices, got, tc.want)
+			}
+		})
+	}
+}
+
+type unimplementedStreamHandler struct {
+	calls  atomic.Int32
+	called chan struct{}
+}
+
+func (h *unimplementedStreamHandler) HandleWatchResourcesStream(context.Context, drahealthv1alpha1.DRAResourceHealth_NodeWatchResourcesClient, string) error {
+	h.calls.Add(1)
+	select {
+	case h.called <- struct{}{}:
+	default:
+	}
+	return status.Error(codes.Unimplemented, "device health reporting is not supported by this driver")
+}
+
+func TestHealthStreamRequiresAdvertisedService(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ResourceHealthStatus, true)
+	tCtx := ktesting.Init(t)
+	handler := &unimplementedStreamHandler{called: make(chan struct{}, 1)}
+	draPlugins := NewDRAPluginManager(tCtx, nil, nil, handler, 0)
+	t.Cleanup(draPlugins.Stop)
+
+	const driverName = "dummy-driver"
+	tCtx.ExpectNoError(draPlugins.RegisterPlugin(driverName, "dra.sock", []string{drapbv1.DRAPluginService}, nil), "register plugin")
+	t.Cleanup(func() { draPlugins.remove(driverName, "dra.sock") })
+
+	plugin := draPlugins.get(driverName)
+	require.NotNil(t, plugin)
+	require.Never(t, func() bool {
+		plugin.mutex.Lock()
+		defer plugin.mutex.Unlock()
+		return plugin.healthStreamCtx != nil
+	}, time.Second, 10*time.Millisecond, "health stream should not start when the plugin did not advertise the service")
+	require.Zero(t, handler.calls.Load())
+}
+
+func TestUnimplementedHealthStreamIsNotRetried(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ResourceHealthStatus, true)
+	tCtx := ktesting.Init(t)
+
+	addr := path.Join(t.TempDir(), "dra.sock")
+	teardown, err := setupFakeGRPCServer(tCtx, "", addr)
+	require.NoError(t, err)
+	t.Cleanup(teardown)
+
+	handler := &unimplementedStreamHandler{called: make(chan struct{}, 1)}
+	draPlugins := NewDRAPluginManager(tCtx, nil, nil, handler, 0)
+	t.Cleanup(draPlugins.Stop)
+
+	const driverName = "dummy-driver"
+	tCtx.ExpectNoError(draPlugins.RegisterPlugin(driverName, addr, []string{drapbv1.DRAPluginService, drahealthv1alpha1.DRAResourceHealth_ServiceDesc.ServiceName}, nil), "register plugin")
+	t.Cleanup(func() { draPlugins.remove(driverName, addr) })
+
+	select {
+	case <-handler.called:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for health stream handler")
+	}
+
+	plugin := draPlugins.get(driverName)
+	require.NotNil(t, plugin)
+	plugin.mutex.Lock()
+	healthStreamCtx := plugin.healthStreamCtx
+	plugin.mutex.Unlock()
+	require.NotNil(t, healthStreamCtx)
+	select {
+	case <-healthStreamCtx.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("health stream was not stopped after an Unimplemented error")
+	}
+	require.EqualValues(t, 1, handler.calls.Load(), "health stream handler should only be called once")
+}
 
 func TestAddSameName(t *testing.T) {
 	tCtx := ktesting.Init(t)
@@ -32,14 +141,14 @@ func TestAddSameName(t *testing.T) {
 
 	// ensure the plugin we are using is registered
 	draPlugins := NewDRAPluginManager(tCtx, nil, nil, nil, 0)
-	tCtx.ExpectNoError(draPlugins.add(driverName, "old.sock", "", defaultClientCallTimeout), "add first plugin")
+	tCtx.ExpectNoError(draPlugins.add(driverName, "old.sock", "", "", defaultClientCallTimeout), "add first plugin")
 	p, err := draPlugins.GetPlugin(driverName)
 	tCtx.ExpectNoError(err, "get first plugin")
 
 	// Same name, same endpoint -> error.
-	require.Error(tCtx, draPlugins.add(driverName, "old.sock", "", defaultClientCallTimeout))
+	require.Error(tCtx, draPlugins.add(driverName, "old.sock", "", "", defaultClientCallTimeout))
 
-	tCtx.ExpectNoError(draPlugins.add(driverName, "new.sock", "", defaultClientCallTimeout), "add second plugin")
+	tCtx.ExpectNoError(draPlugins.add(driverName, "new.sock", "", "", defaultClientCallTimeout), "add second plugin")
 	p2, err := draPlugins.GetPlugin(driverName)
 	tCtx.ExpectNoError(err, "get second plugin")
 	if p == p2 {
@@ -64,7 +173,7 @@ func TestDelete(t *testing.T) {
 
 	// ensure the plugin we are using is registered
 	draPlugins := NewDRAPluginManager(tCtx, nil, nil, &mockStreamHandler{}, 0)
-	tCtx.ExpectNoError(draPlugins.add(driverName, "dra.sock", "", defaultClientCallTimeout), "add plugin")
+	tCtx.ExpectNoError(draPlugins.add(driverName, "dra.sock", "", "", defaultClientCallTimeout), "add plugin")
 
 	draPlugins.remove(driverName, socketFile)
 

--- a/pkg/kubelet/cm/dra/plugin/dra_plugin_test.go
+++ b/pkg/kubelet/cm/dra/plugin/dra_plugin_test.go
@@ -164,7 +164,7 @@ func TestGRPCConnIsReused(t *testing.T) {
 
 	// ensure the plugin we are using is registered
 	draPlugins := NewDRAPluginManager(tCtx, nil, nil, &mockStreamHandler{}, 0)
-	tCtx.ExpectNoError(draPlugins.add(driverName, addr, drapbv1.DRAPluginService, defaultClientCallTimeout), "add plugin")
+	tCtx.ExpectNoError(draPlugins.add(driverName, addr, drapbv1.DRAPluginService, drahealthv1alpha1.DRAResourceHealth_ServiceDesc.ServiceName, defaultClientCallTimeout), "add plugin")
 	plugin, err := draPlugins.GetPlugin(driverName)
 	tCtx.ExpectNoError(err, "get plugin")
 	conn := plugin.conn
@@ -276,7 +276,7 @@ func TestGRPCConnUsableAfterIdle(t *testing.T) {
 	// ensure the plugin we are using is registered
 	draPlugins := NewDRAPluginManager(tCtx, nil, nil, &mockStreamHandler{}, 0)
 	draPlugins.withIdleTimeout = 5 * time.Second
-	tCtx.ExpectNoError(draPlugins.add(driverName, addr, service, defaultClientCallTimeout), "add plugin")
+	tCtx.ExpectNoError(draPlugins.add(driverName, addr, service, "", defaultClientCallTimeout), "add plugin")
 	plugin, err := draPlugins.GetPlugin(driverName)
 	tCtx.ExpectNoError(err, "get plugin")
 
@@ -320,7 +320,7 @@ func TestGetDRAPlugin(t *testing.T) {
 		{
 			description: "plugin exists",
 			setup: func(draPlugins *DRAPluginManager) error {
-				return draPlugins.add("dummy-driver", "/tmp/dra.sock", "", defaultClientCallTimeout)
+				return draPlugins.add("dummy-driver", "/tmp/dra.sock", "", "", defaultClientCallTimeout)
 			},
 			driverName: "dummy-driver",
 		},
@@ -386,7 +386,7 @@ func TestGRPCMethods(t *testing.T) {
 
 			driverName := "dummy-driver"
 			draPlugins := NewDRAPluginManager(tCtx, nil, nil, &mockStreamHandler{}, 0)
-			tCtx.ExpectNoError(draPlugins.add(driverName, addr, test.chosenService, defaultClientCallTimeout))
+			tCtx.ExpectNoError(draPlugins.add(driverName, addr, test.chosenService, "", defaultClientCallTimeout))
 
 			plugin, err := draPlugins.GetPlugin(driverName)
 			if err != nil {
@@ -425,7 +425,7 @@ func TestGRPCWithTimeoutEnforced(t *testing.T) {
 	driverName := "dummy-driver"
 	timeout := time.Second
 	manager := NewDRAPluginManager(tCtx, nil, nil, nil, 0)
-	err = manager.add(driverName, addr, service, timeout)
+	err = manager.add(driverName, addr, service, "", timeout)
 	require.NoError(t, err, "unexpected error while adding the plugin")
 
 	plugin, err := manager.GetPlugin(driverName)
@@ -537,7 +537,7 @@ func TestPlugin_WatchResources(t *testing.T) {
 	defer teardown()
 
 	draPlugins := NewDRAPluginManager(tCtx, nil, nil, &mockStreamHandler{}, 0)
-	err = draPlugins.add(driverName, addr, drapbv1beta1.DRAPluginService, 5*time.Second)
+	err = draPlugins.add(driverName, addr, drapbv1beta1.DRAPluginService, drahealthv1alpha1.DRAResourceHealth_ServiceDesc.ServiceName, 5*time.Second)
 	require.NoError(t, err)
 	defer draPlugins.remove(driverName, addr)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node
/area kubelet
/wg device-management

#### What this PR does / why we need it:

Kubelet currently starts a DRA resource health stream even when the plugin does not advertise the optional health service. When the driver returns `codes.Unimplemented`, kubelet logs an error and retries every five seconds.

This change:

- negotiates the optional `v1alpha1.DRAResourceHealth` service during plugin registration;
- starts health streaming only when the plugin advertises that service;
- treats `codes.Unimplemented` as terminal and stops retrying;
- avoids logging the expected `Unimplemented` response as an error.

#### Which issue(s) this PR is related to:

Fixes #141855

#### Special notes for your reviewer:

This narrowly adapts the relevant behavior from #139477 for release-1.36 without backporting the v1 health API migration.

Validation:

```console
TMPDIR=/tmp make test WHAT=./pkg/kubelet/cm/dra/...
```

All 223 race-enabled DRA tests passed.

AI assistance was used to investigate the affected code paths, adapt the existing 1.37 behavior to release-1.36, and review the resulting changes and tests. I reviewed and validated the final change.

#### Does this PR introduce a user-facing change?

```release-note
Fixed kubelet repeatedly retrying and logging errors for DRA health streams when a driver does not support resource health reporting.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
