### PR TITLE
perf(scheduler): decouple async API calls client to prevent bind throttling

### DIFF
--- a/REPO.md
+++ b/REPO.md
@@ -1,0 +1,42 @@
+# Kubernetes — Repository Context
+
+## Purpose
+Production-Grade Container Scheduling and Management.
+
+## GitHub
+https://github.com/kubernetes/kubernetes
+
+## Language
+Go
+
+## Fork / Local Path
+`c:\Users\parik\Downloads\lfxx\Batch-02-Cloud-Infrastructure\Kubernetes`
+
+---
+
+## Architecture Overview
+Kubernetes control plane and node architecture:
+- `pkg/kubelet`: Node agent
+- `pkg/controller`: Controllers (daemonset, deployment, job, etc.)
+- `pkg/scheduler`: Pod scheduler
+- `staging/src/k8s.io/kubectl`: Command line interface and client-side drain/eviction logic
+- `staging/src/k8s.io/apiserver`: Core API machinery and HTTP handlers
+- `staging/src/k8s.io/client-go`: Client SDK
+
+## Build
+```bash
+make
+go build ./...
+```
+
+## Test Commands
+```bash
+go test -v ./staging/src/k8s.io/kubectl/pkg/drain
+```
+
+## PR Conventions
+- Title format: `fix(scope): concise description`
+- Draft PR opened, Closes issue #
+
+## Previous Contributions from This Workspace
+- **PR #141607**: `fix(kubectl): stop drain eviction retry loop when pod is recreated or rescheduled` (Closes #138229)

--- a/cmd/kube-scheduler/app/config/config.go
+++ b/cmd/kube-scheduler/app/config/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	SecureServing  *apiserver.SecureServingInfo
 
 	Client             clientset.Interface
+	AsyncClient        clientset.Interface
 	KubeConfig         *restclient.Config
 	InformerFactory    informers.SharedInformerFactory
 	DynInformerFactory dynamicinformer.DynamicSharedInformerFactory

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -316,7 +316,7 @@ func (o *Options) Config(ctx context.Context) (*schedulerappconfig.Config, error
 	}
 
 	// Prepare kube clients.
-	client, eventClient, err := createClients(c.KubeConfig)
+	client, eventClient, asyncClient, err := createClients(c.KubeConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -339,6 +339,7 @@ func (o *Options) Config(ctx context.Context) (*schedulerappconfig.Config, error
 	}
 
 	c.Client = client
+	c.AsyncClient = asyncClient
 	c.InformerFactory = scheduler.NewInformerFactory(client, 0, o.InformerName)
 	dynClient := dynamic.NewForConfigOrDie(c.KubeConfig)
 	c.DynInformerFactory = dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, 0, corev1.NamespaceAll, nil)
@@ -399,17 +400,22 @@ func createKubeConfig(config componentbaseconfig.ClientConnectionConfiguration, 
 	return kubeConfig, nil
 }
 
-// createClients creates a kube client and an event client from the given kubeConfig
-func createClients(kubeConfig *restclient.Config) (clientset.Interface, clientset.Interface, error) {
+// createClients creates a kube client, an event client, and an async client from the given kubeConfig
+func createClients(kubeConfig *restclient.Config) (clientset.Interface, clientset.Interface, clientset.Interface, error) {
 	client, err := clientset.NewForConfig(restclient.AddUserAgent(kubeConfig, "scheduler"))
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	eventClient, err := clientset.NewForConfig(kubeConfig)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return client, eventClient, nil
+	asyncClient, err := clientset.NewForConfig(restclient.AddUserAgent(kubeConfig, "scheduler-async"))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return client, eventClient, asyncClient, nil
 }

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -475,6 +475,7 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 		scheduler.WithPodMaxInUnschedulablePodsDuration(cc.PodMaxInUnschedulablePodsDuration),
 		scheduler.WithExtenders(cc.ComponentConfig.Extenders...),
 		scheduler.WithParallelism(cc.ComponentConfig.Parallelism),
+		scheduler.WithAsyncClient(cc.AsyncClient),
 		scheduler.WithBuildFrameworkCapturer(func(profile kubeschedulerconfig.KubeSchedulerProfile) {
 			// Profiles are processed during Framework instantiation to set default plugins and configurations. Capturing them for logging
 			completedProfiles = append(completedProfiles, profile)

--- a/pkg/scheduler/framework_init.go
+++ b/pkg/scheduler/framework_init.go
@@ -142,7 +142,11 @@ func newFrameworkComponents(ctx context.Context,
 
 	var apiDispatcher *apidispatcher.APIDispatcher
 	if feature.DefaultFeatureGate.Enabled(features.SchedulerAsyncAPICalls) {
-		apiDispatcher = apidispatcher.New(client, int(options.parallelism), apicalls.Relevances)
+		dispatcherClient := client
+		if options.asyncClient != nil {
+			dispatcherClient = options.asyncClient
+		}
+		apiDispatcher = apidispatcher.New(dispatcherClient, int(options.parallelism), apicalls.Relevances)
 	}
 
 	schedulerCache := internalcache.New(ctx, apiDispatcher, feature.DefaultFeatureGate.Enabled(features.GenericWorkload), feature.DefaultFeatureGate.Enabled(features.CompositePodGroup))

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -139,6 +139,7 @@ type schedulerOptions struct {
 	frameworkCapturer          FrameworkCapturer
 	parallelism                int32
 	applyDefaultProfile        bool
+	asyncClient                clientset.Interface
 }
 
 // Option configures a Scheduler
@@ -171,6 +172,13 @@ func WithComponentConfigVersion(apiVersion string) Option {
 func WithKubeConfig(cfg *restclient.Config) Option {
 	return func(o *schedulerOptions) {
 		o.kubeConfig = cfg
+	}
+}
+
+// WithAsyncClient sets the async client for Scheduler.
+func WithAsyncClient(client clientset.Interface) Option {
+	return func(o *schedulerOptions) {
+		o.asyncClient = client
 	}
 }
 


### PR DESCRIPTION
## Problem

When SchedulerAsyncAPICalls is enabled, the asynchronous status updates share the same client-go client instance with essential operations like pod binding. In clusters with a high rate of unschedulable pods, the accumulation of async requests heavily throttles the shared client, severely delaying critical Bind operations and impacting overall scheduler throughput.

## Root Cause

The scheduler uses a single clientset.Interface for both its synchronous critical path and the APIDispatcher responsible for background API calls. Since the client's rate limiter is shared, flooding it with background updates starves synchronous calls.

## Solution

This PR decouples the AsyncClient from the main Client. By creating a separate client with its own rate limiter (via clientset.NewForConfig(restclient.AddUserAgent(kubeConfig, "scheduler-async"))), the async background requests get their own token bucket. If the async queue floods the client and throttles it, the main client (handling bindings) is completely unaffected.

## Benchmark

Tested against a heavy unschedulable pod workload:
Before: Bind API calls heavily delayed due to shared client throttling.
After: Bind API calls process immediately without queue contention, maintaining high scheduler placement throughput.

## Regression Testing
Validated against standard scheduler test suites.

## Trade-offs
Marginally higher initial memory overhead for instantiating an additional clientset.Interface and rate limiter, which is negligible compared to the performance benefit of isolating the critical path.

## Issue
Closes #135900
