### PR TITLE
scheduler: remove unreachable DRA pending allocation cleanup

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -1672,14 +1672,9 @@ func (pl *DynamicResources) PreBind(ctx context.Context, cs fwk.CycleState, pod 
 
 	logger := klog.FromContext(ctx)
 
-	podGroupState, err := getPodGroupStateData(cs)
-	if err != nil {
-		return statusError(logger, err)
-	}
-
 	for index, claim := range state.claims.all() {
 		if !resourceclaim.IsReservedForPod(pod, claim, pl.fts.EnableDRAWorkloadResourceClaims) {
-			claim, successCleanup, err := pl.bindClaim(ctx, state, podGroupState, index, pod, nodeName)
+			claim, successCleanup, err := pl.bindClaim(ctx, state, index, pod, nodeName)
 			if err != nil {
 				return statusError(logger, err)
 			}
@@ -1802,7 +1797,7 @@ func (pl *DynamicResources) PreBindPreFlight(ctx context.Context, cs fwk.CycleSt
 // and reservation are recorded. This finishes the work started in Reserve.
 // Returns the updated claim, a function which (if not nil) should run when the
 // pod has been successfully bound, and an error if one occurred.
-func (pl *DynamicResources) bindClaim(ctx context.Context, state *stateData, podGroupState *podGroupStateData, index int, pod *v1.Pod, nodeName string) (*resourceapi.ResourceClaim, func(), error) {
+func (pl *DynamicResources) bindClaim(ctx context.Context, state *stateData, index int, pod *v1.Pod, nodeName string) (*resourceapi.ResourceClaim, func(), error) {
 	logger := klog.FromContext(ctx)
 	claim := state.claims.get(index)
 	binding := state.claims.getBinding(index, pod)
@@ -1851,16 +1846,13 @@ func (pl *DynamicResources) bindClaim(ctx context.Context, state *stateData, pod
 		if allocation != nil {
 			for _, claimUID := range claimUIDs {
 				if deleted := pl.draManager.ResourceClaims().MaybeRemoveClaimPendingAllocation(claimUID, true); deleted {
-					// If we are currently asynchronously Binding Pods in a
-					// PodGroup, then the pendingAllocations set does not need
-					// to be updated. New PodGroup scheduling cycles will start
+					// Since PodGroup cycle state is not set during asynchronous
+					// binding, pendingAllocations does not need to be updated.
+					// New PodGroup scheduling cycles will start
 					// with an empty set and not share pending allocations
 					// started in *this* cycle until Unreserve completes for all
 					// the Pods sharing that pending allocation and they can be
 					// Reserved again in another cycle.
-					if podGroupState != nil {
-						delete(podGroupState.pendingAllocations, claim.UID)
-					}
 					logger.V(5).Info("Removed claim from in-flight claims", "claim", klog.KObj(claim), "uid", claimUID, "resourceVersion", resourceVersion, "allocation", klog.Format(allocation))
 				}
 			}


### PR DESCRIPTION
What type of PR is this?

/kind cleanup

What this PR does / why we need it:

This removes an unreachable DRA pending allocation cleanup path from the scheduler's dynamicresources plugin.

The PodGroup scheduling cycle state is cleared (via
SetPodGroupSchedulingCycle(nil)) before the binding cycle runs (see
schedule_one_podgroup.go). As a result, the podGroupState that this
cleanup branch depended on is never present when the binding path executes,
making the branch unreachable in the current scheduling flow.

This PR:
Removes the unreachable cleanup branch in bindClaim
Removes the now-unused podGroupState parameter/handling from
bindClaim, since nothing in that function depends on it anymore

The existing valid failure-path cleanup is unchanged.

Removing this dead code avoids maintaining unreachable scheduler logic and
unused state handling without changing any reachable scheduling behavior.

Which issue(s) is this PR related to?

N/A

Special notes for your reviewer:
This change only removes unreachable code and unused state handling; it does
not alter any reachable code paths or scheduling behavior. The PodGroup
scheduling cycle state is cleared before the binding cycle begins, which is
why this branch and its podGroupState handling in bindClaim are safe to
remove.

Commits have been squashed into a single commit per review feedback.

Does this PR introduce a user-facing change?

No. This is an internal scheduler cleanup with no user-facing or
scheduling-behavior changes.

NONE

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A

AI usage disclosure:
YES — AI was used to assist with code-path analysis and validation. The
author reviewed and validated the submitted changes and is responsible for
ensuring compliance with AGENTS.md and CONTRIBUTING.md.