### PR TITLE
Fix cache watcher processing after watcher termination

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
@@ -412,11 +412,11 @@ func (c *cacheWatcher) convertToWatchEvent(event *watchCacheEvent) *watch.Event 
 }
 
 // NOTE: sendWatchCacheEvent is assumed to not modify <event> !!!
-func (c *cacheWatcher) sendWatchCacheEvent(event *watchCacheEvent) (builtAt, sentAt time.Time) {
+func (c *cacheWatcher) sendWatchCacheEvent(event *watchCacheEvent) (builtAt, sentAt time.Time, stopped bool) {
 	watchEvent := c.convertToWatchEvent(event)
 	if watchEvent == nil {
 		// Watcher is not interested in that object.
-		return time.Time{}, time.Time{}
+		return time.Time{}, time.Time{}, false
 	}
 	builtAt = c.clock.Now()
 
@@ -434,7 +434,7 @@ func (c *cacheWatcher) sendWatchCacheEvent(event *watchCacheEvent) (builtAt, sen
 	// events.
 	select {
 	case <-c.done:
-		return time.Time{}, time.Time{}
+		return time.Time{}, time.Time{}, true
 	default:
 	}
 
@@ -443,8 +443,9 @@ func (c *cacheWatcher) sendWatchCacheEvent(event *watchCacheEvent) (builtAt, sen
 		c.markBookmarkAfterRvSent(event)
 		sentAt = c.clock.Now()
 	case <-c.done:
+		stopped = true
 	}
-	return builtAt, sentAt
+	return builtAt, sentAt, stopped
 }
 
 func (c *cacheWatcher) processInterval(ctx context.Context, cacheInterval *watchCacheInterval, resourceVersion uint64) {
@@ -476,6 +477,12 @@ func (c *cacheWatcher) processInterval(ctx context.Context, cacheInterval *watch
 	}
 
 	initEventCount := 0
+	recordInitEvents := func() {
+		if initEventCount > 0 {
+			metrics.InitCounter.WithLabelValues(c.groupResource.Group, c.groupResource.Resource).Add(float64(initEventCount))
+		}
+	}
+
 	for {
 		event, err := cacheInterval.Next()
 		if err != nil {
@@ -499,7 +506,11 @@ func (c *cacheWatcher) processInterval(ctx context.Context, cacheInterval *watch
 		if event == nil {
 			break
 		}
-		c.sendWatchCacheEvent(event)
+		_, sentAt, stopped := c.sendWatchCacheEvent(event)
+		if stopped {
+			recordInitEvents()
+			return
+		}
 
 		// With some events already sent, update resourceVersion so that
 		// events that were buffered and not yet processed won't be delivered
@@ -513,12 +524,13 @@ func (c *cacheWatcher) processInterval(ctx context.Context, cacheInterval *watch
 		if event.ResourceVersion > resourceVersion {
 			resourceVersion = event.ResourceVersion
 		}
-		initEventCount++
+		if !sentAt.IsZero() {
+			initEventCount++
+		}
 	}
 
-	if initEventCount > 0 {
-		metrics.InitCounter.WithLabelValues(c.groupResource.Group, c.groupResource.Resource).Add(float64(initEventCount))
-	}
+	recordInitEvents()
+
 	processingTime := time.Since(startTime)
 	if processingTime > initProcessThreshold {
 		klog.V(2).Infof("processing %d initEvents of %s (%s) took %v", initEventCount, c.groupResource, c.identifier, processingTime)
@@ -550,7 +562,7 @@ func (c *cacheWatcher) process(ctx context.Context, resourceVersion uint64) {
 			// or a bookmark event with an RV equal to resourceVersion
 			// if we haven't sent one to the client
 			if event.ResourceVersion > resourceVersion || (event.Type == watch.Bookmark && event.ResourceVersion == resourceVersion && !c.wasBookmarkAfterRvSent()) {
-				builtAt, sentAt := c.sendWatchCacheEvent(event)
+				builtAt, sentAt, _ := c.sendWatchCacheEvent(event)
 				c.observeDispatchMetrics(event, builtAt, sentAt)
 			}
 		case <-ctx.Done():

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
@@ -80,6 +80,141 @@ func TestCacheWatcherCleanupNotBlockedByResult(t *testing.T) {
 	}
 }
 
+func TestCacheWatcherStopsProcessingInitEventsAfterStop(t *testing.T) {
+	var lock sync.RWMutex
+	var w *cacheWatcher
+	count := 0
+
+	filter := func(string, labels.Set, fields.Set, runtime.Object) bool { return true }
+	forget := func(drainWatcher bool) {
+		lock.Lock()
+		defer lock.Unlock()
+		count++
+		w.setDrainInputBufferLocked(drainWatcher)
+		w.stopLocked()
+	}
+
+	initEvents := []*watchCacheEvent{
+		makeWatchCacheEvent(1),
+		makeWatchCacheEvent(2),
+		makeWatchCacheEvent(3),
+	}
+
+	registry := compbasemetrics.NewKubeRegistry()
+	if err := registry.Register(metrics.InitCounter); err != nil {
+		t.Fatalf("unexpected error registering metric: %v", err)
+	}
+	metrics.InitCounter.WithLabelValues("", "cache-watcher-test").Add(0)
+	t.Cleanup(func() {
+		registry.Reset()
+	})
+
+	w = newCacheWatcher(
+		0,
+		filter,
+		forget,
+		storage.APIObjectVersioner{},
+		time.Now(),
+		false,
+		schema.GroupResource{Resource: "cache-watcher-test"},
+		metrics.NewNoopWatcherMetricsObservers(),
+		nil,
+		"",
+	)
+
+	go w.processInterval(context.Background(), intervalFromEvents(initEvents), 0)
+
+	// Stop the watcher before processInterval can deliver any event.
+	w.Stop()
+
+	// processInterval must terminate after observing that the watcher
+	// has been stopped.
+	if err := wait.PollImmediate(10*time.Millisecond, 5*time.Second, func() (bool, error) {
+		lock.RLock()
+		defer lock.RUnlock()
+		return count == 2, nil
+	}); err != nil {
+		t.Fatalf("expected processInterval to stop after watcher was stopped: %v", err)
+	}
+
+	expected := `
+# HELP apiserver_init_events_total [ALPHA] Counter of init events processed in watch cache broken by resource type.
+# TYPE apiserver_init_events_total counter
+apiserver_init_events_total{group="",resource="cache-watcher-test"} 0
+`
+	if err := testutil.GatherAndCompare(registry, strings.NewReader(expected), "apiserver_init_events_total"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCacheWatcherCountsDeliveredInitEventsBeforeStop(t *testing.T) {
+	var lock sync.RWMutex
+	var w *cacheWatcher
+	forget := func(drainWatcher bool) {
+		lock.Lock()
+		defer lock.Unlock()
+		w.setDrainInputBufferLocked(drainWatcher)
+		w.stopLocked()
+	}
+
+	initEvents := []*watchCacheEvent{
+		makeWatchCacheEvent(1),
+		makeWatchCacheEvent(2),
+	}
+
+	registry := compbasemetrics.NewKubeRegistry()
+	if err := registry.Register(metrics.InitCounter); err != nil {
+		t.Fatalf("unexpected error registering metric: %v", err)
+	}
+	metrics.InitCounter.WithLabelValues("", "cache-watcher-partial-test").Add(0)
+	t.Cleanup(func() {
+		registry.Reset()
+	})
+
+	w = newCacheWatcher(
+		1,
+		func(string, labels.Set, fields.Set, runtime.Object) bool { return true },
+		forget,
+		storage.APIObjectVersioner{},
+		time.Now(),
+		false,
+		schema.GroupResource{Resource: "cache-watcher-partial-test"},
+		metrics.NewNoopWatcherMetricsObservers(),
+		nil,
+		"",
+	)
+
+	go w.processInterval(context.Background(), intervalFromEvents(initEvents), 0)
+
+	// The first event fits in the result buffer. The second event blocks.
+	if err := wait.PollImmediate(10*time.Millisecond, 5*time.Second, func() (bool, error) {
+		return len(w.result) == 1, nil
+	}); err != nil {
+		t.Fatalf("expected first initial event to be buffered: %v", err)
+	}
+
+	// Stop while processInterval is blocked trying to deliver the second event.
+	w.Stop()
+
+	var events []watch.Event
+	for event := range w.ResultChan() {
+		events = append(events, event)
+	}
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 delivered initial event, got %d", len(events))
+	}
+
+	expected := `
+# HELP apiserver_init_events_total [ALPHA] Counter of init events processed in watch cache broken by resource type.
+# TYPE apiserver_init_events_total counter
+apiserver_init_events_total{group="",resource="cache-watcher-partial-test"} 1
+`
+	if err := testutil.GatherAndCompare(registry, strings.NewReader(expected), "apiserver_init_events_total"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestCacheWatcherHandlesFiltering(t *testing.T) {
 	filter := func(_ string, _ labels.Set, field fields.Set, _ runtime.Object) bool {
 		return field["spec.nodeName"] == "host"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`cacheWatcher.processInterval` could continue processing initial events after the
watcher had been terminated. Those events were not delivered to the client but
were still counted in `apiserver_init_events_total`.

This change makes `sendWatchCacheEvent` report watcher termination, stops
`processInterval` immediately when delivery is interrupted, and increments the
init-event counter only for events actually delivered.

#### Which issue(s) this PR fixes:

Fixes #141818

#### Does this PR introduce a user-facing change?

No.