### PR TITLE
Linting: enable waitgroupgo hint

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -568,13 +568,6 @@ linters:
         # context cancellation and also
         # addresses other pain points.
         - testingcontext
-        # Replace wg.Add(1)/go/wg.Done() with wg.Go.
-        #
-        # A useful hint leading to shorter code.
-        # Makes wait.Group obsolete.
-        # Please enable when all supported Kubernetes versions
-        # are on GoLang 1.25+
-        - waitgroupgo
 
     revive:
       # Only these rules are enabled.

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -367,15 +367,13 @@ linters:
         # context cancellation and also
         # addresses other pain points.
         - testingcontext
+        {{- if .Base }}
         # Replace wg.Add(1)/go/wg.Done() with wg.Go.
         #
         # A useful hint leading to shorter code.
         # Makes wait.Group obsolete.
-        {{- if .Hints }}
-        # Please enable when all supported Kubernetes versions
-        # are on GoLang 1.25+
-        {{- end }}
         - waitgroupgo
+        {{- end }}
 
     revive:
       # Only these rules are enabled.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Now that all supported branches are on Go 1.25+, we can enable the waitgroupgo hint to encourage the use of waitgroup.Go instead of waitgroup.Add/waitgrou.Done in new code.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

NO.