### PR TITLE
iscsi: keep detaching block volume when the by-path link is gone

### DIFF
--- a/pkg/volume/iscsi/iscsi_util.go
+++ b/pkg/volume/iscsi/iscsi_util.go
@@ -702,6 +702,11 @@ func (util *ISCSIUtil) DetachBlockISCSIDisk(c iscsiDiskUnmapper, mapPath string)
 	devicePath := getDevByPath(portals[0], iqn, lun)
 	klog.V(5).Infof("iscsi: devicePath: %s", devicePath)
 	if _, err := os.Stat(devicePath); err != nil {
+		if !os.IsNotExist(err) {
+			// The path exists but cannot be accessed (permissions, corrupted
+			// filesystem, ...): surface it instead of continuing.
+			return fmt.Errorf("failed to access devicePath %s: %w", devicePath, err)
+		}
 		// The by-path link may already be gone if the iSCSI session was lost
 		// before teardown ran. The remaining steps handle a missing session
 		// (detachISCSIDisk ignores ISCSI_ERR_NO_OBJS_FOUND and

--- a/pkg/volume/iscsi/iscsi_util.go
+++ b/pkg/volume/iscsi/iscsi_util.go
@@ -701,8 +701,14 @@ func (util *ISCSIUtil) DetachBlockISCSIDisk(c iscsiDiskUnmapper, mapPath string)
 
 	devicePath := getDevByPath(portals[0], iqn, lun)
 	klog.V(5).Infof("iscsi: devicePath: %s", devicePath)
-	if _, err = os.Stat(devicePath); err != nil {
-		return fmt.Errorf("failed to validate devicePath: %s", devicePath)
+	if _, err := os.Stat(devicePath); err != nil {
+		// The by-path link may already be gone if the iSCSI session was lost
+		// before teardown ran. The remaining steps handle a missing session
+		// (detachISCSIDisk ignores ISCSI_ERR_NO_OBJS_FOUND and
+		// ISCSI_ERR_SESS_NOT_FOUND, and isSessionBusy counts plugin
+		// directories rather than devices), so continue instead of failing
+		// detach permanently and stranding the volume in volumesInUse.
+		klog.V(4).Infof("iscsi: devicePath %s already gone, continuing to detach", devicePath)
 	}
 
 	// Lock the target while we determine if we can safely log out or not

--- a/pkg/volume/iscsi/iscsi_util_test.go
+++ b/pkg/volume/iscsi/iscsi_util_test.go
@@ -473,10 +473,16 @@ func TestDetachBlockISCSIDiskMissingDevicePath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating temp dir: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Errorf("error removing temp dir %s: %v", tmpDir, err)
+		}
+	}()
 
 	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, volumetest.NewFakeVolumeHost(t, tmpDir, nil, nil))
+	if err := plugMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, volumetest.NewFakeVolumeHost(t, tmpDir, nil, nil)); err != nil {
+		t.Fatalf("error initializing plugins: %v", err)
+	}
 	plug, err := plugMgr.FindPluginByName(iscsiPluginName)
 	if err != nil {
 		t.Fatalf("can't find the plugin by name: %v", err)

--- a/pkg/volume/iscsi/iscsi_util_test.go
+++ b/pkg/volume/iscsi/iscsi_util_test.go
@@ -19,11 +19,13 @@ limitations under the License.
 package iscsi
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
 
+	utiltesting "k8s.io/client-go/util/testing"
 	testingexec "k8s.io/utils/exec/testing"
 
 	"k8s.io/kubernetes/pkg/kubelet/kubeletconfig"
@@ -460,4 +462,80 @@ func createFakePluginDirs() (string, error) {
 	}
 
 	return dir, err
+}
+
+// TestDetachBlockISCSIDiskMissingDevicePath verifies that DetachBlockISCSIDisk
+// completes when the /dev/disk/by-path link is already gone, e.g. the iSCSI
+// session was lost before teardown ran, instead of failing permanently and
+// stranding the volume in node.status.volumesInUse.
+func TestDetachBlockISCSIDiskMissingDevicePath(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("iscsi_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	plugMgr := volume.VolumePluginMgr{}
+	plugMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, volumetest.NewFakeVolumeHost(t, tmpDir, nil, nil))
+	plug, err := plugMgr.FindPluginByName(iscsiPluginName)
+	if err != nil {
+		t.Fatalf("can't find the plugin by name: %v", err)
+	}
+
+	portal := "127.0.0.1:3260"
+	iqn := "iqn.2016-01.com.example:test"
+	iface := "default"
+	mapPath := filepath.Join(tmpDir, "plugins", iscsiPluginName, "volumeDevices", "iface-"+iface, portal+"-"+iqn+"-lun-0")
+	if err := os.MkdirAll(mapPath, 0750); err != nil {
+		t.Fatalf("error creating map path %s: %v", mapPath, err)
+	}
+	// Persist the volume config so loadISCSI() succeeds like in production.
+	conf := iscsiDisk{
+		VolName: "vol0",
+		Portals: []string{portal},
+		Iqn:     iqn,
+		Lun:     "0",
+		Iface:   iface,
+	}
+	confData, err := json.Marshal(conf)
+	if err != nil {
+		t.Fatalf("error marshaling iscsi config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(mapPath, "iscsi.json"), confData, 0644); err != nil {
+		t.Fatalf("error writing iscsi config: %v", err)
+	}
+
+	fakeExec := &testingexec.FakeExec{}
+	scripts := []volumetest.CommandScript{
+		{
+			Cmd:  "iscsiadm",
+			Args: []string{"-m", "node", "-p", portal, "-T", iqn, "--logout", "-I", iface},
+		},
+		{
+			Cmd:  "iscsiadm",
+			Args: []string{"-m", "node", "-p", portal, "-T", iqn, "-o", "delete", "-I", iface},
+		},
+	}
+	volumetest.ScriptCommands(fakeExec, scripts)
+	fakeExec.ExactOrder = true
+
+	unmapper := &iscsiDiskUnmapper{
+		iscsiDisk: &iscsiDisk{
+			VolName: "vol0",
+			Portals: []string{portal},
+			Iqn:     iqn,
+			Lun:     "0",
+			Iface:   iface,
+			plugin:  plug.(*iscsiPlugin),
+		},
+		exec: fakeExec,
+	}
+	// No /dev/disk/by-path/... link exists in the test environment; detach must
+	// still reach the logout step and complete.
+	if err := (&ISCSIUtil{}).DetachBlockISCSIDisk(*unmapper, mapPath); err != nil {
+		t.Fatalf("DetachBlockISCSIDisk failed: %v", err)
+	}
+	if fakeExec.CommandCalls != len(scripts) {
+		t.Errorf("expected %d iscsiadm calls, got %d", len(scripts), fakeExec.CommandCalls)
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`DetachBlockISCSIDisk` returned an error when the `/dev/disk/by-path/ip-<portal>-iscsi-<iqn>-lun-<n>` symlink for the volume was already missing — which is exactly the state left behind when the iSCSI session is lost while a block-mode pod is still running and teardown happens afterwards:

```
kubelet[...]: Error: failed to validate devicePath: /dev/disk/by-path/ip-<portal>-iscsi-<iqn>-lun-0
```

Every retry failed the same way, the operation never reached its own logout step, and the volume stayed in `node.status.volumesInUse` until kubelet was restarted — during which any pod trying to attach the volume on another node got `Multi-Attach error ... Volume is already exclusively attached to one node`.

Three observations from the issue and verified in the code:

1. `devicePath` is not used after the check — it is computed, logged at V(5), stat'd, and discarded; the detach below uses `portals`, `iqn`, `iface`, `volName`, `initiatorName`.
2. The steps it protects already handle a missing session: `detachISCSIDisk` wraps logout and node-record delete in `ignoreExitCodes(err, exit_ISCSI_ERR_NO_OBJS_FOUND, exit_ISCSI_ERR_SESS_NOT_FOUND)`, and `isSessionBusy` counts plugin directories (portal-iqn prefixed dirs) rather than devices, so the missing link does not affect it.
3. The filesystem-mode equivalent `DetachDisk` performs the same `PathExists` early return, portal/IQN extraction, `isSessionBusy` guard and `detachISCSIDisk` call with no device check at all.

This PR logs the missing link (V(4)) and continues, making the block path behave like the filesystem path. Other `os.Stat` failures (permissions, I/O errors, ...) still abort the detach with an error.

#### Which issue(s) this PR fixes

Fixes #141839

#### Special notes for your reviewer

- Added `TestDetachBlockISCSIDiskMissingDevicePath`: it sets up the plugin `volumeDevices/iface-<iface>/<portal>-<iqn>-lun-0` dir with a persisted `iscsi.json`, no `/dev/disk/by-path` link (none exists in the test environment), and a scripted fake `iscsiadm`. It asserts `DetachBlockISCSIDisk` completes and reaches both the logout and the node-record delete calls. Against the old code it fails with `failed to validate devicePath`.
- Verified against a real cluster by the issue reporter (v1.33.13 with the equivalent change): teardown completed and both volumes left `volumesInUse` on their own.
- The check dates to a6d979dd88 (block volume support) and has been dead-prone since; no release note gating beyond the bugfix one below.

#### Does this PR introduce a user-facing change?

```release-note
Fixed an issue where the in-tree iSCSI detach of a block volume could fail permanently when the /dev/disk/by-path link was already gone (e.g. the iSCSI session was lost before teardown), leaving the volume stuck in node.status.volumesInUse and blocking attach on other nodes.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.

```docs
- [Usage]: https://git.k8s.io/community/contributors/devel/sig-storage/volume-testing.md
```

