### PR TITLE
Add timeout for initial watch events to prevent goroutine leaks

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
@@ -50,6 +50,14 @@ const (
 	cacheWatcherBookmarkSent
 )
 
+// initEventsTimeout is how long we wait for a client to accept a single
+// initial event before terminating its watch.
+//
+// The timer is reset after every event we manage to send, so this bounds how
+// long a watch may make no progress at all, not how long it may take to
+// deliver all of its initial events.
+const initEventsTimeout = 30 * time.Second
+
 // cacheWatcher implements watch.Interface
 // this is not thread-safe
 type cacheWatcher struct {
@@ -412,13 +420,23 @@ func (c *cacheWatcher) convertToWatchEvent(event *watchCacheEvent) *watch.Event 
 }
 
 // NOTE: sendWatchCacheEvent is assumed to not modify <event> !!!
-func (c *cacheWatcher) sendWatchCacheEvent(event *watchCacheEvent) (builtAt, sentAt time.Time) {
+//
+// A nil timer means that the send is not bounded by a timeout and will block
+// until the event is delivered or the watcher is stopped. It returns
+// terminated=true if the watcher was closed because the send timed out.
+func (c *cacheWatcher) sendWatchCacheEvent(event *watchCacheEvent, timer clock.Timer) (builtAt, sentAt time.Time, terminated bool) {
 	watchEvent := c.convertToWatchEvent(event)
 	if watchEvent == nil {
 		// Watcher is not interested in that object.
-		return time.Time{}, time.Time{}
+		return time.Time{}, time.Time{}, false
 	}
 	builtAt = c.clock.Now()
+	// Note that receiving from a nil channel blocks forever, which is exactly
+	// the behaviour we want when no timer was given.
+	var timeoutCh <-chan time.Time
+	if timer != nil {
+		timeoutCh = timer.C()
+	}
 
 	// We need to ensure that if we put event X to the c.result, all
 	// previous events were already put into it before, no matter whether
@@ -434,7 +452,7 @@ func (c *cacheWatcher) sendWatchCacheEvent(event *watchCacheEvent) (builtAt, sen
 	// events.
 	select {
 	case <-c.done:
-		return time.Time{}, time.Time{}
+		return time.Time{}, time.Time{}, false
 	default:
 	}
 
@@ -443,14 +461,23 @@ func (c *cacheWatcher) sendWatchCacheEvent(event *watchCacheEvent) (builtAt, sen
 		c.markBookmarkAfterRvSent(event)
 		sentAt = c.clock.Now()
 	case <-c.done:
+	case <-timeoutCh:
+		// The client is not reading the events we have already sent it, so we
+		// terminate the watcher instead of blocking this goroutine (and
+		// pinning the events it still has to send) indefinitely. The client
+		// can re-establish the watch.
+		klog.V(1).Infof("Forcing %v watcher close due to unresponsiveness while sending initial events: %v. len(c.input) = %v, len(c.result) = %v", c.groupResource.String(), c.identifier, len(c.input), len(c.result))
+		return time.Time{}, time.Time{}, true
 	}
-	return builtAt, sentAt
+	return builtAt, sentAt, false
 }
 
 func (c *cacheWatcher) processInterval(ctx context.Context, cacheInterval *watchCacheInterval, resourceVersion uint64) {
 	defer utilruntime.HandleCrashWithContext(ctx)
 	defer close(c.result)
 	defer c.Stop()
+	timer := c.clock.NewTimer(initEventsTimeout)
+	defer timer.Stop()
 
 	// Check how long we are processing initEvents.
 	// As long as these are not processed, we are not processing
@@ -499,7 +526,11 @@ func (c *cacheWatcher) processInterval(ctx context.Context, cacheInterval *watch
 		if event == nil {
 			break
 		}
-		c.sendWatchCacheEvent(event)
+		_, _, terminated := c.sendWatchCacheEvent(event, timer)
+		if terminated {
+			return
+		}
+		resetTimer(timer, initEventsTimeout)
 
 		// With some events already sent, update resourceVersion so that
 		// events that were buffered and not yet processed won't be delivered
@@ -526,8 +557,14 @@ func (c *cacheWatcher) processInterval(ctx context.Context, cacheInterval *watch
 
 	// send bookmark after sending all events in cacheInterval for watchlist request
 	if cacheInterval.initialEventsEndBookmark != nil {
-		c.sendWatchCacheEvent(cacheInterval.initialEventsEndBookmark)
+		_, _, terminated := c.sendWatchCacheEvent(cacheInterval.initialEventsEndBookmark, timer)
+		if terminated {
+			return
+		}
 	}
+	// All initial events have been sent. From here on unresponsive watchers are
+	// detected at dispatch time by add(), so the timeout no longer applies.
+	timer.Stop()
 	c.process(ctx, resourceVersion)
 }
 
@@ -551,7 +588,7 @@ func (c *cacheWatcher) process(ctx context.Context, resourceVersion uint64) {
 			// or a bookmark event with an RV equal to resourceVersion
 			// if we haven't sent one to the client
 			if event.ResourceVersion > resourceVersion || (event.Type == watch.Bookmark && event.ResourceVersion == resourceVersion && !c.wasBookmarkAfterRvSent()) {
-				builtAt, sentAt := c.sendWatchCacheEvent(event)
+				builtAt, sentAt, _ := c.sendWatchCacheEvent(event, nil)
 				c.observeDispatchMetrics(event, dequeuedAt, builtAt, sentAt)
 			}
 		case <-ctx.Done():
@@ -571,4 +608,14 @@ func (c *cacheWatcher) observeDispatchMetrics(event *watchCacheEvent, dequeuedAt
 	tl.MarkAt(metrics.PointEventBuilt, builtAt)
 	tl.MarkAt(metrics.PointSentToClient, sentAt)
 	c.watcherMetrics.ObserveTimeline(&tl)
+}
+
+func resetTimer(t clock.Timer, d time.Duration) {
+	if !t.Stop() {
+		select {
+		case <-t.C():
+		default:
+		}
+	}
+	t.Reset(d)
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
@@ -718,6 +718,66 @@ func TestBookmarkAfterResourceVersionWatchers(t *testing.T) {
 	}
 }
 
+// TestCacheWatcherStuckOnInitEvents verifies that a client which stops reading
+// the events it asked for does not keep the processInterval goroutine (and the
+// snapshot of initial events it holds) alive forever.
+func TestCacheWatcherStuckOnInitEvents(t *testing.T) {
+	filter := func(string, labels.Set, fields.Set, runtime.Object) bool { return true }
+	forgotten := make(chan bool, 10)
+	forget := func(drainWatcher bool) { forgotten <- drainWatcher }
+
+	initEvents := []*watchCacheEvent{
+		{Object: makeTestPod("pod1", 1), ResourceVersion: 1},
+		{Object: makeTestPod("pod2", 2), ResourceVersion: 2},
+		{Object: makeTestPod("pod3", 3), ResourceVersion: 3},
+		{Object: makeTestPod("pod4", 4), ResourceVersion: 4},
+	}
+
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	// A chanSize of 1 gives us a result channel that a client which never
+	// reads will fill immediately.
+	w := newCacheWatcher(1, filter, forget, storage.APIObjectVersioner{}, time.Now().Add(time.Hour), true,
+		schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), fakeClock, "")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		w.processInterval(context.Background(), intervalFromEvents(initEvents), 0)
+	}()
+
+	// Wait until the result channel is full and the timer is armed, i.e. the
+	// sender is parked on an event the client will never read. Waiting on
+	// HasWaiters() alone would not be enough, as the timer is already armed
+	// before the first event is sent.
+	if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, wait.ForeverTestTimeout, true,
+		func(context.Context) (bool, error) {
+			return len(w.ResultChan()) == 1 && fakeClock.HasWaiters(), nil
+		}); err != nil {
+		t.Fatalf("processInterval didn't block sending initial events: %v", err)
+	}
+	select {
+	case <-done:
+		t.Fatalf("processInterval returned before the timeout elapsed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	fakeClock.Step(initEventsTimeout + time.Second)
+
+	select {
+	case <-done:
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("processInterval is still blocked after the %v timeout elapsed", initEventsTimeout)
+	}
+	select {
+	case drainWatcher := <-forgotten:
+		if drainWatcher {
+			t.Errorf("expected forget(false), the client is not reading so there is nothing to drain")
+		}
+	default:
+		t.Errorf("expected forget() to be called when the send timed out")
+	}
+}
+
 func gatherWithoutBuckets(gatherer compbasemetrics.Gatherer) testutil.GathererFunc {
 	return func() ([]*testutil.MetricFamily, error) {
 		got, err := gatherer.Gather()


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig api-machinery
#### What this PR does / why we need it: 
A watch request that asks for initial events (`sendInitialEvents=true`, or `resourceVersion=0`) is served by `cacheWatcher.processInterval`, which sends a snapshot of the current state to the watcher's result channel before switching to streaming. That channel is drained by the request handler as it writes the response, so a client that stops reading applies backpressure: the buffer fills and the send blocks. The send has no timeout, so the goroutine parks there until the request deadline (`--min-request-timeout`, 30 minutes by default), holding the snapshot of initial events -- which for a cluster-wide watch covers every object of that resource.

This adds a 30s timeout to that send. The timer is reset after every event that is successfully sent, so it bounds how long a watch may make no progress at all, not how long it may take to deliver all initial events: a slow but progressing client is unaffected.
#### Which issue(s) this PR is related to:
fixes #131721

#### Special notes for your reviewer:
`process()` needs no timeout: it only delivers events that arrived through the input channel, and a watcher that stops draining that channel is already closed from the producer side in add(). Initial events never go through that channel.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug in kube-apiserver where a watch request using `sendInitialEvents` (or `resourceVersion=0`) could hold its initial snapshot of objects in memory until the request timeout if the client stopped reading the response. Such watches are now closed after 30 seconds without progress, and the client can re-establish the watch.
```


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:
YES, comments polishing, code reviewing and the test writing
<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
