### PR TITLE
attachdetach: revalidate out-of-service taint live before force detaching

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -176,7 +176,8 @@ func NewAttachDetachController(
 		adc.attacherDetacher,
 		adc.nodeStatusUpdater,
 		adc.nodeLister,
-		recorder)
+		recorder,
+		kubeClient)
 
 	csiTranslator := csitrans.New()
 	adc.intreeToCSITranslator = csiTranslator

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler.go
@@ -26,8 +26,10 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
@@ -75,7 +77,8 @@ func NewReconciler(
 	attacherDetacher operationexecutor.OperationExecutor,
 	nodeStatusUpdater statusupdater.NodeStatusUpdater,
 	nodeLister corelisters.NodeLister,
-	recorder record.EventRecorder) Reconciler {
+	recorder record.EventRecorder,
+	kubeClient clientset.Interface) Reconciler {
 	return &reconciler{
 		loopPeriod:                  loopPeriod,
 		maxWaitForUnmountDuration:   maxWaitForUnmountDuration,
@@ -89,6 +92,7 @@ func NewReconciler(
 		nodeLister:                  nodeLister,
 		timeOfLastSync:              time.Now(),
 		recorder:                    recorder,
+		kubeClient:                  kubeClient,
 	}
 }
 
@@ -105,6 +109,7 @@ type reconciler struct {
 	disableReconciliationSync   bool
 	disableForceDetachOnTimeout bool
 	recorder                    record.EventRecorder
+	kubeClient                  clientset.Interface
 }
 
 func (rc *reconciler) Run(ctx context.Context) {
@@ -233,6 +238,29 @@ func (rc *reconciler) reconcile(ctx context.Context) {
 				logger.V(5).Info("Failed to get taint specs for node",
 					"node", klog.KRef("", string(attachedVolume.NodeName)),
 					"err", err)
+			}
+
+			// hasOutOfServiceTaint above only reflects rc.nodeLister's informer
+			// cache. That taint is what authorizes skipping verifySafeToDetach
+			// below, so before relying on it, revalidate against a live read of
+			// the Node: if an operator already removed the taint (the node
+			// recovered) and this controller's cache hasn't caught up yet,
+			// detaching without the normal safety check can pull the volume out
+			// from under a pod that is actually still running there, and a new
+			// pod attaching it elsewhere risks concurrent writers to the same
+			// volume.
+			if hasOutOfServiceTaint {
+				liveNode, err := rc.kubeClient.CoreV1().Nodes().Get(ctx, string(attachedVolume.NodeName), metav1.GetOptions{})
+				if err != nil {
+					logger.V(5).Info("Failed to get live node to verify out-of-service taint, not skipping the safe-to-detach check",
+						"node", klog.KRef("", string(attachedVolume.NodeName)),
+						"err", err)
+					hasOutOfServiceTaint = false
+				} else if !taints.TaintKeyExists(liveNode.Spec.Taints, v1.TaintNodeOutOfService) {
+					logger.V(4).Info("Node's out-of-service taint was already removed live, not skipping the safe-to-detach check for this volume",
+						"node", klog.KRef("", string(attachedVolume.NodeName)))
+					hasOutOfServiceTaint = false
+				}
 			}
 
 			// Check whether volume is still mounted. Skip detach if it is still mounted unless we have

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler_test.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler_test.go
@@ -84,7 +84,7 @@ func Test_Run_Positive_DoNothing(t *testing.T) {
 		fakeKubeClient, informerFactory.Core().V1().Nodes().Lister(), asw)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder, fakeKubeClient)
 
 	// Act
 	go reconciler.Run(ctx)
@@ -121,7 +121,7 @@ func Test_Run_Positive_OneDesiredVolumeAttach(t *testing.T) {
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder, fakeKubeClient)
 	podName := "pod-uid"
 	volumeName := v1.UniqueVolumeName("volume-name")
 	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
@@ -176,7 +176,7 @@ func Test_Run_Positive_OneDesiredVolumeAttachThenDetachWithUnmountedVolume(t *te
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder, fakeKubeClient)
 	podName := "pod-uid"
 	volumeName := v1.UniqueVolumeName("volume-name")
 	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
@@ -267,7 +267,7 @@ func Test_Run_Positive_OneDesiredVolumeAttachThenDetachWithMountedVolume(t *test
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder, fakeKubeClient)
 	podName := "pod-uid"
 	volumeName := v1.UniqueVolumeName("volume-name")
 	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
@@ -349,7 +349,7 @@ func Test_Run_Negative_OneDesiredVolumeAttachThenDetachWithUnmountedVolumeUpdate
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	nsu := statusupdater.NewFakeNodeStatusUpdater(true /* returnError */)
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder, fakeKubeClient)
 	podName := "pod-uid"
 	volumeName := v1.UniqueVolumeName("volume-name")
 	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
@@ -428,7 +428,7 @@ func Test_Run_OneVolumeAttachAndDetachMultipleNodesWithReadWriteMany(t *testing.
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder, fakeKubeClient)
 	podName1 := "pod-uid1"
 	podName2 := "pod-uid2"
 	volumeName := v1.UniqueVolumeName("volume-name")
@@ -524,7 +524,7 @@ func Test_Run_OneVolumeAttachAndDetachMultipleNodesWithReadWriteOnce(t *testing.
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder, fakeKubeClient)
 	podName1 := "pod-uid1"
 	podName2 := "pod-uid2"
 	volumeName := v1.UniqueVolumeName("volume-name")
@@ -618,7 +618,7 @@ func Test_Run_OneVolumeAttachAndDetachUncertainNodesWithReadWriteOnce(t *testing
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder, fakeKubeClient)
 	podName1 := "pod-uid1"
 	podName2 := "pod-uid2"
 	volumeName := v1.UniqueVolumeName("volume-name")
@@ -681,7 +681,7 @@ func Test_Run_UpdateNodeStatusFailBeforeOneVolumeDetachNodeWithReadWriteOnce(t *
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	rc := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder, fakeKubeClient)
 	reconciliationLoopFunc := rc.(*reconciler).reconciliationLoopFunc(ctx)
 	podName1 := "pod-uid1"
 	volumeName := v1.UniqueVolumeName("volume-name")
@@ -745,7 +745,7 @@ func Test_Run_OneVolumeDetachFailNodeWithReadWriteOnce(t *testing.T) {
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder, fakeKubeClient)
 	podName1 := "pod-uid1"
 	podName2 := "pod-uid2"
 	podName3 := "pod-uid3"
@@ -827,7 +827,7 @@ func Test_Run_OneVolumeAttachAndDetachTimeoutNodesWithReadWriteOnce(t *testing.T
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder, fakeKubeClient)
 	podName1 := "pod-uid1"
 	podName2 := "pod-uid2"
 	volumeName := v1.UniqueVolumeName("volume-name")
@@ -915,7 +915,7 @@ func Test_Run_OneVolumeDetachOnOutOfServiceTaintedNode(t *testing.T) {
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxLongWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad,
-		nsu, nodeLister, fakeRecorder)
+		nsu, nodeLister, fakeRecorder, fakeKubeClient)
 	podName1 := "pod-uid1"
 	volumeName1 := v1.UniqueVolumeName("volume-name1")
 	volumeSpec1 := controllervolumetesting.GetTestVolumeSpec(string(volumeName1), volumeName1)
@@ -925,6 +925,12 @@ func Test_Run_OneVolumeDetachOnOutOfServiceTaintedNode(t *testing.T) {
 		Spec: v1.NodeSpec{
 			Taints: []v1.Taint{{Key: v1.TaintNodeOutOfService, Effect: v1.TaintEffectNoExecute}},
 		},
+	}
+	// The reconciler now revalidates the out-of-service taint against a live
+	// read of the node before skipping the safe-to-detach check, so the fake
+	// clientset needs to carry the taint too, not just the informer cache.
+	if _, err := fakeKubeClient.CoreV1().Nodes().Create(ctx, node1, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create node1: %v", err)
 	}
 	informerFactory.Core().V1().Nodes().Informer().GetStore().Add(node1)
 	dsw.AddNode(nodeName1)
@@ -970,6 +976,98 @@ func Test_Run_OneVolumeDetachOnOutOfServiceTaintedNode(t *testing.T) {
 	testForceDetachMetric(t, int(initialForceDetachCountTimeout), metrics.ForceDetachReasonTimeout)
 }
 
+// Populates the informer cache (rc.nodeLister) with a node carrying the
+// node.kubernetes.io/out-of-service taint, while the live node tracked by the
+// fake clientset never had that taint - simulating an operator removing the
+// taint (the node recovered) before the reconciler's node informer has caught
+// up with the change.
+//
+// Verifies that the volume is NOT force detached: acting on the stale cached
+// taint instead of the live Node would skip the safe-to-detach check for a
+// volume that may still be in active use.
+func Test_Run_OneVolumeDetachOnOutOfServiceTaintedNode_StaleCacheIsNotTrusted(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	registerMetrics.Do(func() {
+		legacyregistry.MustRegister(metrics.ForceDetachMetricCounter)
+	})
+
+	initialForceDetachCountOutOfService, err := metricstestutil.GetCounterMetricValue(metrics.ForceDetachMetricCounter.WithLabelValues(metrics.ForceDetachReasonOutOfService))
+	if err != nil {
+		t.Errorf("Error getting initialForceDetachCountOutOfService")
+	}
+
+	// Arrange
+	volumePluginMgr, fakePlugin := volumetesting.GetTestVolumePluginMgr(t)
+	dsw := cache.NewDesiredStateOfWorld(volumePluginMgr)
+	asw := cache.NewActualStateOfWorld(volumePluginMgr)
+	fakeKubeClient := controllervolumetesting.CreateTestClient(logger)
+	fakeRecorder := &record.FakeRecorder{}
+	fakeHandler := volumetesting.NewBlockVolumePathHandler()
+	ad := operationexecutor.NewOperationExecutor(operationexecutor.NewOperationGenerator(
+		fakeKubeClient,
+		volumePluginMgr,
+		fakeRecorder,
+		fakeHandler))
+	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
+	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
+	nodeLister := informerFactory.Core().V1().Nodes().Lister()
+	// A long timeout so the timeout-based force-detach path can't fire during
+	// this test: any detach we observe must be due to the (stale) taint.
+	reconciler := NewReconciler(
+		reconcilerLoopPeriod, maxLongWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad,
+		nsu, nodeLister, fakeRecorder, fakeKubeClient)
+	podName1 := "pod-uid1"
+	volumeName1 := v1.UniqueVolumeName("volume-name1")
+	volumeSpec1 := controllervolumetesting.GetTestVolumeSpec(string(volumeName1), volumeName1)
+	nodeName1 := k8stypes.NodeName("worker-0")
+
+	// The live node (fake clientset) has recovered: no out-of-service taint.
+	liveNode := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: string(nodeName1)},
+	}
+	if _, err := fakeKubeClient.CoreV1().Nodes().Create(ctx, liveNode, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create liveNode: %v", err)
+	}
+
+	// The cached node (informer store) hasn't caught up yet: it still carries
+	// the out-of-service taint.
+	cachedNode := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: string(nodeName1)},
+		Spec: v1.NodeSpec{
+			Taints: []v1.Taint{{Key: v1.TaintNodeOutOfService, Effect: v1.TaintEffectNoExecute}},
+		},
+	}
+	informerFactory.Core().V1().Nodes().Informer().GetStore().Add(cachedNode)
+	dsw.AddNode(nodeName1)
+
+	generatedVolumeName, podErr := dsw.AddPod(types.UniquePodName(podName1), controllervolumetesting.NewPod(podName1,
+		podName1), volumeSpec1, nodeName1)
+	if podErr != nil {
+		t.Fatalf("AddPod failed. Expected: <no error> Actual: <%v>", podErr)
+	}
+
+	// Act
+	go reconciler.Run(ctx)
+
+	// Assert
+	waitForNewAttacherCallCount(t, 1 /* expectedCallCount */, fakePlugin)
+	waitForAttachCallCount(t, 1 /* expectedAttachCallCount */, fakePlugin)
+
+	// Delete the pod. If the stale cached taint were trusted, this would force
+	// detach immediately, same as Test_Run_OneVolumeDetachOnOutOfServiceTaintedNode
+	// above. Since the live node has no taint, it must not.
+	dsw.DeletePod(types.UniquePodName(podName1), generatedVolumeName, nodeName1)
+	time.Sleep(reconcilerLoopPeriod * 20)
+
+	// Assert -- no detach was triggered, and no force-detach metric was recorded.
+	verifyNewDetacherCallCount(t, true /* expectZeroNewDetacherCallCount */, fakePlugin)
+	waitForDetachCallCount(t, 0 /* expectedDetachCallCount */, fakePlugin)
+	testForceDetachMetric(t, int(initialForceDetachCountOutOfService), metrics.ForceDetachReasonOutOfService)
+}
+
 // Populates desiredStateOfWorld cache with one node/volume/pod tuple.
 // The node does not have the node.kubernetes.io/out-of-service taint present.
 //
@@ -1002,7 +1100,7 @@ func Test_Run_OneVolumeDetachOnNoOutOfServiceTaintedNode(t *testing.T) {
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxLongWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad,
-		nsu, nodeLister, fakeRecorder)
+		nsu, nodeLister, fakeRecorder, fakeKubeClient)
 	podName1 := "pod-uid1"
 	volumeName1 := v1.UniqueVolumeName("volume-name1")
 	volumeSpec1 := controllervolumetesting.GetTestVolumeSpec(string(volumeName1), volumeName1)
@@ -1080,7 +1178,7 @@ func Test_Run_OneVolumeDetachOnUnhealthyNode(t *testing.T) {
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad,
-		nsu, nodeLister, fakeRecorder)
+		nsu, nodeLister, fakeRecorder, fakeKubeClient)
 	podName1 := "pod-uid1"
 	volumeName1 := v1.UniqueVolumeName("volume-name1")
 	volumeSpec1 := controllervolumetesting.GetTestVolumeSpec(string(volumeName1), volumeName1)
@@ -1197,7 +1295,7 @@ func Test_Run_OneVolumeDetachOnUnhealthyNodeWithForceDetachOnUnmountDisabled(t *
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, true, dsw, asw, ad,
-		nsu, nodeLister, fakeRecorder)
+		nsu, nodeLister, fakeRecorder, fakeKubeClient)
 	podName1 := "pod-uid1"
 	volumeName1 := v1.UniqueVolumeName("volume-name1")
 	volumeSpec1 := controllervolumetesting.GetTestVolumeSpec(string(volumeName1), volumeName1)
@@ -1212,6 +1310,9 @@ func Test_Run_OneVolumeDetachOnUnhealthyNodeWithForceDetachOnUnmountDisabled(t *
 				},
 			},
 		},
+	}
+	if _, err := fakeKubeClient.CoreV1().Nodes().Create(ctx, node1, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create node1: %v", err)
 	}
 	addErr := informerFactory.Core().V1().Nodes().Informer().GetStore().Add(node1)
 	if addErr != nil {
@@ -1278,6 +1379,12 @@ func Test_Run_OneVolumeDetachOnUnhealthyNodeWithForceDetachOnUnmountDisabled(t *
 	// Taint the node
 	node3 := node2.DeepCopy()
 	node3.Spec.Taints = append(node3.Spec.Taints, v1.Taint{Key: v1.TaintNodeOutOfService, Effect: v1.TaintEffectNoExecute})
+	// The reconciler now revalidates the out-of-service taint against a live
+	// read of the node before skipping the safe-to-detach check, so the fake
+	// clientset needs to carry the taint too, not just the informer cache.
+	if _, err := fakeKubeClient.CoreV1().Nodes().Update(ctx, node3, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("Failed to update node3: %v", err)
+	}
 	updateErr = informerFactory.Core().V1().Nodes().Informer().GetStore().Update(node3)
 	if updateErr != nil {
 		t.Fatalf("Update node failed. Expected: <no error> Actual: <%v>", updateErr)
@@ -1359,7 +1466,7 @@ func Test_ReportWaitingOnDetach(t *testing.T) {
 		nodeLister := informerFactory.Core().V1().Nodes().Lister()
 		nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 		rc := NewReconciler(
-			reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+			reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder, fakeKubeClient)
 
 		nodes := []k8stypes.NodeName{}
 		for _, n := range test.nodes {

--- a/pkg/controller/volume/attachdetach/testing/testvolumespec.go
+++ b/pkg/controller/volume/attachdetach/testing/testvolumespec.go
@@ -21,6 +21,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -146,6 +147,22 @@ func CreateTestClient(logger klog.Logger) *fake.Clientset {
 			}
 		}
 		return true, updateAction.GetObject(), nil
+	})
+	fakeClient.AddReactor("create", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+		createAction := action.(core.CreateAction)
+		node := createAction.GetObject().(*v1.Node)
+		nodes.Items = append(nodes.Items, *node)
+		return true, createAction.GetObject(), nil
+	})
+	fakeClient.AddReactor("get", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+		getAction := action.(core.GetAction)
+		for _, n := range nodes.Items {
+			if n.Name == getAction.GetName() {
+				node := n
+				return true, &node, nil
+			}
+		}
+		return true, nil, apierrors.NewNotFound(v1.Resource("nodes"), getAction.GetName())
 	})
 	fakeClient.AddReactor("list", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 		obj := &v1.NodeList{}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`reconciler.hasOutOfServiceTaint` checks the `node.kubernetes.io/out-of-service` taint against `rc.nodeLister`, which is a local informer cache. When the taint is present, `reconcile()` sets `verifySafeToDetach := false` and calls `DetachVolume` directly, skipping the normal check that the volume isn't still in use. If an operator removes the taint (because the node has recovered) before this controller's node informer has caught up with that change, the reconciler still sees the stale cached taint and force-detaches the volume without that safety check.

`verifySafeToDetach` exists precisely to avoid detaching a volume that's still genuinely in use. Skipping it based on a cached taint that the live Node object has already contradicted can pull a volume out from under a pod that's actually still running there. If that volume then gets attached to a different node, both can end up writing to it — for a `ReadWriteOnce` volume, that's silent data corruption, not just an extra pod.

This PR adds a live `Get` on the Node right before relying on the taint to skip the safety check, and falls back to the normal `verifySafeToDetach` path if the live object disagrees or the read fails. `gcOrphaned` in the pod GC controller already does the equivalent live check (`checkIfNodeExists`) before treating a pod as orphaned; this gives the attach/detach reconciler's out-of-service path the same guarantee.

#### Which issue(s) this PR is related to:
N/A — found while auditing other call sites of the `node.kubernetes.io/out-of-service` taint for the same stale-informer-cache pattern behind #139992 in the taint-eviction controller and a related fix I made to the pod GC controller's `gcTerminating`.

#### Special notes for your reviewer:
- Threading `kubeClient` into the reconciler required adding it to `NewReconciler`'s signature and updating all existing call sites (production + all 16 test constructions).
- The shared test fake client (`controllervolumetesting.CreateTestClient`, used by this package and `pkg/controller/volume/expand`) had no `get` or `create` reactor registered for Nodes — nothing previously called those verbs through it. Added both, mirroring its existing `update`/`list` reactor pattern; this is additive and doesn't change behavior for any existing caller.
- Two existing tests (`Test_Run_OneVolumeDetachOnOutOfServiceTaintedNode`, `Test_Run_OneVolumeDetachOnUnhealthyNodeWithForceDetachOnUnmountDisabled`) only ever seeded the taint into the informer cache, never into the fake clientset's live state. Updated both to keep cache and live state consistent, which is now required for them to still exercise the scenario they're named for.
- Added `Test_Run_OneVolumeDetachOnOutOfServiceTaintedNode_StaleCacheIsNotTrusted`, which seeds the cache and the fake clientset with disagreeing Node objects. Verified it fails (force-detaches immediately) with the live check disabled and passes with the fix.
- `go build ./...`, `go test -race ./pkg/controller/volume/attachdetach/... ./pkg/controller/volume/expand/...`, `go vet`, and `gofmt` are all clean.

#### Does this PR introduce a user-facing change?
```release-note
Fixed a race in the attach/detach reconciler where a volume on a node tainted `node.kubernetes.io/out-of-service` could be force-detached based on a stale informer cache even after the taint had already been removed on the live Node.
```

