### PR TITLE
Record watcher queue latency in watch dispatch metrics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
@@ -546,12 +546,13 @@ func (c *cacheWatcher) process(ctx context.Context, resourceVersion uint64) {
 			if !ok {
 				return
 			}
+			dequeuedAt := c.clock.Now()
 			// only send events newer than resourceVersion
 			// or a bookmark event with an RV equal to resourceVersion
 			// if we haven't sent one to the client
 			if event.ResourceVersion > resourceVersion || (event.Type == watch.Bookmark && event.ResourceVersion == resourceVersion && !c.wasBookmarkAfterRvSent()) {
 				builtAt, sentAt := c.sendWatchCacheEvent(event)
-				c.observeDispatchMetrics(event, builtAt, sentAt)
+				c.observeDispatchMetrics(event, dequeuedAt, builtAt, sentAt)
 			}
 		case <-ctx.Done():
 			return
@@ -559,13 +560,14 @@ func (c *cacheWatcher) process(ctx context.Context, resourceVersion uint64) {
 	}
 }
 
-func (c *cacheWatcher) observeDispatchMetrics(event *watchCacheEvent, builtAt, sentAt time.Time) {
+func (c *cacheWatcher) observeDispatchMetrics(event *watchCacheEvent, dequeuedAt, builtAt, sentAt time.Time) {
 	if event.Type == watch.Bookmark || sentAt.IsZero() {
 		return
 	}
 	// The pre-fanout points are marked in processEvent; complete the per-watcher
 	// tail here then emit all stages.
 	tl := event.timeline
+	tl.MarkAt(metrics.PointWatcherDequeued, dequeuedAt)
 	tl.MarkAt(metrics.PointEventBuilt, builtAt)
 	tl.MarkAt(metrics.PointSentToClient, sentAt)
 	c.watcherMetrics.ObserveTimeline(&tl)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
@@ -581,6 +581,7 @@ func TestCacheWatcherDrainingNoBookmarkAfterResourceVersionSent(t *testing.T) {
 			metrics.PointStorageDecoded:  fakeClock.Now().Add(-2 * time.Second),
 			metrics.PointCacheReceived:   fakeClock.Now().Add(-1 * time.Second),
 			metrics.PointDispatchStarted: fakeClock.Now().Add(-500 * time.Millisecond),
+			metrics.PointWatcherEnqueued: fakeClock.Now().Add(-500 * time.Millisecond),
 		},
 	}, time.NewTimer(1*time.Second)) {
 		t.Fatal("failed adding an even to the watcher")
@@ -596,6 +597,7 @@ func TestCacheWatcherDrainingNoBookmarkAfterResourceVersionSent(t *testing.T) {
 			metrics.PointStorageDecoded:  fakeClock.Now().Add(-2 * time.Second),
 			metrics.PointCacheReceived:   fakeClock.Now().Add(-1 * time.Second),
 			metrics.PointDispatchStarted: fakeClock.Now().Add(-500 * time.Millisecond),
+			metrics.PointWatcherEnqueued: fakeClock.Now().Add(-500 * time.Millisecond),
 		},
 	}, time.NewTimer(1*time.Second)) {
 		t.Fatal("failed adding an even to the watcher")
@@ -647,6 +649,9 @@ apiserver_watch_events_dispatch_duration_seconds_count{group="",resource="pods",
 apiserver_watch_events_dispatch_duration_seconds_bucket{group="",resource="pods",stage="total",le="+Inf"} 2
 apiserver_watch_events_dispatch_duration_seconds_sum{group="",resource="pods",stage="total"} 4
 apiserver_watch_events_dispatch_duration_seconds_count{group="",resource="pods",stage="total"} 2
+apiserver_watch_events_dispatch_duration_seconds_bucket{group="",resource="pods",stage="watcher_queue_latency",le="+Inf"} 2
+apiserver_watch_events_dispatch_duration_seconds_sum{group="",resource="pods",stage="watcher_queue_latency"} 1
+apiserver_watch_events_dispatch_duration_seconds_count{group="",resource="pods",stage="watcher_queue_latency"} 2
 apiserver_watch_events_dispatch_duration_seconds_bucket{group="",resource="pods",stage="watcher_to_client_handler",le="+Inf"} 2
 apiserver_watch_events_dispatch_duration_seconds_sum{group="",resource="pods",stage="watcher_to_client_handler"} 0
 apiserver_watch_events_dispatch_duration_seconds_count{group="",resource="pods",stage="watcher_to_client_handler"} 2

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -1022,6 +1022,7 @@ func (c *Cacher) dispatchEvent(event *watchCacheEvent) {
 		// Make a shallow copy to allow overwriting Object and PrevObject.
 		wcEvent := *event
 		setCachingObjects(&wcEvent, c.versioner)
+		wcEvent.timeline.MarkAt(metrics.PointWatcherEnqueued, c.clock.Now())
 		event = &wcEvent
 
 		c.blockedWatchers = c.blockedWatchers[:0]

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -45,6 +45,10 @@ const (
 	PointCacheReceived
 	// PointDispatchStarted: the event was dequeued from cacher.incoming and dispatching began.
 	PointDispatchStarted
+	// PointWatcherEnqueued: the event was enqueued to the watcher's input channel.
+	PointWatcherEnqueued
+	// PointWatcherDequeued: the event was dequeued from the watcher's input channel.
+	PointWatcherDequeued
 	// PointEventBuilt: the outgoing watch.Event was built (filter + convert).
 	PointEventBuilt
 	// PointSentToClient: the watch.Event was written to the watcher's result channel.
@@ -77,6 +81,7 @@ var dispatchStages = []struct {
 }{
 	{"storage_to_cache", PointStorageDecoded, PointCacheReceived},
 	{"cacher_queue_latency", PointCacheReceived, PointDispatchStarted},
+	{"watcher_queue_latency", PointWatcherEnqueued, PointWatcherDequeued},
 	{"watcher_to_client_handler", PointEventBuilt, PointSentToClient},
 	{"total", PointStorageDecoded, PointSentToClient},
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Adds the `watcher_queue_latency` stage to the `apiserver_watch_events_dispatch_duration_seconds` histogram metric. This measures the duration an event spends in an individual watcher's input channel buffer (`cacheWatcher.input`) from the moment the cacher dispatches/enqueues it (`PointWatcherEnqueued`) until the watcher worker goroutine dequeues it (`PointWatcherDequeued`). This helps identify delays caused by individual slow or blocked watchers buffering events before processing and transmitting them to clients.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
https://github.com/kubernetes/kubernetes/issues/138774

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added the `watcher_queue_latency` stage to the `apiserver_watch_events_dispatch_duration_seconds` metric to measure watch event queuing latency in individual watch buffers.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->

YES, to add the new label to the metric and update the test.