### PR TITLE
Differentiate between PG and CPG correctly inside findNodeAndParent

### DIFF
--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -797,7 +797,8 @@ func (pgqi *QueuedPodGroupInfo) Type() fwk.EntityKeyType {
 // AddPod adds a pod to the queued pod group info, if the pod belongs to the pod group.
 // In case of hierarchy, we need to go to all leaf PodGroups.
 func (pgqi *QueuedPodGroupInfo) AddPod(pInfo *QueuedPodInfo) {
-	leafPG, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, *pInfo.Pod.Spec.SchedulingGroup.PodGroupName)
+	key := fwk.PodGroupKey(pInfo.Pod.Namespace, *pInfo.Pod.Spec.SchedulingGroup.PodGroupName)
+	leafPG, _ := findTreeNodeAndParent(pgqi.PodGroupInfo, nil, key)
 	if leafPG == nil {
 		return
 	}
@@ -806,7 +807,6 @@ func (pgqi *QueuedPodGroupInfo) AddPod(pInfo *QueuedPodInfo) {
 		pgqi.QueuedPodInfos = make(map[fwk.EntityKey][]*QueuedPodInfo)
 	}
 
-	key := fwk.PodGroupKey(leafPG.GetNamespace(), leafPG.GetName())
 	index, _ := slices.BinarySearchFunc(pgqi.QueuedPodInfos[key], pInfo, PodGroupMemberPodsOrderingFunc)
 
 	pgqi.QueuedPodInfos[key] = slices.Insert(pgqi.QueuedPodInfos[key], index, pInfo)
@@ -835,7 +835,7 @@ func (pgqi *QueuedPodGroupInfo) RemovePod(pod *v1.Pod) *QueuedPodInfo {
 	}
 
 	// Remove from leaf UnscheduledPods
-	leafPG, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, *pod.Spec.SchedulingGroup.PodGroupName)
+	leafPG, _ := findTreeNodeAndParent(pgqi.PodGroupInfo, nil, key)
 	if leafPG == nil {
 		return removed
 	}
@@ -921,7 +921,7 @@ func (pgqi *QueuedPodGroupInfo) Update(pod *v1.Pod) (*QueuedPodInfo, error) {
 		}
 		err := pInfo.PodInfo.Update(pod)
 
-		leafPG, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, *pod.Spec.SchedulingGroup.PodGroupName)
+		leafPG, _ := findTreeNodeAndParent(pgqi.PodGroupInfo, nil, key)
 		if leafPG != nil {
 			for i, p := range leafPG.UnscheduledPods {
 				if p.Name == pod.Name && p.Namespace == pod.Namespace {
@@ -1002,15 +1002,15 @@ func (pgqi *QueuedPodGroupInfo) SetFlushTimestamp(t time.Time) {
 // AddSubtree adds a subtree to the queued pod group info hierarchy.
 // It shouldn't be called when the QueuedPodGroupInfo's root is a PodGroup (not CompositePodGroup).
 func (pgqi *QueuedPodGroupInfo) AddSubtree(subtree *PodGroupInfo) {
-	parentName := subtree.GetParentCompositePodGroupName()
-	if parentName == nil {
+	parentKey, ok := subtree.GetParentKey()
+	if !ok {
 		return
 	}
 
-	parent, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, *parentName)
+	parent, _ := findTreeNodeAndParent(pgqi.PodGroupInfo, nil, parentKey)
 	if parent != nil {
 		for _, child := range parent.Children {
-			if child.GetName() == subtree.GetName() {
+			if child.GetKey() == subtree.GetKey() {
 				return
 			}
 		}
@@ -1020,7 +1020,7 @@ func (pgqi *QueuedPodGroupInfo) AddSubtree(subtree *PodGroupInfo) {
 
 // UpdateGenericPodGroup updates a generic pod group in the queued pod group info hierarchy.
 func (pgqi *QueuedPodGroupInfo) UpdateGenericPodGroup(gpg *fwk.GenericPodGroup) {
-	node, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, gpg.GetName())
+	node, _ := findTreeNodeAndParent(pgqi.PodGroupInfo, nil, gpg.GetKey())
 	if node != nil {
 		node.GenericPodGroup = gpg
 	}
@@ -1029,14 +1029,14 @@ func (pgqi *QueuedPodGroupInfo) UpdateGenericPodGroup(gpg *fwk.GenericPodGroup) 
 // RemoveGenericPodGroup removes a generic pod group from the queued pod group info hierarchy.
 // It returns a slice of all pods within the hierarchy of the removed pod group / composite pod group.
 func (pgqi *QueuedPodGroupInfo) RemoveGenericPodGroup(gpg *fwk.GenericPodGroup) []*QueuedPodInfo {
-	node, parent := findNodeAndParent(pgqi.PodGroupInfo, nil, gpg.GetName())
+	node, parent := findTreeNodeAndParent(pgqi.PodGroupInfo, nil, gpg.GetKey())
 	if node == nil {
 		return nil
 	}
 
 	if parent != nil {
 		for i, child := range parent.Children {
-			if child.GetName() == gpg.GetName() {
+			if child.GetKey() == gpg.GetKey() {
 				parent.Children = append(parent.Children[:i], parent.Children[i+1:]...)
 				break
 			}
@@ -1046,14 +1046,15 @@ func (pgqi *QueuedPodGroupInfo) RemoveGenericPodGroup(gpg *fwk.GenericPodGroup) 
 	return pgqi.deleteSubtreePods(node)
 }
 
-// findNodeAndParent uses DFS to find a node by name in the hierarchy.
+// findTreeNodeAndParent uses DFS to find a tree node by EntityKey in the hierarchy.
 // It returns the target node and its parent. If the target is the root, parent is nil.
-func findNodeAndParent(curr, parent *PodGroupInfo, name string) (*PodGroupInfo, *PodGroupInfo) {
-	if curr.GetName() == name {
+// The target may be a leaf podgroup or a composite podgroup.
+func findTreeNodeAndParent(curr, parent *PodGroupInfo, key fwk.EntityKey) (*PodGroupInfo, *PodGroupInfo) {
+	if curr.GetKey() == key {
 		return curr, parent
 	}
 	for _, child := range curr.Children {
-		if n, p := findNodeAndParent(child, curr, name); n != nil {
+		if n, p := findTreeNodeAndParent(child, curr, key); n != nil {
 			return n, p
 		}
 	}
@@ -1128,7 +1129,7 @@ func (pgi *PodGroupInfo) GetChildGroups() []*PodGroupInfo {
 	result := make([]*PodGroupInfo, len(pgi.Children))
 	copy(result, pgi.Children)
 	// Sort the children by creation timestamp. If timestamps are equal, compare the child groups
-	// by their names to have a tie-breaker that enforces deterministic order.
+	// by their names, and then entity type to have a tie-breaker that enforces deterministic order.
 	slices.SortFunc(result, func(a, b *PodGroupInfo) int {
 		aTime := a.GetCreationTimestamp()
 		bTime := b.GetCreationTimestamp()
@@ -1141,6 +1142,11 @@ func (pgi *PodGroupInfo) GetChildGroups() []*PodGroupInfo {
 		if a.GetName() < b.GetName() {
 			return -1
 		} else if a.GetName() > b.GetName() {
+			return 1
+		}
+		if a.GetType() < b.GetType() {
+			return -1
+		} else if a.GetType() > b.GetType() {
 			return 1
 		}
 		return 0

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -3623,17 +3623,18 @@ func TestQueuedPodGroupInfo_AddCompositePodGroup(t *testing.T) {
 	cpgNotFoundParent := st.MakeCompositePodGroup().Name("cpg-orphan").Namespace("ns1").ParentCompositePodGroup("non-existent").Obj()
 
 	tests := []struct {
-		name       string
-		initialCPG *schedulingv1alpha3.CompositePodGroup
-		cpgToAdd   *schedulingv1alpha3.CompositePodGroup
-		subtree    *PodGroupInfo
-		setup      func(*QueuedPodGroupInfo)
-		verify     func(*testing.T, *QueuedPodGroupInfo)
+		name    string
+		qpgi    *QueuedPodGroupInfo
+		subtree *PodGroupInfo
+		verify  func(*testing.T, *QueuedPodGroupInfo)
 	}{
 		{
-			name:       "Add child CPG to root",
-			initialCPG: cpgRoot,
-			subtree:    newCompositePodGroupInfoForTest(cpgChild),
+			name: "Add child CPG to root",
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo:   newCompositePodGroupInfoForTest(cpgRoot),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
+			},
+			subtree: newCompositePodGroupInfoForTest(cpgChild),
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.PodGroupInfo.Children) != 1 || qpgi.PodGroupInfo.Children[0].GetName() != "cpg-child" {
 					t.Errorf("Child CPG not added to root correctly")
@@ -3641,9 +3642,12 @@ func TestQueuedPodGroupInfo_AddCompositePodGroup(t *testing.T) {
 			},
 		},
 		{
-			name:       "Add CPG with non-existent parent",
-			initialCPG: cpgRoot,
-			subtree:    newCompositePodGroupInfoForTest(cpgNotFoundParent),
+			name: "Add CPG with non-existent parent",
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo:   newCompositePodGroupInfoForTest(cpgRoot),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
+			},
+			subtree: newCompositePodGroupInfoForTest(cpgNotFoundParent),
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.PodGroupInfo.Children) != 0 {
 					t.Errorf("CPG with non-existent parent should not be added")
@@ -3651,9 +3655,12 @@ func TestQueuedPodGroupInfo_AddCompositePodGroup(t *testing.T) {
 			},
 		},
 		{
-			name:       "Add standalone CPG (no parent set)",
-			initialCPG: cpgRoot,
-			subtree:    newCompositePodGroupInfoForTest(st.MakeCompositePodGroup().Name("standalone-cpg").Namespace("ns1").Obj()),
+			name: "Add standalone CPG (no parent set)",
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo:   newCompositePodGroupInfoForTest(cpgRoot),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
+			},
+			subtree: newCompositePodGroupInfoForTest(st.MakeCompositePodGroup().Name("standalone-cpg").Namespace("ns1").Obj()),
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.PodGroupInfo.Children) != 0 {
 					t.Errorf("Standalone CPG should not be added to another root")
@@ -3661,12 +3668,14 @@ func TestQueuedPodGroupInfo_AddCompositePodGroup(t *testing.T) {
 			},
 		},
 		{
-			name:       "Add deeply nested CPG",
-			initialCPG: cpgRoot,
-			subtree:    newCompositePodGroupInfoForTest(cpgNested),
-			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, newCompositePodGroupInfoForTest(cpgChild))
+			name: "Add deeply nested CPG",
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo: newCompositePodGroupInfoForTest(cpgRoot,
+					newCompositePodGroupInfoForTest(cpgChild),
+				),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			},
+			subtree: newCompositePodGroupInfoForTest(cpgNested),
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.PodGroupInfo.Children[0].Children) != 1 || qpgi.PodGroupInfo.Children[0].Children[0].GetName() != "cpg-nested" {
 					t.Errorf("Deeply nested CPG not added correctly")
@@ -3674,8 +3683,11 @@ func TestQueuedPodGroupInfo_AddCompositePodGroup(t *testing.T) {
 			},
 		},
 		{
-			name:       "Add CPG subtree with nested CPGs",
-			initialCPG: cpgRoot,
+			name: "Add CPG subtree with nested CPGs",
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo:   newCompositePodGroupInfoForTest(cpgRoot),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
+			},
 			subtree: newCompositePodGroupInfoForTest(cpgChild,
 				newCompositePodGroupInfoForTest(cpgNested,
 					newPodGroupInfoForTest(st.MakePodGroup().Name("pg-nested-leaf").Namespace("ns1").ParentCompositePodGroup("cpg-nested").Obj()),
@@ -3693,22 +3705,33 @@ func TestQueuedPodGroupInfo_AddCompositePodGroup(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "Add CPG while having a sibling PG with the same name",
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo: newCompositePodGroupInfoForTest(cpgRoot,
+					newPodGroupInfoForTest(st.MakePodGroup().Name("shared-name").Namespace("ns1").ParentCompositePodGroup("cpg-root").Obj()),
+				),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
+			},
+			subtree: newCompositePodGroupInfoForTest(st.MakeCompositePodGroup().Name("shared-name").Namespace("ns1").ParentCompositePodGroup("cpg-root").Obj()),
+			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
+				if len(qpgi.PodGroupInfo.Children) != 2 {
+					t.Fatalf("Expected 2 children under root CPG, got %d", len(qpgi.PodGroupInfo.Children))
+				}
+				if qpgi.PodGroupInfo.Children[0].GetType() != fwk.PodGroupKeyType || qpgi.PodGroupInfo.Children[0].GetName() != "shared-name" {
+					t.Errorf("First child should be PG shared-name")
+				}
+				if qpgi.PodGroupInfo.Children[1].GetType() != fwk.CompositePodGroupKeyType || qpgi.PodGroupInfo.Children[1].GetName() != "shared-name" {
+					t.Errorf("Second child should be CPG shared-name")
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			qpgi := &QueuedPodGroupInfo{
-				PodGroupInfo: &PodGroupInfo{
-					GenericPodGroup: fwk.NewGenericCompositePodGroup(tt.initialCPG),
-					Children:        make([]*PodGroupInfo, 0),
-				},
-				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
-			}
-			if tt.setup != nil {
-				tt.setup(qpgi)
-			}
-			qpgi.AddSubtree(tt.subtree)
-			tt.verify(t, qpgi)
+			tt.qpgi.AddSubtree(tt.subtree)
+			tt.verify(t, tt.qpgi)
 		})
 	}
 }
@@ -3724,19 +3747,20 @@ func TestQueuedPodGroupInfo_UpdateCompositePodGroup(t *testing.T) {
 	cpgChildUpdated.Annotations = map[string]string{"updated": "true"}
 
 	tests := []struct {
-		name       string
-		initialCPG *schedulingv1alpha3.CompositePodGroup
-		updateCPG  *schedulingv1alpha3.CompositePodGroup
-		setup      func(*QueuedPodGroupInfo)
-		verify     func(*testing.T, *QueuedPodGroupInfo)
+		name      string
+		qpgi      *QueuedPodGroupInfo
+		updateCPG *schedulingv1alpha3.CompositePodGroup
+		verify    func(*testing.T, *QueuedPodGroupInfo)
 	}{
 		{
-			name:       "Update existing child CPG",
-			initialCPG: cpgRoot,
-			updateCPG:  cpgChildUpdated,
-			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, newCompositePodGroupInfoForTest(cpgChild))
+			name: "Update existing child CPG",
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo: newCompositePodGroupInfoForTest(cpgRoot,
+					newCompositePodGroupInfoForTest(cpgChild),
+				),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			},
+			updateCPG: cpgChildUpdated,
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.PodGroupInfo.Children) != 1 || qpgi.PodGroupInfo.Children[0].CompositePodGroup.Annotations["updated"] != "true" {
 					t.Errorf("Child CPG not updated correctly")
@@ -3744,10 +3768,12 @@ func TestQueuedPodGroupInfo_UpdateCompositePodGroup(t *testing.T) {
 			},
 		},
 		{
-			name:       "Update non-existent CPG",
-			initialCPG: cpgRoot,
-			updateCPG:  st.MakeCompositePodGroup().Name("non-existent").Namespace("ns1").Obj(),
-			setup:      func(qpgi *QueuedPodGroupInfo) {},
+			name: "Update non-existent CPG",
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo:   newCompositePodGroupInfoForTest(cpgRoot),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
+			},
+			updateCPG: st.MakeCompositePodGroup().Name("non-existent").Namespace("ns1").Obj(),
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				// No panic or errors expected, should just be a no-op
 				if len(qpgi.PodGroupInfo.Children) != 0 {
@@ -3755,20 +3781,34 @@ func TestQueuedPodGroupInfo_UpdateCompositePodGroup(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "Update CPG while having a sibling PG with the same name",
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo: newCompositePodGroupInfoForTest(cpgRoot,
+					newPodGroupInfoForTest(st.MakePodGroup().Name("cpg-child").Namespace("ns1").ParentCompositePodGroup("cpg-root").MinCount(2).Obj()),
+					newCompositePodGroupInfoForTest(cpgChild),
+				),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
+			},
+			updateCPG: cpgChildUpdated,
+			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
+				if len(qpgi.PodGroupInfo.Children) != 2 {
+					t.Fatalf("Expected 2 children, got %d", len(qpgi.PodGroupInfo.Children))
+				}
+				if qpgi.PodGroupInfo.Children[0].GetType() != fwk.PodGroupKeyType || qpgi.PodGroupInfo.Children[0].PodGroup.Spec.SchedulingPolicy.Gang.MinCount != 2 {
+					t.Errorf("PG sibling was corrupted during CPG update")
+				}
+				if qpgi.PodGroupInfo.Children[1].GetType() != fwk.CompositePodGroupKeyType || qpgi.PodGroupInfo.Children[1].CompositePodGroup.Annotations["updated"] != "true" {
+					t.Errorf("Child CPG not updated correctly")
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			qpgi := &QueuedPodGroupInfo{
-				PodGroupInfo: &PodGroupInfo{
-					GenericPodGroup: fwk.NewGenericCompositePodGroup(tt.initialCPG),
-					Children:        make([]*PodGroupInfo, 0),
-				},
-				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
-			}
-			tt.setup(qpgi)
-			qpgi.UpdateGenericPodGroup(fwk.NewGenericCompositePodGroup(tt.updateCPG))
-			tt.verify(t, qpgi)
+			tt.qpgi.UpdateGenericPodGroup(fwk.NewGenericCompositePodGroup(tt.updateCPG))
+			tt.verify(t, tt.qpgi)
 		})
 	}
 }
@@ -3788,22 +3828,23 @@ func TestQueuedPodGroupInfo_RemoveCompositePodGroup(t *testing.T) {
 	tests := []struct {
 		name      string
 		removeCPG *schedulingv1alpha3.CompositePodGroup
-		setup     func(*QueuedPodGroupInfo)
+		qpgi      *QueuedPodGroupInfo
 		verify    func(*testing.T, *QueuedPodGroupInfo, []*QueuedPodInfo)
 	}{
 		{
 			name:      "Remove child CPG and its subtree pods",
 			removeCPG: cpgChild,
-			setup: func(qpgi *QueuedPodGroupInfo) {
-				nestedInfo := newCompositePodGroupInfoForTest(cpgNested,
-					newPodGroupInfoForTest(pgLeaf),
-				)
-				childInfo := newCompositePodGroupInfoForTest(cpgChild, nestedInfo)
-				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, childInfo)
-
-				pod := st.MakePod().Name("pod1").Namespace("ns1").Obj()
-				pod.Spec.SchedulingGroup = &v1.PodSchedulingGroup{PodGroupName: func() *string { s := "pg-leaf"; return &s }()}
-				qpgi.QueuedPodInfos[podKey] = []*QueuedPodInfo{{PodInfo: &PodInfo{Pod: pod}}}
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo: newCompositePodGroupInfoForTest(cpgRoot,
+					newCompositePodGroupInfoForTest(cpgChild,
+						newCompositePodGroupInfoForTest(cpgNested,
+							newPodGroupInfoForTest(pgLeaf),
+						),
+					),
+				),
+				QueuedPodInfos: map[fwk.EntityKey][]*QueuedPodInfo{
+					podKey: {{PodInfo: &PodInfo{Pod: st.MakePod().Name("pod1").Namespace("ns1").PodGroupName("pg-leaf").Obj()}}},
+				},
 			},
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo, removed []*QueuedPodInfo) {
 				if len(qpgi.PodGroupInfo.Children) != 0 {
@@ -3820,8 +3861,11 @@ func TestQueuedPodGroupInfo_RemoveCompositePodGroup(t *testing.T) {
 		{
 			name:      "Remove non-existent CPG",
 			removeCPG: st.MakeCompositePodGroup().Name("non-existent").Namespace("ns1").Obj(),
-			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, newCompositePodGroupInfoForTest(cpgChild))
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo: newCompositePodGroupInfoForTest(cpgRoot,
+					newCompositePodGroupInfoForTest(cpgChild),
+				),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			},
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo, removed []*QueuedPodInfo) {
 				if len(qpgi.PodGroupInfo.Children) != 1 {
@@ -3835,23 +3879,19 @@ func TestQueuedPodGroupInfo_RemoveCompositePodGroup(t *testing.T) {
 		{
 			name:      "Remove nested CPG with multiple podgroups",
 			removeCPG: cpgNested,
-			setup: func(qpgi *QueuedPodGroupInfo) {
-				pgLeaf2 := st.MakePodGroup().Name("pg-leaf2").Namespace("ns1").ParentCompositePodGroup("cpg-nested").Obj()
-				nestedInfo := newCompositePodGroupInfoForTest(cpgNested,
-					newPodGroupInfoForTest(pgLeaf),
-					newPodGroupInfoForTest(pgLeaf2),
-				)
-				childInfo := newCompositePodGroupInfoForTest(cpgChild, nestedInfo)
-				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, childInfo)
-
-				pod1 := st.MakePod().Name("pod1").Namespace("ns1").Obj()
-				pod1.Spec.SchedulingGroup = &v1.PodSchedulingGroup{PodGroupName: func() *string { s := "pg-leaf"; return &s }()}
-
-				pod2 := st.MakePod().Name("pod2").Namespace("ns1").Obj()
-				pod2.Spec.SchedulingGroup = &v1.PodSchedulingGroup{PodGroupName: func() *string { s := "pg-leaf2"; return &s }()}
-
-				qpgi.QueuedPodInfos[fwk.PodGroupKey("ns1", "pg-leaf")] = []*QueuedPodInfo{{PodInfo: &PodInfo{Pod: pod1}}}
-				qpgi.QueuedPodInfos[fwk.PodGroupKey("ns1", "pg-leaf2")] = []*QueuedPodInfo{{PodInfo: &PodInfo{Pod: pod2}}}
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo: newCompositePodGroupInfoForTest(cpgRoot,
+					newCompositePodGroupInfoForTest(cpgChild,
+						newCompositePodGroupInfoForTest(cpgNested,
+							newPodGroupInfoForTest(pgLeaf),
+							newPodGroupInfoForTest(st.MakePodGroup().Name("pg-leaf2").Namespace("ns1").ParentCompositePodGroup("cpg-nested").Obj()),
+						),
+					),
+				),
+				QueuedPodInfos: map[fwk.EntityKey][]*QueuedPodInfo{
+					fwk.PodGroupKey("ns1", "pg-leaf"):  {{PodInfo: &PodInfo{Pod: st.MakePod().Name("pod1").Namespace("ns1").PodGroupName("pg-leaf").Obj()}}},
+					fwk.PodGroupKey("ns1", "pg-leaf2"): {{PodInfo: &PodInfo{Pod: st.MakePod().Name("pod2").Namespace("ns1").PodGroupName("pg-leaf2").Obj()}}},
+				},
 			},
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo, removed []*QueuedPodInfo) {
 				if len(qpgi.PodGroupInfo.Children) != 1 || len(qpgi.PodGroupInfo.Children[0].Children) != 0 {
@@ -3865,20 +3905,44 @@ func TestQueuedPodGroupInfo_RemoveCompositePodGroup(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:      "Remove CPG while having a sibling PG with the same name",
+			removeCPG: cpgChild,
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo: newCompositePodGroupInfoForTest(cpgRoot,
+					newPodGroupInfoForTest(st.MakePodGroup().Name("cpg-child").Namespace("ns1").ParentCompositePodGroup("cpg-root").Obj()),
+					newCompositePodGroupInfoForTest(cpgChild,
+						newCompositePodGroupInfoForTest(cpgNested,
+							newPodGroupInfoForTest(pgLeaf),
+						),
+					),
+				),
+				QueuedPodInfos: map[fwk.EntityKey][]*QueuedPodInfo{
+					podKey:                              {{PodInfo: &PodInfo{Pod: st.MakePod().Name("pod1").Namespace("ns1").PodGroupName("pg-leaf").Obj()}}},
+					fwk.PodGroupKey("ns1", "cpg-child"): {{PodInfo: &PodInfo{Pod: st.MakePod().Name("pod-sibling").Namespace("ns1").PodGroupName("cpg-child").Obj()}}},
+				},
+			},
+			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo, removed []*QueuedPodInfo) {
+				if len(qpgi.PodGroupInfo.Children) != 1 || qpgi.PodGroupInfo.Children[0].GetType() != fwk.PodGroupKeyType {
+					t.Errorf("Expected only sibling PG to remain, got %v", qpgi.PodGroupInfo.Children)
+				}
+				if len(removed) != 1 || removed[0].Pod.Name != "pod1" {
+					t.Errorf("Subtree pods not correctly removed and returned: %v", removed)
+				}
+				if len(qpgi.QueuedPodInfos[podKey]) != 0 {
+					t.Errorf("Nested pod not removed from QueuedPodInfos map")
+				}
+				if len(qpgi.QueuedPodInfos[fwk.PodGroupKey("ns1", "cpg-child")]) != 1 {
+					t.Errorf("Sibling PG pods should not have been removed")
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			qpgi := &QueuedPodGroupInfo{
-				PodGroupInfo: &PodGroupInfo{
-					GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgRoot),
-					Children:        make([]*PodGroupInfo, 0),
-				},
-				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
-			}
-			tt.setup(qpgi)
-			removed := qpgi.RemoveGenericPodGroup(fwk.NewGenericCompositePodGroup(tt.removeCPG))
-			tt.verify(t, qpgi, removed)
+			removed := tt.qpgi.RemoveGenericPodGroup(fwk.NewGenericCompositePodGroup(tt.removeCPG))
+			tt.verify(t, tt.qpgi, removed)
 		})
 	}
 }
@@ -3894,15 +3958,18 @@ func TestQueuedPodGroupInfo_AddPodGroup(t *testing.T) {
 	pgNotFoundParent := st.MakePodGroup().Name("pg-orphan").Namespace("ns1").ParentCompositePodGroup("non-existent").Obj()
 
 	tests := []struct {
-		name       string
-		initialCPG *schedulingv1alpha3.CompositePodGroup
-		pgToAdd    *schedulingv1beta1.PodGroup
-		verify     func(*testing.T, *QueuedPodGroupInfo)
+		name    string
+		qpgi    *QueuedPodGroupInfo
+		pgToAdd *schedulingv1beta1.PodGroup
+		verify  func(*testing.T, *QueuedPodGroupInfo)
 	}{
 		{
-			name:       "Add child PG to root CPG",
-			initialCPG: cpgRoot,
-			pgToAdd:    pgChild,
+			name: "Add child PG to root CPG",
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo:   newCompositePodGroupInfoForTest(cpgRoot),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
+			},
+			pgToAdd: pgChild,
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.PodGroupInfo.Children) != 1 || qpgi.PodGroupInfo.Children[0].GetName() != "pg-child" {
 					t.Errorf("Child PG not added to root correctly")
@@ -3913,9 +3980,12 @@ func TestQueuedPodGroupInfo_AddPodGroup(t *testing.T) {
 			},
 		},
 		{
-			name:       "Add standalone PG (should be ignored by hierarchy builder as it's the root itself)",
-			initialCPG: cpgRoot,
-			pgToAdd:    pgStandalone,
+			name: "Add standalone PG (should be ignored by hierarchy builder as it's the root itself)",
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo:   newCompositePodGroupInfoForTest(cpgRoot),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
+			},
+			pgToAdd: pgStandalone,
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.PodGroupInfo.Children) != 0 {
 					t.Errorf("Standalone PG should not be added to a root CPG's children")
@@ -3923,12 +3993,36 @@ func TestQueuedPodGroupInfo_AddPodGroup(t *testing.T) {
 			},
 		},
 		{
-			name:       "Add PG with non-existent parent",
-			initialCPG: cpgRoot,
-			pgToAdd:    pgNotFoundParent,
+			name: "Add PG with non-existent parent",
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo:   newCompositePodGroupInfoForTest(cpgRoot),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
+			},
+			pgToAdd: pgNotFoundParent,
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.PodGroupInfo.Children) != 0 {
 					t.Errorf("PG with non-existent parent should not be added")
+				}
+			},
+		},
+		{
+			name: "Add child PG to parent CPG while having a sibling PG with the same name as the parent",
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo: newCompositePodGroupInfoForTest(cpgRoot,
+					newPodGroupInfoForTest(st.MakePodGroup().Name("cpg-intermediate").Namespace("ns1").ParentCompositePodGroup("cpg-root").Obj()),
+					newCompositePodGroupInfoForTest(st.MakeCompositePodGroup().Name("cpg-intermediate").Namespace("ns1").ParentCompositePodGroup("cpg-root").Obj()),
+				),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
+			},
+			pgToAdd: st.MakePodGroup().Name("pg-child-nested").Namespace("ns1").ParentCompositePodGroup("cpg-intermediate").Obj(),
+			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
+				pgSiblingNode := qpgi.PodGroupInfo.Children[0]
+				cpgIntermediateNode := qpgi.PodGroupInfo.Children[1]
+				if len(pgSiblingNode.Children) != 0 {
+					t.Errorf("Child PG was incorrectly added to PG node")
+				}
+				if len(cpgIntermediateNode.Children) != 1 || cpgIntermediateNode.Children[0].GetName() != "pg-child-nested" {
+					t.Errorf("Child PG was not added to intermediate CPG node")
 				}
 			},
 		},
@@ -3936,15 +4030,8 @@ func TestQueuedPodGroupInfo_AddPodGroup(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			qpgi := &QueuedPodGroupInfo{
-				PodGroupInfo: &PodGroupInfo{
-					GenericPodGroup: fwk.NewGenericCompositePodGroup(tt.initialCPG),
-					Children:        make([]*PodGroupInfo, 0),
-				},
-				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
-			}
-			qpgi.AddSubtree(newPodGroupInfoForTest(tt.pgToAdd))
-			tt.verify(t, qpgi)
+			tt.qpgi.AddSubtree(newPodGroupInfoForTest(tt.pgToAdd))
+			tt.verify(t, tt.qpgi)
 		})
 	}
 }
@@ -3963,19 +4050,17 @@ func TestQueuedPodGroupInfo_UpdatePodGroup(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		setup    func() *QueuedPodGroupInfo
+		qpgi     *QueuedPodGroupInfo
 		updatePG *schedulingv1beta1.PodGroup
 		verify   func(*testing.T, *QueuedPodGroupInfo)
 	}{
 		{
 			name: "Update child PG in CPG hierarchy",
-			setup: func() *QueuedPodGroupInfo {
-				return &QueuedPodGroupInfo{
-					PodGroupInfo: newCompositePodGroupInfoForTest(cpgRoot,
-						newPodGroupInfoForTest(pgChild),
-					),
-					QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
-				}
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo: newCompositePodGroupInfoForTest(cpgRoot,
+					newPodGroupInfoForTest(pgChild),
+				),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			},
 			updatePG: pgChildUpdated,
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
@@ -3986,11 +4071,9 @@ func TestQueuedPodGroupInfo_UpdatePodGroup(t *testing.T) {
 		},
 		{
 			name: "Update standalone PG",
-			setup: func() *QueuedPodGroupInfo {
-				return &QueuedPodGroupInfo{
-					PodGroupInfo:   newPodGroupInfoForTest(pgStandalone),
-					QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
-				}
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo:   newPodGroupInfoForTest(pgStandalone),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			},
 			updatePG: pgStandaloneUpdated,
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
@@ -4001,11 +4084,9 @@ func TestQueuedPodGroupInfo_UpdatePodGroup(t *testing.T) {
 		},
 		{
 			name: "Update non-existent PG",
-			setup: func() *QueuedPodGroupInfo {
-				return &QueuedPodGroupInfo{
-					PodGroupInfo:   newCompositePodGroupInfoForTest(cpgRoot),
-					QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
-				}
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo:   newCompositePodGroupInfoForTest(cpgRoot),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			},
 			updatePG: st.MakePodGroup().Name("non-existent").Namespace("ns1").Obj(),
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
@@ -4014,13 +4095,31 @@ func TestQueuedPodGroupInfo_UpdatePodGroup(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "Update PG while having a sibling CPG with the same name",
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo: newCompositePodGroupInfoForTest(cpgRoot,
+					newCompositePodGroupInfoForTest(st.MakeCompositePodGroup().Name("shared-name").Namespace("ns1").ParentCompositePodGroup("cpg-root").Obj()),
+					newPodGroupInfoForTest(st.MakePodGroup().Name("shared-name").Namespace("ns1").ParentCompositePodGroup("cpg-root").MinCount(2).Obj()),
+				),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
+			},
+			updatePG: st.MakePodGroup().Name("shared-name").Namespace("ns1").ParentCompositePodGroup("cpg-root").MinCount(10).Obj(),
+			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
+				if qpgi.PodGroupInfo.Children[0].GetType() != fwk.CompositePodGroupKeyType {
+					t.Errorf("CPG node was overwritten during PG update")
+				}
+				if qpgi.PodGroupInfo.Children[1].GetType() != fwk.PodGroupKeyType || qpgi.PodGroupInfo.Children[1].PodGroup.Spec.SchedulingPolicy.Gang.MinCount != 10 {
+					t.Errorf("PG node was not updated correctly")
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			qpgi := tt.setup()
-			qpgi.UpdateGenericPodGroup(fwk.NewGenericPodGroup(tt.updatePG))
-			tt.verify(t, qpgi)
+			tt.qpgi.UpdateGenericPodGroup(fwk.NewGenericPodGroup(tt.updatePG))
+			tt.verify(t, tt.qpgi)
 		})
 	}
 }
@@ -4040,19 +4139,19 @@ func TestQueuedPodGroupInfo_RemovePodGroup(t *testing.T) {
 	tests := []struct {
 		name     string
 		removePG *schedulingv1beta1.PodGroup
-		setup    func(*QueuedPodGroupInfo)
+		qpgi     *QueuedPodGroupInfo
 		verify   func(*testing.T, *QueuedPodGroupInfo, []*QueuedPodInfo)
 	}{
 		{
 			name:     "Remove child PG and its pods",
 			removePG: pgChild,
-			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo = newCompositePodGroupInfoForTest(cpgRoot,
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo: newCompositePodGroupInfoForTest(cpgRoot,
 					newPodGroupInfoForTest(pgChild),
-				)
-				pod := st.MakePod().Name("pod1").Namespace("ns1").Obj()
-				pod.Spec.SchedulingGroup = &v1.PodSchedulingGroup{PodGroupName: func() *string { s := "pg-child"; return &s }()}
-				qpgi.QueuedPodInfos[podKeyChild] = []*QueuedPodInfo{{PodInfo: &PodInfo{Pod: pod}}}
+				),
+				QueuedPodInfos: map[fwk.EntityKey][]*QueuedPodInfo{
+					podKeyChild: {{PodInfo: &PodInfo{Pod: st.MakePod().Name("pod1").Namespace("ns1").PodGroupName("pg-child").Obj()}}},
+				},
 			},
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo, removed []*QueuedPodInfo) {
 				if len(qpgi.PodGroupInfo.Children) != 0 {
@@ -4069,11 +4168,11 @@ func TestQueuedPodGroupInfo_RemovePodGroup(t *testing.T) {
 		{
 			name:     "Remove standalone PG and its pods (root removal)",
 			removePG: pgStandalone,
-			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo = newPodGroupInfoForTest(pgStandalone)
-				pod := st.MakePod().Name("pod2").Namespace("ns1").Obj()
-				pod.Spec.SchedulingGroup = &v1.PodSchedulingGroup{PodGroupName: func() *string { s := "pg-standalone"; return &s }()}
-				qpgi.QueuedPodInfos[podKeyStandalone] = []*QueuedPodInfo{{PodInfo: &PodInfo{Pod: pod}}}
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo: newPodGroupInfoForTest(pgStandalone),
+				QueuedPodInfos: map[fwk.EntityKey][]*QueuedPodInfo{
+					podKeyStandalone: {{PodInfo: &PodInfo{Pod: st.MakePod().Name("pod2").Namespace("ns1").PodGroupName("pg-standalone").Obj()}}},
+				},
 			},
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo, removed []*QueuedPodInfo) {
 				// For standalone PG, removing the root essentially clears the QueuedPodInfos because
@@ -4086,16 +4185,40 @@ func TestQueuedPodGroupInfo_RemovePodGroup(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:     "Remove PG while having a sibling CPG with the same name",
+			removePG: st.MakePodGroup().Name("shared-name").Namespace("ns1").ParentCompositePodGroup("cpg-root").Obj(),
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo: newCompositePodGroupInfoForTest(cpgRoot,
+					newCompositePodGroupInfoForTest(
+						st.MakeCompositePodGroup().Name("shared-name").Namespace("ns1").ParentCompositePodGroup("cpg-root").Obj(),
+						newPodGroupInfoForTest(st.MakePodGroup().Name("pg-nested").Namespace("ns1").ParentCompositePodGroup("shared-name").Obj()),
+					),
+					newPodGroupInfoForTest(st.MakePodGroup().Name("shared-name").Namespace("ns1").ParentCompositePodGroup("cpg-root").Obj()),
+				),
+				QueuedPodInfos: map[fwk.EntityKey][]*QueuedPodInfo{
+					fwk.PodGroupKey("ns1", "pg-nested"):   {{PodInfo: &PodInfo{Pod: st.MakePod().Name("pod-nested").Namespace("ns1").PodGroupName("pg-nested").Obj()}}},
+					fwk.PodGroupKey("ns1", "shared-name"): {{PodInfo: &PodInfo{Pod: st.MakePod().Name("pod-sibling").Namespace("ns1").PodGroupName("shared-name").Obj()}}},
+				},
+			},
+			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo, removed []*QueuedPodInfo) {
+				if len(removed) != 1 || removed[0].Pod.Name != "pod-sibling" {
+					t.Fatalf("Expected pod-sibling removed, got %v", removed)
+				}
+				if len(qpgi.PodGroupInfo.Children) != 1 || qpgi.PodGroupInfo.Children[0].GetType() != fwk.CompositePodGroupKeyType {
+					t.Fatalf("Expected only CPG child to remain, got %v", qpgi.PodGroupInfo.Children)
+				}
+				if len(qpgi.QueuedPodInfos[fwk.PodGroupKey("ns1", "pg-nested")]) != 1 {
+					t.Errorf("CPG's nested pods should not have been removed")
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			qpgi := &QueuedPodGroupInfo{
-				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
-			}
-			tt.setup(qpgi)
-			removed := qpgi.RemoveGenericPodGroup(fwk.NewGenericPodGroup(tt.removePG))
-			tt.verify(t, qpgi, removed)
+			removed := tt.qpgi.RemoveGenericPodGroup(fwk.NewGenericPodGroup(tt.removePG))
+			tt.verify(t, tt.qpgi, removed)
 		})
 	}
 }
@@ -4111,20 +4234,17 @@ func TestQueuedPodGroupInfo_AddPod(t *testing.T) {
 	tests := []struct {
 		name   string
 		pod    *v1.Pod
-		setup  func(*QueuedPodGroupInfo)
+		qpgi   *QueuedPodGroupInfo
 		verify func(*testing.T, *QueuedPodGroupInfo)
 	}{
 		{
 			name: "Add pod to CPG hierarchy leaf PG",
-			pod: func() *v1.Pod {
-				p := st.MakePod().Name("pod1").Namespace("ns1").Obj()
-				p.Spec.SchedulingGroup = &v1.PodSchedulingGroup{PodGroupName: func() *string { s := "pg-child"; return &s }()}
-				return p
-			}(),
-			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo = newCompositePodGroupInfoForTest(cpgRoot,
+			pod:  st.MakePod().Name("pod1").Namespace("ns1").PodGroupName("pg-child").Obj(),
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo: newCompositePodGroupInfoForTest(cpgRoot,
 					newPodGroupInfoForTest(pgChild),
-				)
+				),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			},
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.QueuedPodInfos[podKeyChild]) != 1 {
@@ -4134,13 +4254,10 @@ func TestQueuedPodGroupInfo_AddPod(t *testing.T) {
 		},
 		{
 			name: "Add pod to standalone PG",
-			pod: func() *v1.Pod {
-				p := st.MakePod().Name("pod2").Namespace("ns1").Obj()
-				p.Spec.SchedulingGroup = &v1.PodSchedulingGroup{PodGroupName: func() *string { s := "pg-standalone"; return &s }()}
-				return p
-			}(),
-			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo = newPodGroupInfoForTest(pgStandalone)
+			pod:  st.MakePod().Name("pod2").Namespace("ns1").PodGroupName("pg-standalone").Obj(),
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo:   newPodGroupInfoForTest(pgStandalone),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			},
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.QueuedPodInfos[podKeyStandalone]) != 1 {
@@ -4150,13 +4267,10 @@ func TestQueuedPodGroupInfo_AddPod(t *testing.T) {
 		},
 		{
 			name: "Add pod that does not match leaf PG name",
-			pod: func() *v1.Pod {
-				p := st.MakePod().Name("pod3").Namespace("ns1").Obj()
-				p.Spec.SchedulingGroup = &v1.PodSchedulingGroup{PodGroupName: func() *string { s := "non-existent-pg"; return &s }()}
-				return p
-			}(),
-			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo = newPodGroupInfoForTest(pgStandalone)
+			pod:  st.MakePod().Name("pod3").Namespace("ns1").PodGroupName("non-existent-pg").Obj(),
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo:   newPodGroupInfoForTest(pgStandalone),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			},
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.QueuedPodInfos) != 0 {
@@ -4164,17 +4278,37 @@ func TestQueuedPodGroupInfo_AddPod(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "Add pod to a leaf PG, where the PG and its parent CPG share the same name",
+			pod:  st.MakePod().Name("pod4").Namespace("ns1").PodGroupName("shared-name").Obj(),
+			qpgi: &QueuedPodGroupInfo{
+				PodGroupInfo: newCompositePodGroupInfoForTest(
+					st.MakeCompositePodGroup().Name("shared-name").Namespace("ns1").Obj(),
+					newPodGroupInfoForTest(st.MakePodGroup().Name("shared-name").Namespace("ns1").ParentCompositePodGroup("shared-name").Obj()),
+				),
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
+			},
+			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
+				key := fwk.PodGroupKey("ns1", "shared-name")
+				if len(qpgi.QueuedPodInfos[key]) != 1 {
+					t.Fatalf("Expected 1 queued pod info for leaf PG key, got %d", len(qpgi.QueuedPodInfos[key]))
+				}
+				leafInfo := qpgi.PodGroupInfo.Children[0]
+				if len(leafInfo.UnscheduledPods) != 1 {
+					t.Fatalf("Expected 1 unscheduled pod in leaf PG, got %d", len(leafInfo.UnscheduledPods))
+				}
+				if len(qpgi.PodGroupInfo.UnscheduledPods) != 0 {
+					t.Fatalf("Expected 0 unscheduled pods directly on root CPG, got %d", len(qpgi.PodGroupInfo.UnscheduledPods))
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			qpgi := &QueuedPodGroupInfo{
-				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
-			}
-			tt.setup(qpgi)
 			pInfo := &QueuedPodInfo{PodInfo: &PodInfo{Pod: tt.pod}}
-			qpgi.AddPod(pInfo)
-			tt.verify(t, qpgi)
+			tt.qpgi.AddPod(pInfo)
+			tt.verify(t, tt.qpgi)
 		})
 	}
 }
@@ -4183,17 +4317,45 @@ func TestQueuedPodGroupInfo_UpdateAndRemovePod(t *testing.T) {
 	pgStandalone := st.MakePodGroup().Name("pg-standalone").Namespace("ns1").Obj()
 	podKeyStandalone := fwk.PodGroupKey("ns1", "pg-standalone")
 
-	pod1 := st.MakePod().Name("pod1").Namespace("ns1").Obj()
-	pod1.Spec.SchedulingGroup = &v1.PodSchedulingGroup{PodGroupName: func() *string { s := "pg-standalone"; return &s }()}
+	pod1 := st.MakePod().Name("pod1").Namespace("ns1").PodGroupName("pg-standalone").Obj()
 	pod1Updated := pod1.DeepCopy()
 	pod1Updated.Annotations = map[string]string{"updated": "true"}
 
+	cpgSameName := st.MakeCompositePodGroup().Name("shared-name").Namespace("ns1").Obj()
+	pgSameName := st.MakePodGroup().Name("shared-name").Namespace("ns1").ParentCompositePodGroup("shared-name").Obj()
+	podShared := st.MakePod().Name("pod-shared").Namespace("ns1").PodGroupName("shared-name").Obj()
+	podSharedUpdated := podShared.DeepCopy()
+	podSharedUpdated.Annotations = map[string]string{"updated": "true"}
+	podKeyShared := fwk.PodGroupKey("ns1", "shared-name")
+
+	newStandaloneQPGInfo := func() *QueuedPodGroupInfo {
+		return &QueuedPodGroupInfo{
+			PodGroupInfo: newPodGroupInfoForTest(pgStandalone),
+			QueuedPodInfos: map[fwk.EntityKey][]*QueuedPodInfo{
+				podKeyStandalone: {{PodInfo: &PodInfo{Pod: pod1}}},
+			},
+		}
+	}
+
+	newSharedNameQPGInfo := func() *QueuedPodGroupInfo {
+		leafInfo := newPodGroupInfoForTest(pgSameName)
+		leafInfo.UnscheduledPods = []*v1.Pod{podShared}
+		return &QueuedPodGroupInfo{
+			PodGroupInfo: newCompositePodGroupInfoForTest(cpgSameName, leafInfo),
+			QueuedPodInfos: map[fwk.EntityKey][]*QueuedPodInfo{
+				podKeyShared: {{PodInfo: &PodInfo{Pod: podShared}}},
+			},
+		}
+	}
+
 	tests := []struct {
 		name    string
+		qpgi    *QueuedPodGroupInfo
 		execute func(*testing.T, *QueuedPodGroupInfo)
 	}{
 		{
 			name: "Update Pod",
+			qpgi: newStandaloneQPGInfo(),
 			execute: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				pInfo, err := qpgi.Update(pod1Updated)
 				if err != nil {
@@ -4206,9 +4368,9 @@ func TestQueuedPodGroupInfo_UpdateAndRemovePod(t *testing.T) {
 		},
 		{
 			name: "Update Pod not found",
+			qpgi: newStandaloneQPGInfo(),
 			execute: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
-				podNotFound := st.MakePod().Name("pod-not-found").Namespace("ns1").Obj()
-				podNotFound.Spec.SchedulingGroup = &v1.PodSchedulingGroup{PodGroupName: func() *string { s := "pg-standalone"; return &s }()}
+				podNotFound := st.MakePod().Name("pod-not-found").Namespace("ns1").PodGroupName("pg-standalone").Obj()
 				_, err := qpgi.Update(podNotFound)
 				if err == nil {
 					t.Errorf("Expected error when updating non-existent pod")
@@ -4217,6 +4379,7 @@ func TestQueuedPodGroupInfo_UpdateAndRemovePod(t *testing.T) {
 		},
 		{
 			name: "Remove Pod",
+			qpgi: newStandaloneQPGInfo(),
 			execute: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				removed := qpgi.RemovePod(pod1)
 				if removed == nil || removed.Pod.Name != "pod1" {
@@ -4229,12 +4392,46 @@ func TestQueuedPodGroupInfo_UpdateAndRemovePod(t *testing.T) {
 		},
 		{
 			name: "Remove Pod not found",
+			qpgi: newStandaloneQPGInfo(),
 			execute: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
-				podNotFound := st.MakePod().Name("pod-not-found").Namespace("ns1").Obj()
-				podNotFound.Spec.SchedulingGroup = &v1.PodSchedulingGroup{PodGroupName: func() *string { s := "pg-standalone"; return &s }()}
+				podNotFound := st.MakePod().Name("pod-not-found").Namespace("ns1").PodGroupName("pg-standalone").Obj()
 				removed := qpgi.RemovePod(podNotFound)
 				if removed != nil {
 					t.Errorf("Expected nil when removing non-existent pod")
+				}
+			},
+		},
+		{
+			name: "Update Pod in a leaf PG, where the PG and its parent CPG share the same name",
+			qpgi: newSharedNameQPGInfo(),
+			execute: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
+				pInfo, err := qpgi.Update(podSharedUpdated)
+				if err != nil {
+					t.Fatalf("Update failed: %v", err)
+				}
+				if pInfo.Pod.Annotations["updated"] != "true" {
+					t.Errorf("Pod was not correctly updated")
+				}
+				leafInfo := qpgi.PodGroupInfo.Children[0]
+				if len(leafInfo.UnscheduledPods) != 1 || leafInfo.UnscheduledPods[0].Annotations["updated"] != "true" {
+					t.Errorf("Leaf PG UnscheduledPods was not updated")
+				}
+			},
+		},
+		{
+			name: "Remove Pod from a leaf PG, where the PG and its parent CPG share the same name",
+			qpgi: newSharedNameQPGInfo(),
+			execute: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
+				removed := qpgi.RemovePod(podShared)
+				if removed == nil || removed.Pod.Name != "pod-shared" {
+					t.Fatalf("Pod not correctly removed")
+				}
+				if len(qpgi.QueuedPodInfos[podKeyShared]) != 0 {
+					t.Errorf("Pod still present in QueuedPodInfos")
+				}
+				leafInfo := qpgi.PodGroupInfo.Children[0]
+				if len(leafInfo.UnscheduledPods) != 0 {
+					t.Errorf("Leaf PG UnscheduledPods was not cleared")
 				}
 			},
 		},
@@ -4242,14 +4439,7 @@ func TestQueuedPodGroupInfo_UpdateAndRemovePod(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			qpgi := &QueuedPodGroupInfo{
-				PodGroupInfo:   newPodGroupInfoForTest(pgStandalone),
-				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
-			}
-			pInfo1 := &QueuedPodInfo{PodInfo: &PodInfo{Pod: pod1}}
-			qpgi.QueuedPodInfos[podKeyStandalone] = []*QueuedPodInfo{pInfo1}
-
-			tt.execute(t, qpgi)
+			tt.execute(t, tt.qpgi)
 		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig scheduling

#### What this PR does / why we need it:
After unifying `PodGroup` and `CompositePodGroup`: https://github.com/kubernetes/kubernetes/pull/141081, we may have case where `findNodeAndParent()` would cause lookup collision and return unexpected results (e.g. we are looking for a `GenericPodGroup` of type **CPG**, but a different tree node is returned (a `GenericPodGroup` of type **PG** because they both have the same name)).

The fix is to make sure in `findNodeAndParent()` we are looking up an entity with both same name and type and not name only.

#### Additional Changes include:
- Changed the method name: `findNodeAndParent` into `findTreeNodeAndParent` to avoid confusion because in context of kubernetes scheduler, this usually refer to k8s nodes.
- Test cases included across all actions that involve `findNodeAndParent`. where a cpg and pg has the same name. and a collision would happen if we don't compare types.

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
```release-note
Fix a bug in scheduler where a PodGroup and CompositePodGroup sharing the same name may cause lookup collisions.
```