### PR TITLE
Record cacher queue latency in watch dispatch metrics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
@@ -578,8 +578,9 @@ func TestCacheWatcherDrainingNoBookmarkAfterResourceVersionSent(t *testing.T) {
 		ResourceVersion: 5,
 		RecordTime:      fakeClock.Now().Add(-2 * time.Second),
 		timeline: metrics.DispatchTimeline{
-			metrics.PointStorageDecoded: fakeClock.Now().Add(-2 * time.Second),
-			metrics.PointCacheReceived:  fakeClock.Now().Add(-1 * time.Second),
+			metrics.PointStorageDecoded:  fakeClock.Now().Add(-2 * time.Second),
+			metrics.PointCacheReceived:   fakeClock.Now().Add(-1 * time.Second),
+			metrics.PointDispatchStarted: fakeClock.Now().Add(-500 * time.Millisecond),
 		},
 	}, time.NewTimer(1*time.Second)) {
 		t.Fatal("failed adding an even to the watcher")
@@ -592,8 +593,9 @@ func TestCacheWatcherDrainingNoBookmarkAfterResourceVersionSent(t *testing.T) {
 		ResourceVersion: 15,
 		RecordTime:      fakeClock.Now().Add(-2 * time.Second),
 		timeline: metrics.DispatchTimeline{
-			metrics.PointStorageDecoded: fakeClock.Now().Add(-2 * time.Second),
-			metrics.PointCacheReceived:  fakeClock.Now().Add(-1 * time.Second),
+			metrics.PointStorageDecoded:  fakeClock.Now().Add(-2 * time.Second),
+			metrics.PointCacheReceived:   fakeClock.Now().Add(-1 * time.Second),
+			metrics.PointDispatchStarted: fakeClock.Now().Add(-500 * time.Millisecond),
 		},
 	}, time.NewTimer(1*time.Second)) {
 		t.Fatal("failed adding an even to the watcher")
@@ -636,6 +638,9 @@ func TestCacheWatcherDrainingNoBookmarkAfterResourceVersionSent(t *testing.T) {
 	expected := `
 # HELP apiserver_watch_events_dispatch_duration_seconds [ALPHA] Histogram of watch event dispatch latency broken by resource type and pipeline stage. The 'total' stage is the end-to-end latency of a delivered event.
 # TYPE apiserver_watch_events_dispatch_duration_seconds histogram
+apiserver_watch_events_dispatch_duration_seconds_bucket{group="",resource="pods",stage="cacher_queue_latency",le="+Inf"} 2
+apiserver_watch_events_dispatch_duration_seconds_sum{group="",resource="pods",stage="cacher_queue_latency"} 1
+apiserver_watch_events_dispatch_duration_seconds_count{group="",resource="pods",stage="cacher_queue_latency"} 2
 apiserver_watch_events_dispatch_duration_seconds_bucket{group="",resource="pods",stage="storage_to_cache",le="+Inf"} 2
 apiserver_watch_events_dispatch_duration_seconds_sum{group="",resource="pods",stage="storage_to_cache"} 2
 apiserver_watch_events_dispatch_duration_seconds_count{group="",resource="pods",stage="storage_to_cache"} 2

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -940,6 +940,7 @@ func (c *Cacher) dispatchEvents() {
 			// of a bookmark event or regular Add/Update/Delete operation by
 			// checking if resourceVersion here has changed.
 			if event.Type != watch.Bookmark {
+				event.timeline.MarkAt(metrics.PointDispatchStarted, c.clock.Now())
 				c.dispatchEvent(&event)
 				metrics.EventsCounter.WithLabelValues(c.groupResource.Group, c.groupResource.Resource).Inc()
 			}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -43,6 +43,8 @@ const (
 	PointStorageDecoded DispatchPoint = iota
 	// PointCacheReceived: the event was first processed by the cacher's reflector loop.
 	PointCacheReceived
+	// PointDispatchStarted: the event was dequeued from cacher.incoming and dispatching began.
+	PointDispatchStarted
 	// PointEventBuilt: the outgoing watch.Event was built (filter + convert).
 	PointEventBuilt
 	// PointSentToClient: the watch.Event was written to the watcher's result channel.
@@ -74,6 +76,7 @@ var dispatchStages = []struct {
 	from, to DispatchPoint
 }{
 	{"storage_to_cache", PointStorageDecoded, PointCacheReceived},
+	{"cacher_queue_latency", PointCacheReceived, PointDispatchStarted},
 	{"watcher_to_client_handler", PointEventBuilt, PointSentToClient},
 	{"total", PointStorageDecoded, PointSentToClient},
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Adds the cacher_queue_latency stage to the apiserver_watch_events_dispatch_duration_seconds histogram metric. This measures the duration an event spends queued in cacher.incoming from the time it is received from reflector/storage (PointCacheReceived) until it is dequeued for dispatching (PointDispatchStarted). This helps identify whether watch dispatch latency spikes are caused by backpressure in the cacher's incoming event queue.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
https://github.com/kubernetes/kubernetes/issues/138774

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added the `cacher_queue_latency` stage to the `apiserver_watch_events_dispatch_duration_seconds` metric to measure watch event queuing latency in the cacher.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->

YES, to add the new label to the metric and update the test.