### PR TITLE
pv_controller: revalidate claim live before deleting released volume

### DIFF
--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -1238,7 +1238,7 @@ func (ctrl *PersistentVolumeController) recycleVolumeOperation(ctx context.Conte
 		logger.V(3).Info("Error reading persistent volume", "volumeName", volume.Name, "err", err)
 		return
 	}
-	needsReclaim, err := ctrl.isVolumeReleased(logger, newVolume)
+	needsReclaim, err := ctrl.isVolumeReleased(ctx, logger, newVolume)
 	if err != nil {
 		logger.V(3).Info("Error reading claim for volume", "volumeName", volume.Name, "err", err)
 		return
@@ -1351,7 +1351,7 @@ func (ctrl *PersistentVolumeController) deleteVolumeOperation(ctx context.Contex
 		return "", nil
 	}
 
-	needsReclaim, err := ctrl.isVolumeReleased(logger, newVolume)
+	needsReclaim, err := ctrl.isVolumeReleased(ctx, logger, newVolume)
 	if err != nil {
 		logger.V(3).Info("Error reading claim for volume", "volumeName", volume.Name, "err", err)
 		return "", nil
@@ -1400,7 +1400,7 @@ func (ctrl *PersistentVolumeController) deleteVolumeOperation(ctx context.Contex
 // isVolumeReleased returns true if given volume is released and can be recycled
 // or deleted, based on its retain policy. I.e. the volume is bound to a claim
 // and the claim does not exist or exists and is bound to different volume.
-func (ctrl *PersistentVolumeController) isVolumeReleased(logger klog.Logger, volume *v1.PersistentVolume) (bool, error) {
+func (ctrl *PersistentVolumeController) isVolumeReleased(ctx context.Context, logger klog.Logger, volume *v1.PersistentVolume) (bool, error) {
 	// A volume needs reclaim if it has ClaimRef and appropriate claim does not
 	// exist.
 	if volume.Spec.ClaimRef == nil {
@@ -1421,7 +1421,23 @@ func (ctrl *PersistentVolumeController) isVolumeReleased(logger klog.Logger, vol
 		return false, err
 	}
 	if !found {
-		// Fall through with claim = nil
+		// ctrl.claims is populated from this controller's claim informer, so
+		// "not found" here normally means the claim was deleted. But it can
+		// also just mean the informer's cache is temporarily behind the API
+		// server (e.g. right after a relist). Since returning true here can
+		// lead to the underlying storage being permanently deleted, confirm
+		// against the API server that the claim is actually gone before
+		// trusting the cache.
+		liveClaim, err := ctrl.kubeClient.CoreV1().PersistentVolumeClaims(volume.Spec.ClaimRef.Namespace).Get(ctx, volume.Spec.ClaimRef.Name, metav1.GetOptions{})
+		switch {
+		case apierrors.IsNotFound(err):
+			// Confirmed live: claim stays nil.
+		case err != nil:
+			return false, err
+		default:
+			logger.V(4).Info("isVolumeReleased: claim missing from cache but present live, not releasing", "volumeName", volume.Name, "PVC", klog.KObj(liveClaim))
+			claim = liveClaim
+		}
 	} else {
 		var ok bool
 		claim, ok = obj.(*v1.PersistentVolumeClaim)

--- a/pkg/controller/volume/persistentvolume/pv_controller_test.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_test.go
@@ -472,6 +472,78 @@ func TestControllerCacheParsingError(t *testing.T) {
 	}
 }
 
+// TestIsVolumeReleased verifies that isVolumeReleased does not treat a volume
+// as released purely because its claim is momentarily missing from
+// ctrl.claims. That cache is populated asynchronously from the claim
+// informer and can lag behind the API server (e.g. right after a relist);
+// isVolumeReleased must fall back to a live check before authorizing
+// permanent deletion of the volume's backing storage.
+func TestIsVolumeReleased(t *testing.T) {
+	const claimUID = "uid-is-released-1"
+	const claimName = "claim-is-released-1"
+
+	tests := []struct {
+		name string
+		// claimCached: the claim is present in ctrl.claims.
+		claimCached bool
+		// claimLive: a claim with the same UID exists on the API server.
+		claimLive        bool
+		expectedReleased bool
+	}{
+		{
+			name:             "claim is cached and still bound, volume is not released",
+			claimCached:      true,
+			claimLive:        true,
+			expectedReleased: false,
+		},
+		{
+			name:             "claim is genuinely gone from cache and API server, volume is released",
+			claimCached:      false,
+			claimLive:        false,
+			expectedReleased: true,
+		},
+		{
+			name:             "claim missing only from ctrl.claims but still live, volume must not be released",
+			claimCached:      false,
+			claimLive:        true,
+			expectedReleased: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			claim := newClaim(claimName, claimUID, "1Gi", "", v1.ClaimBound, nil)
+			pv := newVolume("volume-is-released-1", "1Gi", claimUID, claimName, v1.VolumeBound, v1.PersistentVolumeReclaimDelete, classEmpty)
+
+			client := fake.NewSimpleClientset()
+			logger, ctx := ktesting.NewTestContext(t)
+			if test.claimLive {
+				if _, err := client.CoreV1().PersistentVolumeClaims(claim.Namespace).Create(ctx, claim, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Failed to create live claim: %v", err)
+				}
+			}
+
+			ctrl, err := newTestController(ctx, client, nil, false)
+			if err != nil {
+				t.Fatalf("Failed to create controller: %v", err)
+			}
+			if test.claimCached {
+				if err := ctrl.claims.Add(claim); err != nil {
+					t.Fatalf("Failed to seed claim cache: %v", err)
+				}
+			}
+
+			released, err := ctrl.isVolumeReleased(ctx, logger, pv)
+			if err != nil {
+				t.Fatalf("isVolumeReleased returned unexpected error: %v", err)
+			}
+			if released != test.expectedReleased {
+				t.Errorf("isVolumeReleased() = %v, want %v", released, test.expectedReleased)
+			}
+		})
+	}
+}
+
 func makeStorageClass(scName string, mode *storagev1.VolumeBindingMode) *storagev1.StorageClass {
 	return &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes a race in `isVolumeReleased` where a `PersistentVolume` with reclaim policy `Delete` could be marked as released (and its backing storage deleted) due to a transient cache miss in `ctrl.claims` informer store (e.g. during a relist or watch hiccup).

Unlike other controller cleanup paths, `isVolumeReleased` had no live API fallback before letting `deleteVolumeOperation` trigger backing storage deletion.

This PR adds a live `Get` fallback on the PVC before concluding the claim is deleted. If the claim is found live on the API server, the volume is not released.

- Added live fallback read in `isVolumeReleased` when cache lookup misses.
- Added `TestIsVolumeReleased` in `pv_controller_test.go` to test cached, live, and cache-miss scenarios.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

/sig storage
/cc @carlory @xing-yang @jsafrane @msau42

#### Does this PR introduce a user-facing change?

```release-note
Fixed a race condition in the PersistentVolume controller where a volume could be reported as released, and its backing storage deleted, due to a transient informer cache miss.
```