### PR TITLE
podgc: revalidate node out-of-service taint live before force deleting

### DIFF
--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -179,6 +179,22 @@ func (gcc *PodGCController) gcTerminating(ctx context.Context, pods []*v1.Pod) {
 		wait.Add(1)
 		go func(pod *v1.Pod) {
 			defer wait.Done()
+			// The out-of-service taint is what authorizes force-deleting this pod
+			// without waiting for kubelet to confirm it's gone, so re-verify it
+			// against a live read of the Node right before deleting: gcc.nodeLister
+			// above is a local informer cache that can still show the taint after
+			// an operator has already cleared it (e.g. once the node recovers), and
+			// force-deleting on that stale view can produce two running copies of
+			// the same pod, which is exactly what this taint is meant to prevent.
+			node, err := gcc.kubeClient.CoreV1().Nodes().Get(ctx, pod.Spec.NodeName, metav1.GetOptions{})
+			if err != nil {
+				utilruntime.HandleErrorWithContext(ctx, err, "Failed to get live node before force-deleting terminating pod on out-of-service node", "pod", klog.KObj(pod), "node", klog.KRef("", pod.Spec.NodeName))
+				return
+			}
+			if nodeutil.IsNodeReady(node) || !taints.TaintKeyExists(node.Spec.Taints, v1.TaintNodeOutOfService) {
+				logger.V(4).Info("Skipping force deletion of terminating pod: node is no longer out-of-service", "pod", klog.KObj(pod), "node", klog.KRef("", pod.Spec.NodeName))
+				return
+			}
 			metrics.DeletingPodsTotal.WithLabelValues(pod.Namespace, metrics.PodGCReasonTerminatingOutOfService).Inc()
 			if err := gcc.markFailedAndDeletePod(ctx, pod); err != nil {
 				// ignore not founds

--- a/pkg/controller/podgc/gc_controller_test.go
+++ b/pkg/controller/podgc/gc_controller_test.go
@@ -634,6 +634,84 @@ func TestGCTerminating(t *testing.T) {
 	}
 }
 
+// TestGCTerminatingRevalidatesLiveNodeBeforeForceDeleting covers the case where
+// gcc.nodeLister (the informer cache consulted to decide *which* pods qualify
+// for force deletion) has fallen behind the live Node object. The out-of-service
+// taint is what authorizes force-deleting a terminating pod without waiting for
+// kubelet to confirm it's gone, so acting on a stale copy of that taint can
+// force-delete a pod whose node has, in reality, already recovered - producing
+// two running copies of the same pod.
+func TestGCTerminatingRevalidatesLiveNodeBeforeForceDeleting(t *testing.T) {
+	type node struct {
+		name           string
+		readyCondition v1.ConditionStatus
+		taints         []v1.Taint
+	}
+
+	outOfServiceTaint := []v1.Taint{{Key: v1.TaintNodeOutOfService, Effect: v1.TaintEffectNoExecute}}
+
+	testCases := []struct {
+		name            string
+		cachedNode      node
+		liveNode        node
+		deletedPodNames sets.Set[string]
+	}{
+		{
+			name:            "cache and live node agree the node is out-of-service and not ready: pod is force deleted",
+			cachedNode:      node{name: "worker", readyCondition: v1.ConditionFalse, taints: outOfServiceTaint},
+			liveNode:        node{name: "worker", readyCondition: v1.ConditionFalse, taints: outOfServiceTaint},
+			deletedPodNames: sets.New("a"),
+		},
+		{
+			name:       "an operator already removed the out-of-service taint on the live node, but the informer cache hasn't caught up: pod must not be force deleted",
+			cachedNode: node{name: "worker", readyCondition: v1.ConditionFalse, taints: outOfServiceTaint},
+			liveNode:   node{name: "worker", readyCondition: v1.ConditionFalse},
+		},
+		{
+			name:       "the live node has already recovered (Ready again), but the informer cache still shows it NotReady: pod must not be force deleted",
+			cachedNode: node{name: "worker", readyCondition: v1.ConditionFalse, taints: outOfServiceTaint},
+			liveNode:   node{name: "worker", readyCondition: v1.ConditionTrue, taints: outOfServiceTaint},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			resetMetrics()
+			_, ctx := ktesting.NewTestContext(t)
+
+			newNode := func(n node) *v1.Node {
+				return &v1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: n.name},
+					Spec:       v1.NodeSpec{Taints: n.taints},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{{Type: v1.NodeReady, Status: n.readyCondition}},
+					},
+				}
+			}
+
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: metav1.NamespaceDefault, DeletionTimestamp: &metav1.Time{}},
+				Status:     v1.PodStatus{Phase: v1.PodRunning},
+				Spec:       v1.PodSpec{NodeName: test.cachedNode.name},
+			}
+
+			// The fake clientset stands in for the API server: it only ever knows
+			// about the live node.
+			client := setupNewSimpleClient([]*v1.Node{newNode(test.liveNode)}, []*v1.Pod{pod})
+			gcc, podInformer, nodeInformer := NewFromClient(ctx, client, -1)
+
+			// The informer cache is seeded independently of the fake clientset, so
+			// it can lag behind the live node above exactly as it would during a
+			// real watch delay.
+			podInformer.Informer().GetStore().Add(pod)
+			nodeInformer.Informer().GetStore().Add(newNode(test.cachedNode))
+
+			gcc.gc(ctx)
+			verifyDeletedAndPatchedPods(t, client, test.deletedPodNames, test.deletedPodNames)
+		})
+	}
+}
+
 func TestGCInspectingPatchedPodBeforeDeletion(t *testing.T) {
 	testCases := []struct {
 		name                 string


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`gcTerminating` in `pkg/controller/podgc/gc_controller.go` decides which terminating pods to force-delete by reading the `node.kubernetes.io/out-of-service` taint off `gcc.nodeLister`, which is a local informer cache. If an operator removes that taint (because the node has recovered) before this controller's node informer has caught up with the change, `gcTerminating` still sees the stale taint and force-deletes the pod without waiting for kubelet to confirm it's actually gone.

The out-of-service taint exists specifically to authorize that kind of force deletion once an operator has confirmed the node is truly down (KEP-2268, Non-Graceful Node Shutdown). Acting on a cached view of the taint that the live object has already contradicted defeats that safeguard: it can force-delete a pod whose node has, in reality, already recovered, leaving two copies of the same pod running — the exact split-brain scenario the taint is meant to prevent (e.g. for a StatefulSet pod attached to shared storage).

This PR adds a live `Get` on the Node right before deleting, and skips the deletion if the taint has been removed or the node has become ready again by that point. `gcOrphaned` next to it already does the equivalent live check (`checkIfNodeExists`) before treating a pod as orphaned; `gcTerminating` was missing the analogous check for its own destructive path.

#### Which issue(s) this PR is related to:
N/A — found while auditing controllers that read Node taint state from an informer cache before taking an irreversible action, the same failure pattern behind #139992 in the taint-eviction controller.

#### Special notes for your reviewer:
- Added `TestGCTerminatingRevalidatesLiveNodeBeforeForceDeleting`, which seeds the informer cache and the fake clientset with different Node objects to simulate the cache lagging the live state. Verified it fails against the pre-fix code (force-deletes the pod) and passes with the fix.
- Existing `TestGCTerminating` cases are unaffected since their fixtures already seed matching node state into both the cache and the fake client.
- `go test -race ./pkg/controller/podgc/...`, `go vet`, and `gofmt` are all clean.

#### Does this PR introduce a user-facing change?
```release-note
Fixed a race in the pod garbage collector where a terminating pod on a node tainted `node.kubernetes.io/out-of-service` could be force-deleted based on a stale informer cache even after the taint had already been removed on the live Node.
```


