### PR TITLE
Linting: drop obsolete "unused" exclusion

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -68,17 +68,6 @@ linters:
         text: comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form|comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form|exported (.+) should have comment( \(or a comment on this block\))? or be unexported|package comment should be of the form "(.+)...|comment on exported (.+) should be of the form "(.+)...|should have a package comment
         path-except: cmd/kubeadm
 
-      # The unused linter that comes from staticcheck currently does not handle types which implement
-      # a generic interface. The linter incorrectly reports the implementations of unexported
-      # interface methods as unused. See https://github.com/dominikh/go-tools/issues/1294.
-      # Rather than exporting the interface methods, which makes the error go away but changes the
-      # semantics of the code, we ignore this error for affected files.
-      # This can be removed when the staticcheck implementation of this rule is fixed, which may
-      # depend on https://github.com/golang/go/issues/63982.
-      - linters:
-          - unused
-        path: staging/src/k8s.io/client-go/util/workqueue/metrics.go
-
       # SSA Extract calls are allowed in tests.
       - linters:
           - forbidigo

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -68,17 +68,6 @@ linters:
         text: comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form|comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form|exported (.+) should have comment( \(or a comment on this block\))? or be unexported|package comment should be of the form "(.+)...|comment on exported (.+) should be of the form "(.+)...|should have a package comment
         path-except: cmd/kubeadm
 
-      # The unused linter that comes from staticcheck currently does not handle types which implement
-      # a generic interface. The linter incorrectly reports the implementations of unexported
-      # interface methods as unused. See https://github.com/dominikh/go-tools/issues/1294.
-      # Rather than exporting the interface methods, which makes the error go away but changes the
-      # semantics of the code, we ignore this error for affected files.
-      # This can be removed when the staticcheck implementation of this rule is fixed, which may
-      # depend on https://github.com/golang/go/issues/63982.
-      - linters:
-          - unused
-        path: staging/src/k8s.io/client-go/util/workqueue/metrics.go
-
       # SSA Extract calls are allowed in tests.
       - linters:
           - forbidigo

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -68,17 +68,6 @@ linters:
         text: comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form|comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form|exported (.+) should have comment( \(or a comment on this block\))? or be unexported|package comment should be of the form "(.+)...|comment on exported (.+) should be of the form "(.+)...|should have a package comment
         path-except: cmd/kubeadm
 
-      # The unused linter that comes from staticcheck currently does not handle types which implement
-      # a generic interface. The linter incorrectly reports the implementations of unexported
-      # interface methods as unused. See https://github.com/dominikh/go-tools/issues/1294.
-      # Rather than exporting the interface methods, which makes the error go away but changes the
-      # semantics of the code, we ignore this error for affected files.
-      # This can be removed when the staticcheck implementation of this rule is fixed, which may
-      # depend on https://github.com/golang/go/issues/63982.
-      - linters:
-          - unused
-        path: staging/src/k8s.io/client-go/util/workqueue/metrics.go
-
       # SSA Extract calls are allowed in tests.
       - linters:
           - forbidigo


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

https://github.com/dominikh/go-tools/issues/1294 has been fixed, and the excluded unused linter no longer flags
staging/src/k8s.io/client-go/util/workqueue/metrics.go; this removes the exclusion.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

NO.