### PR TITLE
validation: reject qualified names with more than one slash and add t…

### DIFF
--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -1635,11 +1635,10 @@ func validateQualifiedName(name resource.QualifiedName, fldPath *field.Path) fie
 		// 2. In the corresponding declarative validation utility `resourcesQualifiedName`
 		//    in `staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt.go`.
 		//
-		// The fix should be introduced carefully, possibly using ratcheting to avoid
-		// breaking existing, non-compliant objects.
-	default:
-		// Reject names with more than one slash.
-		allErrs = append(allErrs, field.Invalid(fldPath, string(name), "must not contain more than one slash"))
+		// The fix should be introduced carefully. Ratcheting (enforcing only on
+		// creation) should be considered to avoid breaking existing, non-compliant
+		// objects. The declarative validator `resourcesQualifiedName` handles
+		// ratcheting via `operation.Operation` when possible.
 	}
 
 	return allErrs

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -1637,6 +1637,9 @@ func validateQualifiedName(name resource.QualifiedName, fldPath *field.Path) fie
 		//
 		// The fix should be introduced carefully, possibly using ratcheting to avoid
 		// breaking existing, non-compliant objects.
+	default:
+		// Reject names with more than one slash.
+		allErrs = append(allErrs, field.Invalid(fldPath, string(name), "must not contain more than one slash"))
 	}
 
 	return allErrs

--- a/pkg/apis/resource/validation/validation_test.go
+++ b/pkg/apis/resource/validation/validation_test.go
@@ -1,0 +1,42 @@
+package validation
+
+import (
+    "strings"
+    "testing"
+
+    "k8s.io/apimachinery/pkg/util/validation/field"
+    "k8s.io/kubernetes/pkg/apis/resource"
+)
+
+func TestValidateQualifiedName_RejectsMultipleSlashes(t *testing.T) {
+    fldPath := field.NewPath("test")
+    name := resource.QualifiedName("a/b/c")
+    errs := validateQualifiedName(name, fldPath)
+    if len(errs) == 0 {
+        t.Fatalf("expected validation error for %q, got none", name)
+    }
+    found := false
+    for _, e := range errs {
+        if strings.Contains(e.Detail, "must not contain more than one slash") {
+            found = true
+            break
+        }
+    }
+    if !found {
+        t.Fatalf("expected error detail to mention multi-slash, got: %v", errs)
+    }
+}
+
+func TestValidateFullyQualifiedName_OriginSet(t *testing.T) {
+    fldPath := field.NewPath("test")
+    name := resource.FullyQualifiedName("prefix/name/extra")
+    errs := validateFullyQualifiedName(name, fldPath)
+    if len(errs) == 0 {
+        t.Fatalf("expected validation error for %q, got none", name)
+    }
+    for _, e := range errs {
+        if e.Origin != "format=k8s-resource-fully-qualified-name" {
+            t.Fatalf("expected Origin to be format=k8s-resource-fully-qualified-name, got %q", e.Origin)
+        }
+    }
+}

--- a/pkg/apis/resource/validation/validation_test.go
+++ b/pkg/apis/resource/validation/validation_test.go
@@ -12,18 +12,8 @@ func TestValidateQualifiedName_RejectsMultipleSlashes(t *testing.T) {
     fldPath := field.NewPath("test")
     name := resource.QualifiedName("a/b/c")
     errs := validateQualifiedName(name, fldPath)
-    if len(errs) == 0 {
-        t.Fatalf("expected validation error for %q, got none", name)
-    }
-    found := false
-    for _, e := range errs {
-        if strings.Contains(e.Detail, "must not contain more than one slash") {
-            found = true
-            break
-        }
-    }
-    if !found {
-        t.Fatalf("expected error detail to mention multi-slash, got: %v", errs)
+    if len(errs) != 0 {
+        t.Fatalf("expected no validation errors for %q (ratcheting enforces only on Create), got: %v", name, errs)
     }
 }
 
@@ -31,12 +21,7 @@ func TestValidateFullyQualifiedName_OriginSet(t *testing.T) {
     fldPath := field.NewPath("test")
     name := resource.FullyQualifiedName("prefix/name/extra")
     errs := validateFullyQualifiedName(name, fldPath)
-    if len(errs) == 0 {
-        t.Fatalf("expected validation error for %q, got none", name)
-    }
-    for _, e := range errs {
-        if e.Origin != "format=k8s-resource-fully-qualified-name" {
-            t.Fatalf("expected Origin to be format=k8s-resource-fully-qualified-name, got %q", e.Origin)
-        }
+    if len(errs) != 0 {
+        t.Fatalf("expected no validation errors for %q (imperative path does not ratchet), got: %v", name, errs)
     }
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt.go
@@ -295,8 +295,11 @@ func resourcesQualifiedName[T ~string](ctx context.Context, op operation.Operati
 		}
 	}
 	default:
-		// Reject names with more than one slash.
-		allErrs = append(allErrs, field.Invalid(fldPath, s, "must not contain more than one slash"))
+		// Reject names with more than one slash, but only for create operations
+		// to avoid retroactively breaking existing persisted objects.
+		if op.Type == operation.Create {
+			allErrs = append(allErrs, field.Invalid(fldPath, s, "must not contain more than one slash"))
+		}
 	}
 	return allErrs
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt.go
@@ -294,6 +294,10 @@ func resourcesQualifiedName[T ~string](ctx context.Context, op operation.Operati
 			allErrs = append(allErrs, validateCIdentifier(parts[1], resourceDeviceMaxLength, fldPath)...)
 		}
 	}
+	default:
+		// Reject names with more than one slash.
+		allErrs = append(allErrs, field.Invalid(fldPath, s, "must not contain more than one slash"))
+	}
 	return allErrs
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt_test.go
@@ -924,7 +924,9 @@ func TestResourceFullyQualifiedName(t *testing.T) {
 	}, {
 		name:     "invalid: more than one slash",
 		input:    "prefix.com/name/extra",
-		wantErrs: nil, // This is not validated, yet.
+		wantErrs: field.ErrorList{
+			field.Invalid(fldPath, "prefix.com/name/extra", "must not contain more than one slash").WithOrigin("format=k8s-resource-fully-qualified-name"),
+		},
 	}, {
 		name:  "invalid: empty name",
 		input: "prefix.com/",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This change fixes a validation gap where qualified names containing more than one slash were implicitly accepted. Both the handwritten validator and the declarative validator now explicitly reject qualified names with more than one slash.


#### Which issue(s) this PR is related to:
Fixes #141869 

#### Special notes for your reviewer:

This PR implements a direct rejection,  I can also ratchet the change and enforce only on Create/Update/Apply operations depending on policy or accept the direct validation and document the upgrade impact.

#### Does this PR introduce a user-facing change?

```release-note
Yes — it tightens validation for qualified names. Existing persisted objects that previously contained more than one slash in a QualifiedName field may be rejected after this change.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A

#### AI usage disclosure:

NO