### PR TITLE
scheduler: report pending gang quorum in pod events

### DIFF
--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
@@ -36,6 +36,8 @@ import (
 const (
 	// Name is the name of the plugin used in the plugin registry and configurations.
 	Name = names.GangScheduling
+
+	gangSchedulingPendingReason = "GangSchedulingPending"
 )
 
 // GangScheduling is a plugin that enforces "all-or-nothing" scheduling for pods
@@ -233,7 +235,16 @@ func (pl *GangScheduling) preEnqueueWithHierarchies(pod *v1.Pod) *fwk.Status {
 		if pl.isPGReady(snapshot, namespace, podGroup.Name, func(s fwk.PodGroupState) int { return s.AllPodsCount() }) {
 			return nil
 		}
-		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for minCount pods from a gang to appear in scheduling queue")
+		podGroupState, err := snapshot.PodGroupStates().Get(namespace, podGroup.Name)
+		if err != nil {
+			return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for minCount pods from a gang to appear in scheduling queue")
+		}
+		allPodsCount := podGroupState.AllPodsCount()
+		minCount := int(podGroup.Spec.SchedulingPolicy.Gang.MinCount)
+		if allPodsCount >= minCount {
+			return nil
+		}
+		return pl.gangPendingStatus(pod, allPodsCount, minCount)
 	}
 
 	return pl.checkCPGHierarchyReadiness(snapshot, namespace, *podGroup.Spec.ParentCompositePodGroupName, func(s fwk.PodGroupState) int { return s.AllPodsCount() })
@@ -268,11 +279,19 @@ func (pl *GangScheduling) preEnqueueHierarchiesDisabled(pod *v1.Pod) *fwk.Status
 	}
 	allPodsCount := podGroupState.AllPodsCount()
 	if allPodsCount < int(policy.Gang.MinCount) {
-		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for minCount pods from a gang to appear in scheduling queue")
+		return pl.gangPendingStatus(pod, allPodsCount, int(policy.Gang.MinCount))
 	}
 
 	// The quorum is met, allow the pod to enter the scheduling queue.
 	return nil
+}
+
+func (pl *GangScheduling) gangPendingStatus(pod *v1.Pod, available, required int) *fwk.Status {
+	message := fmt.Sprintf("waiting for gang quorum: %d/%d pods are available", available, required)
+	if recorder := pl.handle.EventRecorder(); recorder != nil {
+		recorder.Eventf(pod, nil, v1.EventTypeNormal, gangSchedulingPendingReason, "Scheduling", message)
+	}
+	return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, message)
 }
 
 // checkCPGHierarchyReadiness checks if the Composite Pod Group hierarchy is ready for scheduling.

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -29,6 +29,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/events"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
@@ -680,6 +681,7 @@ func TestPreEnqueue(t *testing.T) {
 		initialCompositePodGroups  []*schedulingv1alpha3.CompositePodGroup
 		isCompositePodGroupEnabled []bool
 		wantPreEnqueueStatus       *fwk.Status
+		wantEvent                  string
 	}
 	baseTests := []testCase{
 		{
@@ -718,7 +720,8 @@ func TestPreEnqueue(t *testing.T) {
 			pod:                        p1,
 			initialPods:                []*v1.Pod{p2, p4, p5},
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2},
-			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for minCount pods from a gang to appear in scheduling queue"),
+			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for gang quorum: 2/3 pods are available"),
+			wantEvent:                  "Normal GangSchedulingPending waiting for gang quorum: 2/3 pods are available",
 		},
 		{
 			name:                       "gang pod passes PreEnqueue",
@@ -798,7 +801,8 @@ func TestPreEnqueue(t *testing.T) {
 			initialPods:                []*v1.Pod{p1_1BasicCPG, p1_2BasicCPG},
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pgBasic1CPG, pgBasic2CPG},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgBasicRoot},
-			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for minCount pods from a gang to appear in scheduling queue"),
+			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for gang quorum: 1/2 pods are available"),
+			wantEvent:                  "Normal GangSchedulingPending waiting for gang quorum: 1/2 pods are available",
 		},
 	}
 
@@ -820,8 +824,10 @@ func TestPreEnqueue(t *testing.T) {
 				}
 				fakeActivator := &podActivatorMock{}
 				snapshot := internalcache.NewEmptySnapshot()
+				eventRecorder := events.NewFakeRecorder(1)
 				fh, err := frameworkruntime.NewFramework(ctx, nil, nil,
 					frameworkruntime.WithInformerFactory(informerFactory),
+					frameworkruntime.WithEventRecorder(eventRecorder),
 					frameworkruntime.WithPodGroupManager(cache),
 					frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
 					frameworkruntime.WithPodActivator(fakeActivator),
@@ -863,6 +869,16 @@ func TestPreEnqueue(t *testing.T) {
 				gotPreEnqueueStatus := pl.PreEnqueue(ctx, tt.pod)
 				if diff := cmp.Diff(tt.wantPreEnqueueStatus, gotPreEnqueueStatus); diff != "" {
 					t.Fatalf("Unexpected PreEnqueue status (-want,+got):\n%s", diff)
+				}
+				if tt.wantEvent != "" {
+					select {
+					case gotEvent := <-eventRecorder.Events:
+						if gotEvent != tt.wantEvent {
+							t.Fatalf("Unexpected event: got %q, want %q", gotEvent, tt.wantEvent)
+						}
+					default:
+						t.Fatalf("Expected event %q, but no event was recorded", tt.wantEvent)
+					}
 				}
 			})
 		}


### PR DESCRIPTION
## What this PR does / why we need it

When GangScheduling rejects a Pod in `PreEnqueue` because the PodGroup has fewer pods than `minCount`, the Pod is gated before a scheduling cycle starts. As a result, users see `Pending` with no `PodScheduled` condition and no `FailedScheduling` Event, even though the scheduler has a concrete reason.

This change:

- reports the current gang quorum in the PreEnqueue status, for example `waiting for gang quorum: 3/4 pods are available`;
- emits a `Normal` `GangSchedulingPending` Event on the gated Pod with the same diagnostic;
- preserves the existing gating and scheduling behavior;
- keeps Basic PodGroups and CompositePodGroup hierarchy handling unchanged.

The Event is associated with the Pod so it is visible through `kubectl describe pod` in clusters using the v1alpha1 Workload API, where PodGroups are embedded in Workloads.

## Related issue

Related to #141025

## Testing

- `go test ./pkg/scheduler/framework/plugins/gangscheduling -count=1`
- `go test ./pkg/scheduler/...`

```release-note
When GangScheduling gates a Pod because a gang has not reached minCount, kube-scheduler reports the current quorum in the Pod's scheduling status and emits a GangSchedulingPending Event.
```
