### PR TITLE
apiserver/cacher: have Snapshot.RangePrefix return a Range

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/snapshot_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/snapshot_test.go
@@ -102,14 +102,14 @@ func TestSnapshotListPrefix(t *testing.T) {
 					}
 					assert.Equal(t, tc.expectKeys, listed, "OrderedListPrefix")
 
+					r := snapshot.RangePrefix(tc.prefix, tc.continueKey)
 					var ranged []string
-					for elem, err := range snapshot.RangePrefix(tc.prefix, tc.continueKey) {
+					for elem, err := range r.All() {
 						require.NoError(t, err)
 						ranged = append(ranged, elem.Key)
 					}
 					assert.Equal(t, tc.expectKeys, ranged, "RangePrefix")
-
-					assert.Equal(t, len(tc.expectKeys), snapshot.Count(tc.prefix, tc.continueKey), "Count")
+					assert.Equal(t, len(tc.expectKeys), r.Count(), "Count")
 				})
 			}
 		})

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store.go
@@ -69,7 +69,6 @@ type Indexer interface {
 	GetByKey(key string) (item interface{}, exists bool, err error)
 	Replace([]interface{}, string) error
 	ByIndex(indexName, indexedValue string) ([]interface{}, error)
-	Count(prefix, continueKey string) (count int)
 	Clone() Snapshot
 	OrderedListPrefix(prefix, continueKey string) ([]interface{}, error)
 }
@@ -78,12 +77,32 @@ type Indexer interface {
 type Snapshot interface {
 	GetByKey(key string) (item interface{}, exists bool, err error)
 	OrderedListPrefix(prefix, continueKey string) ([]interface{}, error)
-	// RangePrefix iterates the elements with the given key prefix, in key
-	// order, starting from continueKey.
-	RangePrefix(prefix, continueKey string) iter.Seq2[*Element, error]
-	// Count returns the number of items RangePrefix(prefix, continueKey)
-	// would visit.
-	Count(prefix, continueKey string) (count int)
+	RangePrefix(prefix, continueKey string) Range
+}
+
+// Range is the elements of a Snapshot with a given key prefix, in key
+// order, starting from continueKey.
+type Range interface {
+	All() iter.Seq2[*Element, error]
+	Count() int
+}
+
+type prefixRanger interface {
+	rangePrefix(prefix, continueKey string) iter.Seq2[*Element, error]
+	countPrefix(prefix, continueKey string) int
+}
+
+type prefixRange struct {
+	snapshot            prefixRanger
+	prefix, continueKey string
+}
+
+func (r prefixRange) All() iter.Seq2[*Element, error] {
+	return r.snapshot.rangePrefix(r.prefix, r.continueKey)
+}
+
+func (r prefixRange) Count() int {
+	return r.snapshot.countPrefix(r.prefix, r.continueKey)
 }
 
 func NewIndexer(indexers *cache.Indexers) Indexer {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree.go
@@ -44,12 +44,6 @@ type threadedStoreIndexer struct {
 	indexer indexer
 }
 
-func (si *threadedStoreIndexer) Count(prefix, continueKey string) (count int) {
-	si.lock.RLock()
-	defer si.lock.RUnlock()
-	return si.store.Count(prefix, continueKey)
-}
-
 func (si *threadedStoreIndexer) Clone() Snapshot {
 	// Clone should not be called concurrently.
 	si.lock.Lock()
@@ -270,7 +264,11 @@ func (s *btreeStore) OrderedListPrefix(prefix, continueKey string) ([]interface{
 	return result, nil
 }
 
-func (s *btreeStore) RangePrefix(prefix, continueKey string) iter.Seq2[*Element, error] {
+func (s *btreeStore) RangePrefix(prefix, continueKey string) Range {
+	return prefixRange{s, prefix, continueKey}
+}
+
+func (s *btreeStore) rangePrefix(prefix, continueKey string) iter.Seq2[*Element, error] {
 	if continueKey == "" {
 		continueKey = prefix
 	}
@@ -284,7 +282,7 @@ func (s *btreeStore) RangePrefix(prefix, continueKey string) iter.Seq2[*Element,
 	}
 }
 
-func (s *btreeStore) Count(prefix, continueKey string) (count int) {
+func (s *btreeStore) countPrefix(prefix, continueKey string) (count int) {
 	if continueKey == "" {
 		continueKey = prefix
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package store
 
 import (
-	"iter"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -166,10 +165,7 @@ func (f fakeIndexer) ListKeys() []string {
 func (f fakeIndexer) Replace([]interface{}, string) error {
 	return nil
 }
-func (f fakeIndexer) Count(prefixKey, continueKey string) int { return 0 }
-func (f fakeIndexer) RangePrefix(prefixKey, continueKey string) iter.Seq2[*Element, error] {
-	return func(yield func(*Element, error) bool) {}
-}
+func (f fakeIndexer) RangePrefix(prefixKey, continueKey string) Range { return nil }
 
 type fakeSnapshotter struct {
 	getLessOrEqual func(rv uint64) (Snapshot, bool)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/watch_cache_storage.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/watch_cache_storage.go
@@ -145,7 +145,11 @@ func (o orderedListSnapshot) OrderedListPrefix(prefix, continueKey string) ([]in
 	return o.Items, nil
 }
 
-func (o orderedListSnapshot) RangePrefix(prefix, continueKey string) iter.Seq2[*Element, error] {
+func (o orderedListSnapshot) RangePrefix(prefix, continueKey string) Range {
+	return prefixRange{o, prefix, continueKey}
+}
+
+func (o orderedListSnapshot) rangePrefix(prefix, continueKey string) iter.Seq2[*Element, error] {
 	return func(yield func(*Element, error) bool) {
 		for _, item := range o.Items {
 			elem, ok := item.(*Element)
@@ -160,7 +164,7 @@ func (o orderedListSnapshot) RangePrefix(prefix, continueKey string) iter.Seq2[*
 	}
 }
 
-func (o orderedListSnapshot) Count(prefix, continueKey string) int {
+func (o orderedListSnapshot) countPrefix(prefix, continueKey string) int {
 	return len(o.Items)
 }
 
@@ -200,7 +204,12 @@ func (l listSnapshot) OrderedListPrefix(prefix string, continueKey string) ([]in
 	return result, nil
 }
 
-func (l listSnapshot) RangePrefix(prefix, continueKey string) iter.Seq2[*Element, error] {
+func (l listSnapshot) RangePrefix(prefix, continueKey string) Range {
+	// TODO: filter and sort once here instead of on every All and Count.
+	return prefixRange{l, prefix, continueKey}
+}
+
+func (l listSnapshot) rangePrefix(prefix, continueKey string) iter.Seq2[*Element, error] {
 	return func(yield func(*Element, error) bool) {
 		items, err := l.OrderedListPrefix(prefix, continueKey)
 		if err != nil {
@@ -216,9 +225,7 @@ func (l listSnapshot) RangePrefix(prefix, continueKey string) iter.Seq2[*Element
 	}
 }
 
-// Count returns the number of items RangePrefix(prefix, continueKey) would
-// yield, by applying its filter without allocating or sorting.
-func (l listSnapshot) Count(prefix, continueKey string) int {
+func (l listSnapshot) countPrefix(prefix, continueKey string) int {
 	count := 0
 	for _, item := range l.Items {
 		elem, ok := item.(*Element)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval_test.go
@@ -19,7 +19,6 @@ package cacher
 import (
 	"errors"
 	"fmt"
-	"iter"
 	"reflect"
 	"sort"
 	"sync"
@@ -543,18 +542,8 @@ func (s *countingSnapshot) OrderedListPrefix(_, _ string) ([]interface{}, error)
 	return s.items, nil
 }
 
-func (s *countingSnapshot) RangePrefix(_, _ string) iter.Seq2[*store.Element, error] {
-	return func(yield func(*store.Element, error) bool) {
-		for _, item := range s.items {
-			if !yield(item.(*store.Element), nil) {
-				return
-			}
-		}
-	}
-}
-
-func (s *countingSnapshot) Count(_, _ string) int {
-	return len(s.items)
+func (s *countingSnapshot) RangePrefix(_, _ string) store.Range {
+	return nil
 }
 
 // TestLazySnapshotCacheIntervalSourceEmpty checks that on an empty snapshot Next() returns


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Prep for #140896, from the discussion [there](https://github.com/kubernetes/kubernetes/pull/140896#discussion_r3926975068): `Snapshot.RangePrefix(prefix, continueKey)` and `Snapshot.Count(prefix, continueKey)` took the same arguments, so a caller wanting both had to carry them next to the snapshot. `RangePrefix` now returns a `Range` and `Count` moves onto it:

```go
type Snapshot interface {
	GetByKey(key string) (item interface{}, exists bool, err error)
	OrderedListPrefix(prefix, continueKey string) ([]interface{}, error)
	RangePrefix(prefix, continueKey string) Range
}

type Range interface {
	All() iter.Seq2[*Element, error]
	Count() int
}
```

Interface change only: `Range` delegates to each snapshot's existing range and count code, which is unchanged. `Indexer.Count` had no callers and is removed.

#140896 rebased on this is `listResp{ResourceVersion uint64; store.Range}` with no request fields; #141824 then removes `OrderedListPrefix`.

#### Which issue(s) this PR is related to:

Prerequisite for #140896.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
