### PR TITLE
Document platform-specific semantics of volumesAttached[].devicePath

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -6217,7 +6217,7 @@
       "description": "AttachedVolume describes a volume attached to a node",
       "properties": {
         "devicePath": {
-          "description": "DevicePath represents the device path where the volume should be available",
+          "description": "DevicePath represents the path where the attached volume is available on the node. On Linux nodes, this is the host block-device node (e.g. /dev/xvdX) that the kubelet uses to mount and format the volume. On Windows nodes there is no /dev device tree, so this carries the CSI VolumeID (the attach identity reported by the CSI driver) instead of a device path.",
           "type": "string"
         },
         "name": {

--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -294,7 +294,7 @@
         "properties": {
           "devicePath": {
             "default": "",
-            "description": "DevicePath represents the device path where the volume should be available",
+            "description": "DevicePath represents the path where the attached volume is available on the node. On Linux nodes, this is the host block-device node (e.g. /dev/xvdX) that the kubelet uses to mount and format the volume. On Windows nodes there is no /dev device tree, so this carries the CSI VolumeID (the attach identity reported by the CSI driver) instead of a device path.",
             "type": "string"
           },
           "name": {

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -5999,7 +5999,11 @@ type AttachedVolume struct {
 	// Name of the attached volume
 	Name UniqueVolumeName
 
-	// DevicePath represents the device path where the volume should be available
+	// DevicePath represents the path where the attached volume is available on
+	// the node. On Linux nodes, this is the host block-device node (e.g. /dev/xvdX)
+	// that the kubelet uses to mount and format the volume. On Windows nodes there
+	// is no /dev device tree, so this carries the CSI VolumeID (the attach identity
+	// reported by the CSI driver) instead of a device path.
 	DevicePath string
 }
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -19952,7 +19952,7 @@ func schema_k8sio_api_core_v1_AttachedVolume(ref common.ReferenceCallback) commo
 					},
 					"devicePath": {
 						SchemaProps: spec.SchemaProps{
-							Description: "DevicePath represents the device path where the volume should be available",
+							Description: "DevicePath represents the path where the attached volume is available on the node. On Linux nodes, this is the host block-device node (e.g. /dev/xvdX) that the kubelet uses to mount and format the volume. On Windows nodes there is no /dev device tree, so this carries the CSI VolumeID (the attach identity reported by the CSI driver) instead of a device path.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/pkg/volume/util/hostutil/hostutil_windows.go
+++ b/pkg/volume/util/hostutil/hostutil_windows.go
@@ -73,11 +73,16 @@ func getDeviceNameFromMount(mounter mount.Interface, mountPath, pluginMountDir s
 }
 
 // DeviceOpened determines if the device is in use elsewhere
+// Windows has no /dev device node tree: Node.status.volumesAttached[].devicePath
+// carries the CSI VolumeID on Windows rather than a block-device node, so this
+// check does not apply and always reports the device as not opened.
 func (hu *HostUtil) DeviceOpened(pathname string) (bool, error) {
 	return false, nil
 }
 
 // PathIsDevice determines if a path is a device.
+// Windows has no /dev device node tree: paths here are volume-GUID paths or CSI
+// VolumeIDs, never a unix-style block-device node, so this always reports false.
 func (hu *HostUtil) PathIsDevice(pathname string) (bool, error) {
 	return false, nil
 }

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -883,6 +883,11 @@ func (og *operationGenerator) GenerateUnmountDeviceFunc(
 		// use hostutil.PathIsDevice to check if the path is a device,
 		// if so use hostutil.DeviceOpened to check if the device is in use anywhere
 		// else on the system. Retry if it returns true.
+		// Note: this in-use safety check only takes effect on platforms with a
+		// device node tree (Linux). On Windows, hostutil.PathIsDevice and
+		// hostutil.DeviceOpened always report (false, nil), so the check is a
+		// no-op there; Node.status.volumesAttached[].devicePath carries the CSI
+		// VolumeID on Windows rather than a device path.
 		deviceOpened, deviceOpenedErr := isDeviceOpened(deviceToDetach, hostutil)
 		if deviceOpenedErr != nil {
 			return volumetypes.NewOperationContext(nil, deviceOpenedErr, migrated)
@@ -1357,6 +1362,11 @@ func (og *operationGenerator) GenerateUnmapDeviceFunc(
 		// use hostutil.PathIsDevice to check if the path is a device,
 		// if so use hostutil.DeviceOpened to check if the device is in use anywhere
 		// else on the system. Retry if it returns true.
+		// Note: this in-use safety check only takes effect on platforms with a
+		// device node tree (Linux). On Windows, hostutil.PathIsDevice and
+		// hostutil.DeviceOpened always report (false, nil), so the check is a
+		// no-op there; Node.status.volumesAttached[].devicePath carries the CSI
+		// VolumeID on Windows rather than a device path.
 		deviceOpened, deviceOpenedErr := isDeviceOpened(deviceToDetach, hostutil)
 		if deviceOpenedErr != nil {
 			return volumetypes.NewOperationContext(nil, deviceOpenedErr, migrated)
@@ -2186,6 +2196,9 @@ func checkNodeAffinity(og *operationGenerator, volumeToMount VolumeToMount) erro
 }
 
 // isDeviceOpened checks the device status if the device is in use anywhere else on the system
+// The check is meaningful only on platforms with a device node tree (Linux): on Windows,
+// hostutil.PathIsDevice and hostutil.DeviceOpened always report (false, nil), so this
+// unconditionally reports the device as not in use; detach proceeds without the check.
 func isDeviceOpened(deviceToDetach AttachedVolume, hostUtil hostutil.HostUtils) (bool, error) {
 	isDevicePath, devicePathErr := hostUtil.PathIsDevice(deviceToDetach.DevicePath)
 	var deviceOpened bool

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -101,7 +101,11 @@ message AttachedVolume {
   // Name of the attached volume
   optional string name = 1;
 
-  // DevicePath represents the device path where the volume should be available
+  // DevicePath represents the path where the attached volume is available on
+  // the node. On Linux nodes, this is the host block-device node (e.g. /dev/xvdX)
+  // that the kubelet uses to mount and format the volume. On Windows nodes there
+  // is no /dev device tree, so this carries the CSI VolumeID (the attach identity
+  // reported by the CSI driver) instead of a device path.
   optional string devicePath = 2;
 }
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -7157,7 +7157,11 @@ type AttachedVolume struct {
 	// Name of the attached volume
 	Name UniqueVolumeName `json:"name" protobuf:"bytes,1,rep,name=name"`
 
-	// DevicePath represents the device path where the volume should be available
+	// DevicePath represents the path where the attached volume is available on
+	// the node. On Linux nodes, this is the host block-device node (e.g. /dev/xvdX)
+	// that the kubelet uses to mount and format the volume. On Windows nodes there
+	// is no /dev device tree, so this carries the CSI VolumeID (the attach identity
+	// reported by the CSI driver) instead of a device path.
 	DevicePath string `json:"devicePath" protobuf:"bytes,2,rep,name=devicePath"`
 }
 

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -63,7 +63,7 @@ func (AppArmorProfile) SwaggerDoc() map[string]string {
 var map_AttachedVolume = map[string]string{
 	"":           "AttachedVolume describes a volume attached to a node",
 	"name":       "Name of the attached volume",
-	"devicePath": "DevicePath represents the device path where the volume should be available",
+	"devicePath": "DevicePath represents the path where the attached volume is available on the node. On Linux nodes, this is the host block-device node (e.g. /dev/xvdX) that the kubelet uses to mount and format the volume. On Windows nodes there is no /dev device tree, so this carries the CSI VolumeID (the attach identity reported by the CSI driver) instead of a device path.",
 }
 
 func (AttachedVolume) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/testdata/swagger.json
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/testdata/swagger.json
@@ -678,7 +678,7 @@
       "description": "AttachedVolume describes a volume attached to a node",
       "properties": {
         "devicePath": {
-          "description": "DevicePath represents the device path where the volume should be available",
+          "description": "DevicePath represents the path where the attached volume is available on the node. On Linux nodes, this is the host block-device node (e.g. /dev/xvdX) that the kubelet uses to mount and format the volume. On Windows nodes there is no /dev device tree, so this carries the CSI VolumeID (the attach identity reported by the CSI driver) instead of a device path.",
           "type": "string"
         },
         "name": {

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/testdata/swagger.json
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/testdata/swagger.json
@@ -678,7 +678,7 @@
       "description": "AttachedVolume describes a volume attached to a node",
       "properties": {
         "devicePath": {
-          "description": "DevicePath represents the path where the attached volume is available on the node. On Linux nodes, this is the host block-device node (e.g. /dev/xvdX) that the kubelet uses to mount and format the volume. On Windows nodes there is no /dev device tree, so this carries the CSI VolumeID (the attach identity reported by the CSI driver) instead of a device path.",
+          "description": "DevicePath represents the device path where the volume should be available",
           "type": "string"
         },
         "name": {

--- a/staging/src/k8s.io/cli-runtime/artifacts/openapi/swagger-with-shared-parameters.json
+++ b/staging/src/k8s.io/cli-runtime/artifacts/openapi/swagger-with-shared-parameters.json
@@ -4386,7 +4386,7 @@
       "description": "AttachedVolume describes a volume attached to a node",
       "properties": {
         "devicePath": {
-          "description": "DevicePath represents the device path where the volume should be available",
+          "description": "DevicePath represents the path where the attached volume is available on the node. On Linux nodes, this is the host block-device node (e.g. /dev/xvdX) that the kubelet uses to mount and format the volume. On Windows nodes there is no /dev device tree, so this carries the CSI VolumeID (the attach identity reported by the CSI driver) instead of a device path.",
           "type": "string"
         },
         "name": {

--- a/staging/src/k8s.io/cli-runtime/artifacts/openapi/swagger.json
+++ b/staging/src/k8s.io/cli-runtime/artifacts/openapi/swagger.json
@@ -4829,7 +4829,7 @@
       "description": "AttachedVolume describes a volume attached to a node",
       "properties": {
         "devicePath": {
-          "description": "DevicePath represents the device path where the volume should be available",
+          "description": "DevicePath represents the path where the attached volume is available on the node. On Linux nodes, this is the host block-device node (e.g. /dev/xvdX) that the kubelet uses to mount and format the volume. On Windows nodes there is no /dev device tree, so this carries the CSI VolumeID (the attach identity reported by the CSI driver) instead of a device path.",
           "type": "string"
         },
         "name": {

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/attachedvolume.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/attachedvolume.go
@@ -29,7 +29,7 @@ import (
 type AttachedVolumeApplyConfiguration struct {
 	// Name of the attached volume
 	Name *corev1.UniqueVolumeName `json:"name,omitempty"`
-	// DevicePath represents the device path where the volume should be available
+	// DevicePath represents the path where the attached volume is available on the node. On Linux nodes, this is the host block-device node (e.g. /dev/xvdX) that the kubelet uses to mount and format the volume. On Windows nodes there is no /dev device tree, so this carries the CSI VolumeID (the attach identity reported by the CSI driver) instead of a device path.
 	DevicePath *string `json:"devicePath,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/attachedvolume.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/attachedvolume.go
@@ -29,7 +29,11 @@ import (
 type AttachedVolumeApplyConfiguration struct {
 	// Name of the attached volume
 	Name *corev1.UniqueVolumeName `json:"name,omitempty"`
-	// DevicePath represents the path where the attached volume is available on the node. On Linux nodes, this is the host block-device node (e.g. /dev/xvdX) that the kubelet uses to mount and format the volume. On Windows nodes there is no /dev device tree, so this carries the CSI VolumeID (the attach identity reported by the CSI driver) instead of a device path.
+	// DevicePath represents the path where the attached volume is available on
+	// the node. On Linux nodes, this is the host block-device node (e.g. /dev/xvdX)
+	// that the kubelet uses to mount and format the volume. On Windows nodes there
+	// is no /dev device tree, so this carries the CSI VolumeID (the attach identity
+	// reported by the CSI driver) instead of a device path.
 	DevicePath *string `json:"devicePath,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/openapi/openapitest/testdata/api__v1_openapi.json
+++ b/staging/src/k8s.io/client-go/openapi/openapitest/testdata/api__v1_openapi.json
@@ -268,7 +268,7 @@
         "properties": {
           "devicePath": {
             "default": "",
-            "description": "DevicePath represents the device path where the volume should be available",
+            "description": "DevicePath represents the path where the attached volume is available on the node. On Linux nodes, this is the host block-device node (e.g. /dev/xvdX) that the kubelet uses to mount and format the volume. On Windows nodes there is no /dev device tree, so this carries the CSI VolumeID (the attach identity reported by the CSI driver) instead of a device path.",
             "type": "string"
           },
           "name": {

--- a/staging/src/k8s.io/kubectl/testdata/openapi/swagger.json
+++ b/staging/src/k8s.io/kubectl/testdata/openapi/swagger.json
@@ -5192,7 +5192,7 @@
       "description": "AttachedVolume describes a volume attached to a node",
       "properties": {
         "devicePath": {
-          "description": "DevicePath represents the device path where the volume should be available",
+          "description": "DevicePath represents the path where the attached volume is available on the node. On Linux nodes, this is the host block-device node (e.g. /dev/xvdX) that the kubelet uses to mount and format the volume. On Windows nodes there is no /dev device tree, so this carries the CSI VolumeID (the attach identity reported by the CSI driver) instead of a device path.",
           "type": "string"
         },
         "name": {

--- a/staging/src/k8s.io/kubectl/testdata/openapi/v3/api/v1.json
+++ b/staging/src/k8s.io/kubectl/testdata/openapi/v3/api/v1.json
@@ -20619,7 +20619,7 @@
         "required": ["name", "devicePath"],
         "properties": {
           "devicePath": {
-            "description": "DevicePath represents the device path where the volume should be available",
+            "description": "DevicePath represents the path where the attached volume is available on the node. On Linux nodes, this is the host block-device node (e.g. /dev/xvdX) that the kubelet uses to mount and format the volume. On Windows nodes there is no /dev device tree, so this carries the CSI VolumeID (the attach identity reported by the CSI driver) instead of a device path.",
             "type": "string",
             "default": ""
           },


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/kind api-change

#### What this PR does / why we need it

`Node.status.volumesAttached[].devicePath` is documented as a device path, but its value is platform- and plugin-specific:

- On **Linux** nodes it is the host block-device node (e.g. `/dev/xvdX`) that the kubelet uses for mount/format and the block-volume mapping.
- On **Windows** nodes there is no `/dev` device tree; the field carries the **CSI VolumeID** (the attach identity reported by the CSI driver). Windows `hostutil.PathIsDevice`/`DeviceOpened` unconditionally return `(false, nil)`, so the detach-path device-in-use check is a no-op there.

This PR makes the contract explicit instead of leaving it undefined:

1. Updates the `AttachedVolume.DevicePath` doc comment in `pkg/apis/core/types.go`, `staging/src/k8s.io/api/core/v1/types.go`, and `staging/src/k8s.io/api/core/v1/generated.proto`, plus the regenerated `types_swagger_doc_generated.go`, `zz_generated.openapi.go`, and the OpenAPI specs (v2 + v3).
2. Updates the apply-configuration doc comment in client-go (`attachedvolume.go`), which mirrors the field docs.
3. Documents the platform limitation at the kubelet detach sites (`operation_generator.go`: `unmount_device`, `unmap_device`, and the `isDeviceOpened` helper) so the unix-only check is no longer silently dead code on Windows, and at the Windows `hostutil` stubs.

Kubernetes API conventions state that field descriptions belong to the API definition, so the doc-comment change and its regenerated artifacts are included here. No API type changes, no wire-format changes - documentation only.

#### Which issue(s) this PR fixes

Fixes #141842

#### Special notes for your reviewer

- The comment-only change in `pkg/volume/...` and the doc-comment change in `pkg/apis/core/types.go` + staging mirror what `make update` would regenerate. Follow-up commit 3ac7291da88 corrects two artifacts against the generators' conventions: `attachedvolume.go` is re-wrapped to mirror the source comment line breaks (applyconfiguration-gen copies them verbatim), and an edit to the hand-maintained managedfields testdata fixture (which is not a generated artifact) was reverted.
- The `devicePath` doc comment is intentionally kept single-paragraph in generated artifacts (`swagger_doc`, `zz_generated.openapi.go`) to match openapi-gen output conventions for a one-comment field.
- Targeting sig/windows + sig/storage for review; happy to adjust wording of the contract as maintainers prefer.

#### Does this PR introduce a user-facing change?

```release-note
The documentation of `Node.status.volumesAttached[].devicePath` now states the platform-specific semantics: on Linux it is the host block-device node, on Windows it carries the CSI VolumeID.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.

```docs
- [Usage]: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#optional-vs-required
```
