### PR TITLE
test(e2e): label DRA Node Allocatable Resources tests with DRA

### DIFF
--- a/test/e2e/dra/dra_node_allocatable_resources.go
+++ b/test/e2e/dra/dra_node_allocatable_resources.go
@@ -1036,10 +1036,13 @@ func mapToResizableContainerInfo(containers []draContainerInfo) []podresize.Resi
 	return res
 }
 
-var _ = framework.SIGDescribe("node")("DRA Node Allocatable Resources", framework.WithLabel("DRA"), framework.WithSerial(), feature.DynamicResourceAllocation, framework.WithFeatureGate(features.DRANodeAllocatableResources), framework.WithFeatureGate(features.InPlacePodLevelResourcesVerticalScaling), func() {
+var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), "Node Allocatable Resources", feature.DynamicResourceAllocation, framework.WithFeatureGate(features.DRANodeAllocatableResources), func() {
 	f := framework.NewDefaultFramework("dra-node-allocatable-resources")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 	doNodeAllocatableCgroupsTests(f)
-	doNodeAllocatableResizeTests(f)
+
+	f.Context("resize", framework.WithFeatureGate(features.InPlacePodLevelResourcesVerticalScaling), func() {
+		doNodeAllocatableResizeTests(f)
+	})
 })

--- a/test/e2e/dra/dra_node_allocatable_resources.go
+++ b/test/e2e/dra/dra_node_allocatable_resources.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package node
+package dra
 
 import (
 	"context"
@@ -42,7 +42,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	"k8s.io/kubernetes/test/utils/client-go/ktesting"
 )
 
@@ -1037,15 +1036,9 @@ func mapToResizableContainerInfo(containers []draContainerInfo) []podresize.Resi
 	return res
 }
 
-var _ = SIGDescribe("DRA Node Allocatable Resources", framework.WithSerial(), feature.DynamicResourceAllocation, framework.WithFeatureGate(features.DRANodeAllocatableResources), framework.WithFeatureGate(features.InPlacePodLevelResourcesVerticalScaling), func() {
+var _ = framework.SIGDescribe("node")("DRA Node Allocatable Resources", framework.WithLabel("DRA"), framework.WithSerial(), feature.DynamicResourceAllocation, framework.WithFeatureGate(features.DRANodeAllocatableResources), framework.WithFeatureGate(features.InPlacePodLevelResourcesVerticalScaling), func() {
 	f := framework.NewDefaultFramework("dra-node-allocatable-resources")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
-
-	ginkgo.BeforeEach(func(ctx context.Context) {
-		if framework.NodeOSDistroIs("windows") {
-			e2eskipper.Skipf("not supported on windows -- skipping")
-		}
-	})
 
 	doNodeAllocatableCgroupsTests(f)
 	doNodeAllocatableResizeTests(f)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The DRA Node Allocatable Resources e2e test was missing the DRA label. 

Because [DRA CI Job](https://github.com/kubernetes/test-infra/blob/c88faa12d563498f3e81f57b03b79543241d0363/config/jobs/kubernetes/sig-node/dra-presubmit.yaml#L82) filter tests using:
`--label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !Flaky"`
The suite was never selected by the DRA test jobs.

Also move the test to `test/e2e/dra/` since these are cluster E2E tests.

#### Which issue(s) this PR is related to:
N/A
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:
YES. AI was used to validate the fix.

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
