### PR TITLE
printers: measure printed cell width when computing column widths

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter.go
@@ -208,9 +208,9 @@ func printTable(table *metav1.Table, output io.Writer, options PrintOptions) err
 				}
 				var l int
 				if s, ok := cell.(string); ok {
-					l = len(s)
+					l = cellPrintWidth(s)
 				} else {
-					l = len(fmt.Sprint(cell))
+					l = cellPrintWidth(fmt.Sprint(cell))
 				}
 				if l > maxCellWidths[i] {
 					maxCellWidths[i] = l
@@ -306,7 +306,7 @@ func printTable(table *metav1.Table, output io.Writer, options PrintOptions) err
 				default:
 					cellStr = fmt.Sprint(val)
 				}
-				cellLen = len(cellStr)
+				cellLen = cellPrintWidth(cellStr)
 				rowBuf = appendCellValue(output, rowBuf, cellStr)
 			}
 			if padFirstRow && ri == 0 && i != lastVisibleCol && i < len(maxCellWidths) {
@@ -323,6 +323,19 @@ func printTable(table *metav1.Table, output io.Writer, options PrintOptions) err
 		}
 	}
 	return nil
+}
+
+// cellPrintWidth returns the number of bytes appendCellValue writes for val,
+// which is not len(val): a value is truncated at its first break character and
+// terminal-unsafe characters are escaped into longer replacements.
+func cellPrintWidth(val string) int {
+	if !strings.ContainsAny(val, cellSpecialChars) {
+		return len(val)
+	}
+	if breakchar := strings.IndexAny(val, cellBreakChars); breakchar >= 0 {
+		return len(EscapeTerminal(val[:breakchar])) + len("...")
+	}
+	return len(EscapeTerminal(val))
 }
 
 // appendCellValue appends a cell's display text to rowBuf. For the common

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter_test.go
@@ -34,22 +34,22 @@ var testPodName = "test-pod-name"
 var testPodNamespace = "test-namespace"
 
 var testPod = &corev1.Pod{
-	TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      testPodName,
-		Namespace: testPodNamespace,
-		Labels: map[string]string{
-			"first-label":  "12",
-			"second-label": "label-value",
-		},
+	APIVersion: "v1",
+	Kind:       "Pod",
+	Name:       testPodName,
+	Namespace:  testPodNamespace,
+	Labels: map[string]string{
+		"first-label":  "12",
+		"second-label": "label-value",
 	},
 }
 
 var testStatus = &metav1.Status{
-	TypeMeta: metav1.TypeMeta{APIVersion: "metav1", Kind: "Status"},
-	Status:   "Failure",
-	Message:  "test-status-message",
-	Reason:   "test-status-reason",
+	APIVersion: "metav1",
+	Kind:       "Status",
+	Status:     "Failure",
+	Message:    "test-status-message",
+	Reason:     "test-status-reason",
 }
 
 func TestPrintTable_MissingColumnsRows(t *testing.T) {
@@ -116,7 +116,7 @@ func TestPrintTable_ColumnPriority(t *testing.T) {
 				{Name: "Age", Type: "string", Priority: 1},      // Priority > 0
 			},
 			rows: []metav1.TableRow{
-				{Cells: []interface{}{"test1", "1/1", "podPhase", int64(5), "20h"}},
+				{Cells: []any{"test1", "1/1", "podPhase", int64(5), "20h"}},
 			},
 			options:  PrintOptions{},
 			expected: "NAME    READY   STATUS\ntest1   1/1     podPhase\n",
@@ -131,9 +131,9 @@ func TestPrintTable_ColumnPriority(t *testing.T) {
 				{Name: "Age", Type: "string", Priority: 1},      // Priority > 0
 			},
 			rows: []metav1.TableRow{
-				{Cells: []interface{}{"test1", "1/1", "podPhase", int64(5), "20h"}},
-				{Cells: []interface{}{"test2", "1/2", "podPhase", int64(30), "21h"}},
-				{Cells: []interface{}{"test3", "4/4", "podPhase", int64(1), "22h"}},
+				{Cells: []any{"test1", "1/1", "podPhase", int64(5), "20h"}},
+				{Cells: []any{"test2", "1/2", "podPhase", int64(30), "21h"}},
+				{Cells: []any{"test3", "4/4", "podPhase", int64(1), "22h"}},
 			},
 			options: PrintOptions{},
 			expected: `NAME    READY   STATUS
@@ -152,7 +152,7 @@ test3   4/4     podPhase
 				{Name: "Age", Type: "string", Priority: 1},
 			},
 			rows: []metav1.TableRow{
-				{Cells: []interface{}{"test1", "1/1", "podPhase", int64(5), "20h"}},
+				{Cells: []any{"test1", "1/1", "podPhase", int64(5), "20h"}},
 			},
 			// Print with no headers.
 			options:  PrintOptions{Wide: true},
@@ -168,9 +168,9 @@ test3   4/4     podPhase
 				{Name: "Age", Type: "string", Priority: 1},
 			},
 			rows: []metav1.TableRow{
-				{Cells: []interface{}{"test1", "1/1", "podPhase", int64(5), "20h"}},
-				{Cells: []interface{}{"test2", "1/2", "podPhase", int64(30), "21h"}},
-				{Cells: []interface{}{"test3", "4/4", "podPhase", int64(1), "22h"}},
+				{Cells: []any{"test1", "1/1", "podPhase", int64(5), "20h"}},
+				{Cells: []any{"test2", "1/2", "podPhase", int64(30), "21h"}},
+				{Cells: []any{"test3", "4/4", "podPhase", int64(1), "22h"}},
 			},
 			options: PrintOptions{Wide: true},
 			expected: `NAME    READY   STATUS     RETRIES   AGE
@@ -214,7 +214,7 @@ func TestPrintTable_ColumnHeaders(t *testing.T) {
 				{Name: "Age", Type: "string"},
 			},
 			rows: []metav1.TableRow{
-				{Cells: []interface{}{"test1", "1/1", "podPhase", int64(5), "20h"}},
+				{Cells: []any{"test1", "1/1", "podPhase", int64(5), "20h"}},
 			},
 			options:  PrintOptions{},
 			expected: "NAME    READY   STATUS     RETRIES   AGE\ntest1   1/1     podPhase   5         20h\n",
@@ -229,9 +229,9 @@ func TestPrintTable_ColumnHeaders(t *testing.T) {
 				{Name: "Age", Type: "string"},
 			},
 			rows: []metav1.TableRow{
-				{Cells: []interface{}{"test1", "1/1", "podPhase", int64(5), "20h"}},
-				{Cells: []interface{}{"test2", "1/2", "podPhase", int64(30), "21h"}},
-				{Cells: []interface{}{"test3", "4/4", "podPhase", int64(1), "22h"}},
+				{Cells: []any{"test1", "1/1", "podPhase", int64(5), "20h"}},
+				{Cells: []any{"test2", "1/2", "podPhase", int64(30), "21h"}},
+				{Cells: []any{"test3", "4/4", "podPhase", int64(1), "22h"}},
 			},
 			options: PrintOptions{},
 			expected: `NAME    READY   STATUS     RETRIES   AGE
@@ -250,7 +250,7 @@ test3   4/4     podPhase   1         22h
 				{Name: "Age", Type: "string"},
 			},
 			rows: []metav1.TableRow{
-				{Cells: []interface{}{"test1", "1/1", "podPhase", int64(5), "20h"}},
+				{Cells: []any{"test1", "1/1", "podPhase", int64(5), "20h"}},
 			},
 			// Print with no headers.
 			options:  PrintOptions{NoHeaders: true},
@@ -266,9 +266,9 @@ test3   4/4     podPhase   1         22h
 				{Name: "Age", Type: "string"},
 			},
 			rows: []metav1.TableRow{
-				{Cells: []interface{}{"test1", "1/1", "podPhase", int64(5), "20h"}},
-				{Cells: []interface{}{"test2", "1/2", "podPhase", int64(30), "21h"}},
-				{Cells: []interface{}{"test3", "4/4", "podPhase", int64(1), "22h"}},
+				{Cells: []any{"test1", "1/1", "podPhase", int64(5), "20h"}},
+				{Cells: []any{"test2", "1/2", "podPhase", int64(30), "21h"}},
+				{Cells: []any{"test3", "4/4", "podPhase", int64(1), "22h"}},
 			},
 			options: PrintOptions{NoHeaders: true},
 			expected: `test1   1/1   podPhase   5     20h
@@ -312,7 +312,7 @@ func TestPrintTable_WithNamespace(t *testing.T) {
 			},
 			rows: []metav1.TableRow{
 				{
-					Cells:  []interface{}{"test1", "1/1", "podPhase", int64(5), "20h"},
+					Cells:  []any{"test1", "1/1", "podPhase", int64(5), "20h"},
 					Object: runtime.RawExtension{Object: testPod},
 				},
 			},
@@ -358,7 +358,7 @@ func TestPrintTable_WithKind(t *testing.T) {
 			},
 			rows: []metav1.TableRow{
 				{
-					Cells: []interface{}{"test1", "1/1", "podPhase", int64(5), "20h"},
+					Cells: []any{"test1", "1/1", "podPhase", int64(5), "20h"},
 				},
 			},
 			// Print with Kind "pod" prepended to name.
@@ -403,7 +403,7 @@ func TestPrintTable_WithLabels(t *testing.T) {
 			},
 			rows: []metav1.TableRow{
 				{
-					Cells:  []interface{}{"test1", "1/1", "podPhase", int64(5), "20h"},
+					Cells:  []any{"test1", "1/1", "podPhase", int64(5), "20h"},
 					Object: runtime.RawExtension{Object: testPod},
 				},
 			},
@@ -423,7 +423,7 @@ test1   1/1     podPhase   5         20h   first-label=12,second-label=label-val
 			},
 			rows: []metav1.TableRow{
 				{
-					Cells:  []interface{}{"test1", "1/1", "podPhase", int64(5), "20h"},
+					Cells:  []any{"test1", "1/1", "podPhase", int64(5), "20h"},
 					Object: runtime.RawExtension{Object: testPod},
 				},
 			},
@@ -444,7 +444,7 @@ test1   1/1     podPhase   5         20h   label-value
 			},
 			rows: []metav1.TableRow{
 				{
-					Cells:  []interface{}{"test1", "1/1", "podPhase", int64(5), "20h"},
+					Cells:  []any{"test1", "1/1", "podPhase", int64(5), "20h"},
 					Object: runtime.RawExtension{Object: testPod},
 				},
 			},
@@ -549,7 +549,7 @@ func TestPrintTable_WatchEvents(t *testing.T) {
 			},
 			rows: []metav1.TableRow{
 				{
-					Cells:  []interface{}{"test1", "1/1", "podPhase", int64(5), "20h"},
+					Cells:  []any{"test1", "1/1", "podPhase", int64(5), "20h"},
 					Object: runtime.RawExtension{Object: testPod},
 				},
 			},
@@ -569,7 +569,7 @@ Added   test1   1/1     podPhase   5         20h
 			},
 			rows: []metav1.TableRow{
 				{
-					Cells:  []interface{}{"test1", "1/1", "podPhase", int64(5), "20h"},
+					Cells:  []any{"test1", "1/1", "podPhase", int64(5), "20h"},
 					Object: runtime.RawExtension{Object: testPod},
 				},
 			},
@@ -601,21 +601,21 @@ Added   test1   1/1     podPhase   5         20h
 
 func TestPrintUnstructuredObject(t *testing.T) {
 	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "Test",
 			"dummy1":     "present",
 			"dummy2":     "present",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":              "MyName",
 				"namespace":         "MyNamespace",
 				"creationTimestamp": "2017-04-01T00:00:00Z",
 				"resourceVersion":   123,
 				"uid":               "00000000-0000-0000-0000-000000000001",
 				"dummy3":            "present",
-				"labels":            map[string]interface{}{"test": "other"},
+				"labels":            map[string]any{"test": "other"},
 			},
-			/*"items": []interface{}{
+			/*"items": []any{
 				map[string]interface{}{
 					"itemBool": true,
 					"itemInt":  42,
@@ -653,25 +653,25 @@ func TestPrintUnstructuredObject(t *testing.T) {
 		{
 			expected: "NAME\\s+AGE\nMyName\\s+\\d+\\w+\nMyName2\\s+\\d+",
 			object: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"apiVersion": "v1",
 					"kind":       "Test",
 					"dummy1":     "present",
 					"dummy2":     "present",
-					"items": []interface{}{
-						map[string]interface{}{
-							"metadata": map[string]interface{}{
+					"items": []any{
+						map[string]any{
+							"metadata": map[string]any{
 								"name":              "MyName",
 								"namespace":         "MyNamespace",
 								"creationTimestamp": "2017-04-01T00:00:00Z",
 								"resourceVersion":   123,
 								"uid":               "00000000-0000-0000-0000-000000000001",
 								"dummy3":            "present",
-								"labels":            map[string]interface{}{"test": "other"},
+								"labels":            map[string]any{"test": "other"},
 							},
 						},
-						map[string]interface{}{
-							"metadata": map[string]interface{}{
+						map[string]any{
+							"metadata": map[string]any{
 								"name":              "MyName2",
 								"namespace":         "MyNamespace",
 								"creationTimestamp": "2017-04-01T00:00:00Z",
@@ -732,7 +732,7 @@ func TestPrintTable_ConsistentAlignmentAcrossFlushes(t *testing.T) {
 			if i == rowCount-1 {
 				name = longName
 			}
-			rows[i] = metav1.TableRow{Cells: []interface{}{name, "Running", "5d"}}
+			rows[i] = metav1.TableRow{Cells: []any{name, "Running", "5d"}}
 		}
 		return &metav1.Table{ColumnDefinitions: columns, Rows: rows}
 	}
@@ -784,6 +784,61 @@ func TestPrintTable_ConsistentAlignmentAcrossFlushes(t *testing.T) {
 	})
 }
 
+// TestPrintTable_ColumnWidthUsesPrintedCellWidth verifies that a cell holding a
+// break character does not widen its column to the untruncated length of the
+// value. printTable pre-scans cell widths to prime the tabwriter, and that scan
+// has to measure what appendCellValue actually writes: everything from the
+// first break character onwards is replaced by "...".
+func TestPrintTable_ColumnWidthUsesPrintedCellWidth(t *testing.T) {
+	build := func(msg string) *metav1.Table {
+		return &metav1.Table{
+			ColumnDefinitions: []metav1.TableColumnDefinition{
+				{Name: "NAME", Type: "string"},
+				{Name: "MESSAGE", Type: "string"},
+				{Name: "AGE", Type: "string"},
+			},
+			Rows: []metav1.TableRow{
+				{Cells: []any{"a", "short", "1d"}},
+				{Cells: []any{"b", msg, "2d"}},
+				{Cells: []any{"c", "tail", "3d"}},
+			},
+		}
+	}
+
+	render := func(t *testing.T, table *metav1.Table, options PrintOptions) string {
+		t.Helper()
+		out := &bytes.Buffer{}
+		if err := NewTablePrinter(options).PrintObj(table, out); err != nil {
+			t.Fatalf("PrintObj error: %v", err)
+		}
+		return out.String()
+	}
+
+	// The multi-line value is printed as "line-one...", so it has to lay out
+	// exactly like a cell that literally holds "line-one...".
+	const truncated = "line-one..."
+	multiline := "line-one\nline-two-is-much-longer-than-it-looks"
+
+	for _, options := range []PrintOptions{{}, {NoHeaders: true}} {
+		name := "WithHeaders"
+		if options.NoHeaders {
+			name = "NoHeaders"
+		}
+		t.Run(name, func(t *testing.T) {
+			got := render(t, build(multiline), options)
+			want := render(t, build(truncated), options)
+			if got != want {
+				t.Errorf("column layout differs from an equivalent already-truncated cell:\ngot:\n%s\nwant:\n%s", got, want)
+			}
+			for line := range strings.SplitSeq(strings.TrimRight(got, "\n"), "\n") {
+				if strings.Contains(line, strings.Repeat(" ", 12)) {
+					t.Errorf("column padded well past the widest printed cell: %q", line)
+				}
+			}
+		})
+	}
+}
+
 // columnStartOffsets returns the byte offsets of the start of each non-first
 // column on a tabwriter-formatted line. A column starts at the first non-space
 // byte following a run of >=2 spaces. This matches tabwriter's inter-column
@@ -809,7 +864,7 @@ func TestPrintTable_LargeRowCount(t *testing.T) {
 	rowCount := 500
 	rows := make([]metav1.TableRow, rowCount)
 	for i := range rows {
-		rows[i] = metav1.TableRow{Cells: []interface{}{
+		rows[i] = metav1.TableRow{Cells: []any{
 			fmt.Sprintf("pod-%d", i), "Running", "5d",
 		}}
 	}
@@ -870,7 +925,7 @@ func TestStringPrinting(t *testing.T) {
 				{Name: "Description", Type: "string"},
 			},
 			rows: []metav1.TableRow{
-				{Cells: []interface{}{"test1", "20h", "This is first line\nThis is second line\nThis is third line\nand another one\n"}},
+				{Cells: []any{"test1", "20h", "This is first line\nThis is second line\nThis is third line\nand another one\n"}},
 			},
 			expected: `NAME    AGE   DESCRIPTION
 test1   20h   This is first line...
@@ -884,7 +939,7 @@ test1   20h   This is first line...
 				{Name: "Description", Type: "string"},
 			},
 			rows: []metav1.TableRow{
-				{Cells: []interface{}{"test1", "20h", "This is first line which is long and goes for on and on and on an on and on and on and on and on and on and on and on and on and on and on"}},
+				{Cells: []any{"test1", "20h", "This is first line which is long and goes for on and on and on an on and on and on and on and on and on and on and on and on and on and on"}},
 			},
 			expected: `NAME    AGE   DESCRIPTION
 test1   20h   This is first line which is long and goes for on and on and on an on and on and on and on and on and on and on and on and on and on and on
@@ -898,7 +953,7 @@ test1   20h   This is first line which is long and goes for on and on and on an 
 				{Name: "Description", Type: "string"},
 			},
 			rows: []metav1.TableRow{
-				{Cells: []interface{}{"test1", "20h", "This is first\n line which is long and goes for on and on and on an on and on and on and on and on and on and on and on and on and on and on"}},
+				{Cells: []any{"test1", "20h", "This is first\n line which is long and goes for on and on and on an on and on and on and on and on and on and on and on and on and on and on"}},
 			},
 			expected: `NAME    AGE   DESCRIPTION
 test1   20h   This is first...
@@ -910,7 +965,7 @@ test1   20h   This is first...
 				{Name: "Name", Type: "string"},
 			},
 			rows: []metav1.TableRow{
-				{Cells: []interface{}{"test1\x1b"}},
+				{Cells: []any{"test1\x1b"}},
 			},
 			expected: `NAME
 test1^[


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/sig cli

#### What this PR does / why we need it:

`printTable` measures cell widths with `len(cell)`, but `appendCellValue` does not
write `cell` verbatim: it truncates the value at its first break character
(`\f`, `\n`, `\r`) and replaces the remainder with `...`, and it escapes
terminal-unsafe characters, turning `\x1b` into `^[`. The measurement and the
write therefore disagree, in both directions.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

**Prepare**

```bash
kubectl create namespace kubectl-bughunt

cat <<'EOF' | kubectl apply -f -
apiVersion: v1
kind: Event
metadata: {name: multiline-demo, namespace: kubectl-bughunt}
involvedObject: {apiVersion: v1, kind: Pod, name: demo-pod, namespace: kubectl-bughunt}
reason: Failed
type: Warning
count: 1
firstTimestamp: "2026-09-05T10:00:00Z"
lastTimestamp:  "2026-09-05T10:00:00Z"
source: {component: kubelet}
message: |-
  failed to pull image
  Error response from daemon: manifest unknown: manifest tagged by "v1.2.3" is not found
---
apiVersion: v1
kind: Event
metadata: {name: short-demo, namespace: kubectl-bughunt}
involvedObject: {apiVersion: v1, kind: Pod, name: demo-pod, namespace: kubectl-bughunt}
reason: Started
type: Normal
count: 1
firstTimestamp: "2026-09-05T10:00:00Z"
lastTimestamp:  "2026-09-05T10:00:00Z"
source: {component: kubelet}
message: container started
EOF
```

**Test**
```bash

# Old version kubectl 
zshuang@dev:~/workspace/kubernetes$ kubectl version
Client Version: v1.31.3
Kustomize Version: v5.4.2
Server Version: v1.32.2
zshuang@dev:~/workspace/kubernetes$ kubectl get events -n kubectl-bughunt -o wide
LAST SEEN   TYPE      REASON    OBJECT         SUBOBJECT   SOURCE    MESSAGE                   FIRST SEEN   COUNT   NAME
132m        Warning   Failed    pod/demo-pod               kubelet   failed to pull image...   132m         1       multiline-demo
132m        Normal    Started   pod/demo-pod               kubelet   container started         132m         1       short-demo

# 1.37.0
zshuang@dev:~/workspace/kubernetes$ ~/kubectl version
Client Version: v1.37.0
Kustomize Version: v5.8.1
Server Version: v1.32.2
Warning: version difference between client (1.37) and server (1.32) exceeds the supported minor version skew of +/-1
zshuang@dev:~/workspace/kubernetes$ ~/kubectl get events -n kubectl-bughunt -o wide
LAST SEEN   TYPE      REASON    OBJECT         SUBOBJECT   SOURCE    MESSAGE                                                                                                       FIRST SEEN   COUNT   NAME
132m        Warning   Failed    pod/demo-pod               kubelet   failed to pull image...                                                                                       132m         1       multiline-demo
132m        Normal    Started   pod/demo-pod               kubelet   container started                                                                                             132m         1       short-demo

# Fixed version
zshuang@dev:~/workspace/kubernetes$ _output/bin/kubectl version
Client Version: v1.38.0-alpha.0.498+b2ec8b6fefac45-dirty
Kustomize Version: v5.8.1
Server Version: v1.32.2
Warning: version difference between client (1.38) and server (1.32) exceeds the supported minor version skew of +/-1
zshuang@dev:~/workspace/kubernetes$ _output/bin/kubectl get events -n kubectl-bughunt -o wide
LAST SEEN   TYPE      REASON    OBJECT         SUBOBJECT   SOURCE    MESSAGE                   FIRST SEEN   COUNT   NAME
133m        Warning   Failed    pod/demo-pod               kubelet   failed to pull image...   133m         1       multiline-demo
133m        Normal    Started   pod/demo-pod               kubelet   container started         133m         1       short-demo

```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
printers: measure printed cell width when computing column widths
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
