### PR TITLE
Migrate pkg/credentialprovider/plugin to contextual logging

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -347,7 +347,6 @@ linters:
             structured k8s.io/kms/.*
             structured k8s.io/apiserver/pkg/storage/value/.*
             structured k8s.io/apiserver/pkg/server/options/encryptionconfig/.*
-            structured k8s.io/kubernetes/pkg/credentialprovider/plugin/.*
             
             # The following packages have been migrated to contextual logging.
             # Packages matched here do not have to be listed above because
@@ -378,6 +377,7 @@ linters:
             contextual k8s.io/kubernetes/pkg/client/.*
             contextual k8s.io/kubernetes/pkg/cluster/.*
             contextual k8s.io/kubernetes/pkg/controller/.*
+            contextual k8s.io/kubernetes/pkg/credentialprovider/plugin/.*
             contextual k8s.io/kubernetes/pkg/features/.*
             contextual k8s.io/kubernetes/pkg/fieldpath/.*
             contextual k8s.io/kubernetes/pkg/generated/.*

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -360,7 +360,6 @@ linters:
             structured k8s.io/kms/.*
             structured k8s.io/apiserver/pkg/storage/value/.*
             structured k8s.io/apiserver/pkg/server/options/encryptionconfig/.*
-            structured k8s.io/kubernetes/pkg/credentialprovider/plugin/.*
             
             # The following packages have been migrated to contextual logging.
             # Packages matched here do not have to be listed above because
@@ -391,6 +390,7 @@ linters:
             contextual k8s.io/kubernetes/pkg/client/.*
             contextual k8s.io/kubernetes/pkg/cluster/.*
             contextual k8s.io/kubernetes/pkg/controller/.*
+            contextual k8s.io/kubernetes/pkg/credentialprovider/plugin/.*
             contextual k8s.io/kubernetes/pkg/features/.*
             contextual k8s.io/kubernetes/pkg/fieldpath/.*
             contextual k8s.io/kubernetes/pkg/generated/.*

--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -19,7 +19,6 @@ structured k8s.io/kubernetes/pkg/proxy/.*
 structured k8s.io/kms/.*
 structured k8s.io/apiserver/pkg/storage/value/.*
 structured k8s.io/apiserver/pkg/server/options/encryptionconfig/.*
-structured k8s.io/kubernetes/pkg/credentialprovider/plugin/.*
 
 # The following packages have been migrated to contextual logging.
 # Packages matched here do not have to be listed above because
@@ -50,6 +49,7 @@ contextual k8s.io/kubernetes/pkg/capabilities/.*
 contextual k8s.io/kubernetes/pkg/client/.*
 contextual k8s.io/kubernetes/pkg/cluster/.*
 contextual k8s.io/kubernetes/pkg/controller/.*
+contextual k8s.io/kubernetes/pkg/credentialprovider/plugin/.*
 contextual k8s.io/kubernetes/pkg/features/.*
 contextual k8s.io/kubernetes/pkg/fieldpath/.*
 contextual k8s.io/kubernetes/pkg/generated/.*

--- a/pkg/credentialprovider/keyring.go
+++ b/pkg/credentialprovider/keyring.go
@@ -17,6 +17,7 @@ limitations under the License.
 package credentialprovider
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -40,7 +41,7 @@ import (
 //     most specific match for a given image
 //   - iterating a map does not yield predictable results
 type DockerKeyring interface {
-	Lookup(image string) ([]TrackedAuthConfig, bool)
+	Lookup(ctx context.Context, image string) ([]TrackedAuthConfig, bool)
 }
 
 // BasicDockerKeyring is a trivial map-backed implementation of DockerKeyring
@@ -291,7 +292,7 @@ func URLsMatch(globURL *url.URL, targetURL *url.URL) (bool, error) {
 // Lookup implements the DockerKeyring method for fetching credentials based on image name.
 // Multiple credentials may be returned if there are multiple potentially valid credentials
 // available.  This allows for rotation.
-func (dk *BasicDockerKeyring) Lookup(image string) ([]TrackedAuthConfig, bool) {
+func (dk *BasicDockerKeyring) Lookup(ctx context.Context, image string) ([]TrackedAuthConfig, bool) {
 	// range over the index as iterating over a map does not provide a predictable ordering
 	ret := []TrackedAuthConfig{}
 	for _, k := range dk.index {
@@ -318,14 +319,14 @@ func (dk *BasicDockerKeyring) Lookup(image string) ([]TrackedAuthConfig, bool) {
 
 // Lookup implements the DockerKeyring method for fetching credentials
 // based on image name.
-func (dk *providersDockerKeyring) Lookup(image string) ([]TrackedAuthConfig, bool) {
+func (dk *providersDockerKeyring) Lookup(ctx context.Context, image string) ([]TrackedAuthConfig, bool) {
 	keyring := &BasicDockerKeyring{}
 
 	for _, p := range dk.Providers {
 		keyring.Add(nil, p.Provide(image))
 	}
 
-	return keyring.Lookup(image)
+	return keyring.Lookup(ctx, image)
 }
 
 // FakeKeyring a fake config credentials
@@ -336,7 +337,7 @@ type FakeKeyring struct {
 
 // Lookup implements the DockerKeyring method for fetching credentials based on image name
 // return fake auth and ok
-func (f *FakeKeyring) Lookup(image string) ([]TrackedAuthConfig, bool) {
+func (f *FakeKeyring) Lookup(ctx context.Context, image string) ([]TrackedAuthConfig, bool) {
 	return f.auth, f.ok
 }
 
@@ -345,14 +346,14 @@ type UnionDockerKeyring []DockerKeyring
 
 // Lookup implements the DockerKeyring method for fetching credentials based on image name.
 // return each credentials
-func (k UnionDockerKeyring) Lookup(image string) ([]TrackedAuthConfig, bool) {
+func (k UnionDockerKeyring) Lookup(ctx context.Context, image string) ([]TrackedAuthConfig, bool) {
 	authConfigs := []TrackedAuthConfig{}
 	for _, subKeyring := range k {
 		if subKeyring == nil {
 			continue
 		}
 
-		currAuthResults, _ := subKeyring.Lookup(image)
+		currAuthResults, _ := subKeyring.Lookup(ctx, image)
 		authConfigs = append(authConfigs, currAuthResults...)
 	}
 

--- a/pkg/credentialprovider/keyring_test.go
+++ b/pkg/credentialprovider/keyring_test.go
@@ -229,7 +229,7 @@ func TestDockerKeyringForGlob(t *testing.T) {
 			keyring.Add(nil, cfg)
 		}
 
-		creds, ok := keyring.Lookup(test.targetURL + "/foo/bar")
+		creds, ok := keyring.Lookup(t.Context(), test.targetURL+"/foo/bar")
 		if !ok {
 			t.Errorf("%d: Didn't find expected URL: %s", i, test.targetURL)
 			continue
@@ -297,7 +297,7 @@ func TestKeyringMiss(t *testing.T) {
 			keyring.Add(nil, cfg)
 		}
 
-		_, ok := keyring.Lookup(test.lookupURL + "/foo/bar")
+		_, ok := keyring.Lookup(t.Context(), test.lookupURL+"/foo/bar")
 		if ok {
 			t.Errorf("Expected not to find URL %s, but found", test.lookupURL)
 		}
@@ -325,7 +325,7 @@ func TestKeyringMissWithDockerHubCredentials(t *testing.T) {
 		keyring.Add(nil, cfg)
 	}
 
-	val, ok := keyring.Lookup("world.mesos.org/foo/bar")
+	val, ok := keyring.Lookup(t.Context(), "world.mesos.org/foo/bar")
 	if ok {
 		t.Errorf("Found unexpected credential: %+v", val)
 	}
@@ -351,7 +351,7 @@ func TestKeyringHitWithUnqualifiedDockerHub(t *testing.T) {
 		keyring.Add(nil, cfg)
 	}
 
-	creds, ok := keyring.Lookup("google/docker-registry")
+	creds, ok := keyring.Lookup(t.Context(), "google/docker-registry")
 	if !ok {
 		t.Errorf("Didn't find expected URL: %s", url)
 		return
@@ -392,7 +392,7 @@ func TestKeyringHitWithUnqualifiedLibraryDockerHub(t *testing.T) {
 		keyring.Add(nil, cfg)
 	}
 
-	creds, ok := keyring.Lookup("jenkins")
+	creds, ok := keyring.Lookup(t.Context(), "jenkins")
 	if !ok {
 		t.Errorf("Didn't find expected URL: %s", url)
 		return
@@ -433,7 +433,7 @@ func TestKeyringHitWithQualifiedDockerHub(t *testing.T) {
 		keyring.Add(nil, cfg)
 	}
 
-	creds, ok := keyring.Lookup(url + "/google/docker-registry")
+	creds, ok := keyring.Lookup(t.Context(), url+"/google/docker-registry")
 	if !ok {
 		t.Errorf("Didn't find expected URL: %s", url)
 		return
@@ -487,15 +487,15 @@ func TestProvidersDockerKeyring(t *testing.T) {
 	if provider.Count != 0 {
 		t.Errorf("Unexpected number of Provide calls: %v", provider.Count)
 	}
-	keyring.Lookup("foo")
+	keyring.Lookup(t.Context(), "foo")
 	if provider.Count != 1 {
 		t.Errorf("Unexpected number of Provide calls: %v", provider.Count)
 	}
-	keyring.Lookup("foo")
+	keyring.Lookup(t.Context(), "foo")
 	if provider.Count != 2 {
 		t.Errorf("Unexpected number of Provide calls: %v", provider.Count)
 	}
-	keyring.Lookup("foo")
+	keyring.Lookup(t.Context(), "foo")
 	if provider.Count != 3 {
 		t.Errorf("Unexpected number of Provide calls: %v", provider.Count)
 	}
@@ -558,7 +558,7 @@ func TestDockerKeyringLookup(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		match, ok := dk.Lookup(tt.image)
+		match, ok := dk.Lookup(t.Context(), tt.image)
 		if tt.ok != ok {
 			t.Errorf("case %d: expected ok=%t, got %t", i, tt.ok, ok)
 		}
@@ -605,7 +605,7 @@ func TestIssue3797(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		match, ok := dk.Lookup(tt.image)
+		match, ok := dk.Lookup(t.Context(), tt.image)
 		if tt.ok != ok {
 			t.Errorf("case %d: expected ok=%t, got %t", i, tt.ok, ok)
 		}

--- a/pkg/credentialprovider/plugin/plugin.go
+++ b/pkg/credentialprovider/plugin/plugin.go
@@ -405,17 +405,18 @@ type perPodPluginProvider struct {
 // used for credential resolution. If ServiceAccountCoordinates is nil, it means no service account
 // context was used (e.g., the plugin is not operating in service account token mode or no service
 // account was provided for the request).
-func (p *perPodPluginProvider) provideWithCoordinates(image string) (credentialprovider.DockerConfig, *credentialprovider.ServiceAccountCoordinates) {
-	credentials, coordinates, err := p.provider.provide(image, p.podNamespace, p.podName, p.podUID, p.serviceAccountName)
+func (p *perPodPluginProvider) provideWithCoordinates(ctx context.Context, image string) (credentialprovider.DockerConfig, *credentialprovider.ServiceAccountCoordinates) {
+	credentials, coordinates, err := p.provider.provide(ctx, image, p.podNamespace, p.podName, p.podUID, p.serviceAccountName)
 	if err == nil {
 		return credentials, coordinates
 	}
 
 	// If there was an error providing credentials, we log the error but do not return it.
+	logger := klog.FromContext(ctx)
 	if p.provider.serviceAccountProvider != nil {
-		klog.ErrorS(err, "Failed to provide credentials for image", "provider", p.provider.name, "image", image, "pod", klog.KRef(p.podNamespace, p.podName), "podUID", p.podUID, "serviceAccount", klog.KRef(p.podNamespace, p.serviceAccountName))
+		logger.Error(err, "Failed to provide credentials for image", "provider", p.provider.name, "image", image, "pod", klog.KRef(p.podNamespace, p.podName), "podUID", p.podUID, "serviceAccount", klog.KRef(p.podNamespace, p.serviceAccountName))
 	} else {
-		klog.ErrorS(err, "Failed to provide credentials for image", "provider", p.provider.name, "image", image)
+		logger.Error(err, "Failed to provide credentials for image", "provider", p.provider.name, "image", image)
 	}
 
 	return credentialprovider.DockerConfig{}, nil
@@ -426,7 +427,7 @@ func (p *perPodPluginProvider) provideWithCoordinates(image string) (credentialp
 // If ServiceAccountCoordinates is nil, it means no service account context was used
 // (e.g., the plugin is not operating in service account token mode or no service account
 // was provided for the request).
-func (p *pluginProvider) provide(image, podNamespace, podName string, podUID types.UID, serviceAccountName string) (credentialprovider.DockerConfig, *credentialprovider.ServiceAccountCoordinates, error) {
+func (p *pluginProvider) provide(ctx context.Context, image, podNamespace, podName string, podUID types.UID, serviceAccountName string) (credentialprovider.DockerConfig, *credentialprovider.ServiceAccountCoordinates, error) {
 	if !p.isImageAllowed(image) {
 		return credentialprovider.DockerConfig{}, nil, nil
 	}
@@ -441,7 +442,7 @@ func (p *pluginProvider) provide(image, podNamespace, podName string, podUID typ
 
 	if p.serviceAccountProvider != nil {
 		if len(serviceAccountName) == 0 && p.serviceAccountProvider.requireServiceAccount {
-			klog.V(5).InfoS("Service account name is empty", "provider", p.name, "image", image, "pod", klog.KRef(podNamespace, podName), "podUID", podUID)
+			klog.FromContext(ctx).V(5).Info("Service account name is empty", "provider", p.name, "image", image, "pod", klog.KRef(podNamespace, podName), "podUID", podUID)
 			return credentialprovider.DockerConfig{}, nil, nil
 		}
 
@@ -455,7 +456,7 @@ func (p *pluginProvider) provide(image, podNamespace, podName string, podUID typ
 					// The required annotation could be a mechanism for individual workloads to opt in to using service account tokens
 					// for image pull. If any of the required annotation is missing, we will not invoke the plugin. We will log the error
 					// at higher verbosity level as it could be noisy.
-					klog.V(5).ErrorS(err, "Failed to get service account data", "provider", p.name, "image", image, "pod", klog.KRef(podNamespace, podName), "podUID", podUID, "serviceAccount", klog.KRef(podNamespace, serviceAccountName))
+					klog.FromContext(ctx).V(5).Info("Failed to get service account data", "err", err, "provider", p.name, "image", image, "pod", klog.KRef(podNamespace, podName), "podUID", podUID, "serviceAccount", klog.KRef(podNamespace, serviceAccountName))
 					return credentialprovider.DockerConfig{}, nil, nil
 				}
 
@@ -520,7 +521,7 @@ func (p *pluginProvider) provide(image, podNamespace, podName string, podUID typ
 		}
 	}
 	res, err, _ := p.group.Do(singleFlightKey, func() (interface{}, error) {
-		return p.plugin.ExecPlugin(context.Background(), image, serviceAccountToken, saAnnotations)
+		return p.plugin.ExecPlugin(ctx, image, serviceAccountToken, saAnnotations)
 	})
 
 	if err != nil {
@@ -684,7 +685,7 @@ type execPlugin struct {
 // The plugin is expected to receive the CredentialProviderRequest API via stdin from the kubelet and
 // return CredentialProviderResponse via stdout.
 func (e *execPlugin) ExecPlugin(ctx context.Context, image, serviceAccountToken string, serviceAccountAnnotations map[string]string) (*credentialproviderapi.CredentialProviderResponse, error) {
-	klog.V(5).InfoS("Getting image credentials from external exec plugin", "pluginName", e.name, "image", image)
+	klog.FromContext(ctx).V(5).Info("Getting image credentials from external exec plugin", "pluginName", e.name, "image", image)
 
 	authRequest := &credentialproviderapi.CredentialProviderRequest{Image: image, ServiceAccountToken: serviceAccountToken, ServiceAccountAnnotations: serviceAccountAnnotations}
 	data, err := e.encodeRequest(authRequest)

--- a/pkg/credentialprovider/plugin/plugin_test.go
+++ b/pkg/credentialprovider/plugin/plugin_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"reflect"
 	"strings"
@@ -39,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
 	credentialproviderapi "k8s.io/kubelet/pkg/apis/credentialprovider"
 	credentialproviderv1 "k8s.io/kubelet/pkg/apis/credentialprovider/v1"
 	credentialproviderv1alpha1 "k8s.io/kubelet/pkg/apis/credentialprovider/v1alpha1"
@@ -125,7 +125,7 @@ func TestSingleflightProvide(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			result, _ := dynamicProvider.provideWithCoordinates(image)
+			result, _ := dynamicProvider.provideWithCoordinates(t.Context(), image)
 			results[i] = result
 		}(i)
 	}
@@ -158,7 +158,7 @@ func TestSingleflightProvide(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			result, _ := dynamicProvider.provideWithCoordinates(image)
+			result, _ := dynamicProvider.provideWithCoordinates(t.Context(), image)
 			results[i] = result
 		}(i)
 	}
@@ -179,7 +179,7 @@ func TestSingleflightProvide(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			result, _ := dynamicProvider.provideWithCoordinates(image)
+			result, _ := dynamicProvider.provideWithCoordinates(t.Context(), image)
 			results[i] = result
 		}(i)
 	}
@@ -192,12 +192,6 @@ func TestSingleflightProvide(t *testing.T) {
 }
 
 func Test_ProvideWithCoordinates(t *testing.T) {
-	klog.InitFlags(nil)
-	if err := flag.Set("v", "6"); err != nil {
-		t.Fatalf("failed to set log level: %v", err)
-	}
-	flag.Parse()
-
 	tclock := clock.RealClock{}
 	testcases := []struct {
 		name                   string
@@ -385,7 +379,7 @@ func Test_ProvideWithCoordinates(t *testing.T) {
 			},
 			image:        "test.registry.io/foo/bar",
 			dockerconfig: credentialprovider.DockerConfig{},
-			wantLog:      `Service account name is empty" provider="test-plugin" image="test.registry.io/foo/bar" pod="ns/pod-name" podUID="pod-uid"`,
+			wantLog:      `Service account name is empty provider="test-plugin" image="test.registry.io/foo/bar" pod="ns/pod-name" podUID="pod-uid"`,
 		},
 		{
 			name: "[service account mode] sa does not have required annotations",
@@ -416,7 +410,7 @@ func Test_ProvideWithCoordinates(t *testing.T) {
 			},
 			image:        "test.registry.io/foo/bar",
 			dockerconfig: credentialprovider.DockerConfig{},
-			wantLog:      `"Failed to get service account data" err="required annotation domain.io/identity-id not found" provider="test-plugin" image="test.registry.io/foo/bar" pod="ns/pod-name" podUID="pod-uid" serviceAccount="ns/sa-name"`,
+			wantLog:      `Failed to get service account data err="required annotation domain.io/identity-id not found" provider="test-plugin" image="test.registry.io/foo/bar" pod="ns/pod-name" podUID="pod-uid" serviceAccount="ns/sa-name"`,
 		},
 		{
 			name: "[service account mode] failed to get service account token",
@@ -455,7 +449,7 @@ func Test_ProvideWithCoordinates(t *testing.T) {
 			},
 			image:        "test.registry.io/foo/bar",
 			dockerconfig: credentialprovider.DockerConfig{},
-			wantLog:      `"Failed to provide credentials for image" err="failed to get service account token: failed to get token" provider="test-plugin" image="test.registry.io/foo/bar" pod="ns/pod-name" podUID="pod-uid" serviceAccount="ns/sa-name"`,
+			wantLog:      `Failed to provide credentials for image err="failed to get service account token: failed to get token" provider="test-plugin" image="test.registry.io/foo/bar" pod="ns/pod-name" podUID="pod-uid" serviceAccount="ns/sa-name"`,
 		},
 		{
 			name: "[service account mode] cache type not token but service account echoed back",
@@ -506,7 +500,7 @@ func Test_ProvideWithCoordinates(t *testing.T) {
 			},
 			image:        "test.registry.io/foo/bar",
 			dockerconfig: credentialprovider.DockerConfig{},
-			wantLog:      `"Failed to provide credentials for image" err="credential provider plugin returned the service account token as the password which is not allowed when service account cache type is not set to 'Token'" provider="test-plugin" image="test.registry.io/foo/bar" pod="ns/pod-name" podUID="pod-uid" serviceAccount="ns/sa-name"`,
+			wantLog:      `Failed to provide credentials for image err="credential provider plugin returned the service account token as the password which is not allowed when service account cache type is not set to 'Token'" provider="test-plugin" image="test.registry.io/foo/bar" pod="ns/pod-name" podUID="pod-uid" serviceAccount="ns/sa-name"`,
 		},
 		{
 			name: "[service account mode] exact image match",
@@ -572,12 +566,10 @@ func Test_ProvideWithCoordinates(t *testing.T) {
 
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
-			var buf bytes.Buffer
-			klog.SetOutput(&buf)
-			klog.LogToStderr(false)
-			defer klog.LogToStderr(true)
+			logger := ktesting.NewLogger(t, ktesting.NewConfig(ktesting.BufferLogs(true), ktesting.Verbosity(5)))
+			ctx := klog.NewContext(t.Context(), logger)
 
-			gotConfig, gotCoordinates := testcase.pluginProvider.provideWithCoordinates(testcase.image)
+			gotConfig, gotCoordinates := testcase.pluginProvider.provideWithCoordinates(ctx, testcase.image)
 			if !reflect.DeepEqual(gotConfig, testcase.dockerconfig) {
 				t.Errorf("unexpected docker config from ProvideWithCoordinates: %v, expected: %v", gotConfig, testcase.dockerconfig)
 			}
@@ -590,9 +582,7 @@ func Test_ProvideWithCoordinates(t *testing.T) {
 				t.Errorf("expected nil service account coordinates but got: %v", gotCoordinates)
 			}
 
-			klog.Flush()
-			klog.SetOutput(&bytes.Buffer{}) // prevent further writes into buf
-			capturedOutput := buf.String()
+			capturedOutput := logger.GetSink().(ktesting.Underlier).GetBuffer().String()
 
 			if len(testcase.wantLog) > 0 && !strings.Contains(capturedOutput, testcase.wantLog) {
 				t.Log("Captured output:", capturedOutput)
@@ -664,7 +654,7 @@ func Test_ProvideParallel(t *testing.T) {
 			for i := 0; i < 5; i++ {
 				go func(w *sync.WaitGroup) {
 					image := fmt.Sprintf(testcase.registry+"/%s", rand.String(5))
-					dockerconfigResponse, _ := pluginProvider.provideWithCoordinates(image)
+					dockerconfigResponse, _ := pluginProvider.provideWithCoordinates(t.Context(), image)
 					if !reflect.DeepEqual(dockerconfigResponse, dockerconfig) {
 						t.Errorf("unexpected docker config for image %s: %v, expected: %v", image, dockerconfigResponse, dockerconfig)
 					}
@@ -1131,7 +1121,7 @@ func Test_NoCacheResponse(t *testing.T) {
 		},
 	}
 
-	dockerConfig, _ := pluginProvider.provideWithCoordinates("test.registry.io/foo/bar")
+	dockerConfig, _ := pluginProvider.provideWithCoordinates(t.Context(), "test.registry.io/foo/bar")
 	if !reflect.DeepEqual(dockerConfig, expectedDockerConfig) {
 		t.Logf("actual docker config: %v", dockerConfig)
 		t.Logf("expected docker config: %v", expectedDockerConfig)
@@ -1585,7 +1575,7 @@ func Test_CacheKeyGeneration(t *testing.T) {
 				cacheType:   cacheTypeValue,
 			}
 
-			dockerConfig, _ := pluginProvider.provideWithCoordinates(testImage)
+			dockerConfig, _ := pluginProvider.provideWithCoordinates(t.Context(), testImage)
 			verifyDockerConfig(t, dockerConfig)
 
 			// Verify the cache key is as expected
@@ -1598,7 +1588,7 @@ func Test_CacheKeyGeneration(t *testing.T) {
 
 			// Test cache hit (nil out plugin to ensure cache is used)
 			pluginProvider.provider.plugin = nil
-			cachedConfig, _ := pluginProvider.provideWithCoordinates(testImage)
+			cachedConfig, _ := pluginProvider.provideWithCoordinates(t.Context(), testImage)
 			verifyDockerConfig(t, cachedConfig)
 		})
 	}

--- a/pkg/credentialprovider/plugin/plugins.go
+++ b/pkg/credentialprovider/plugin/plugins.go
@@ -17,6 +17,7 @@ limitations under the License.
 package plugin
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -30,7 +31,7 @@ import (
 
 type dockerConfigProviderWithCoordinates interface {
 	// provideWithCoordinates returns the DockerConfig and service account coordinates for the given image.
-	provideWithCoordinates(image string) (credentialprovider.DockerConfig, *credentialprovider.ServiceAccountCoordinates)
+	provideWithCoordinates(ctx context.Context, image string) (credentialprovider.DockerConfig, *credentialprovider.ServiceAccountCoordinates)
 }
 
 type provider struct {
@@ -52,14 +53,14 @@ func registerCredentialProviderPlugin(name string, p *pluginProvider) {
 	seenProviderNames.Insert(name)
 
 	providers = append(providers, provider{name, p})
-	klog.V(4).InfoS("Registered credential provider", "provider", name)
+	klog.Background().V(4).Info("Registered credential provider", "provider", name)
 }
 
 type externalCredentialProviderKeyring struct {
 	providers []dockerConfigProviderWithCoordinates
 }
 
-func NewExternalCredentialProviderDockerKeyring(podNamespace, podName, podUID, serviceAccountName string) credentialprovider.DockerKeyring {
+func NewExternalCredentialProviderDockerKeyring(ctx context.Context, podNamespace, podName, podUID, serviceAccountName string) credentialprovider.DockerKeyring {
 	providersMutex.RLock()
 	defer providersMutex.RUnlock()
 
@@ -72,14 +73,14 @@ func NewExternalCredentialProviderDockerKeyring(podNamespace, podName, podUID, s
 			provider: p.impl,
 		}
 		if utilfeature.DefaultFeatureGate.Enabled(features.KubeletServiceAccountTokenForCredentialProviders) {
-			klog.V(4).InfoS("Generating per pod credential provider", "provider", p.name, "podName", podName, "podNamespace", podNamespace, "podUID", podUID, "serviceAccountName", serviceAccountName)
+			klog.FromContext(ctx).V(4).Info("Generating per pod credential provider", "provider", p.name, "podName", podName, "podNamespace", podNamespace, "podUID", podUID, "serviceAccountName", serviceAccountName)
 
 			pp.podNamespace = podNamespace
 			pp.podName = podName
 			pp.podUID = types.UID(podUID)
 			pp.serviceAccountName = serviceAccountName
 		} else {
-			klog.V(4).InfoS("Generating credential provider", "provider", p.name)
+			klog.FromContext(ctx).V(4).Info("Generating credential provider", "provider", p.name)
 		}
 
 		keyring.providers = append(keyring.providers, pp)
@@ -88,11 +89,11 @@ func NewExternalCredentialProviderDockerKeyring(podNamespace, podName, podUID, s
 	return keyring
 }
 
-func (k *externalCredentialProviderKeyring) Lookup(image string) ([]credentialprovider.TrackedAuthConfig, bool) {
+func (k *externalCredentialProviderKeyring) Lookup(ctx context.Context, image string) ([]credentialprovider.TrackedAuthConfig, bool) {
 	keyring := &credentialprovider.BasicDockerKeyring{}
 
 	for _, p := range k.providers {
-		dockerConfig, saCoords := p.provideWithCoordinates(image)
+		dockerConfig, saCoords := p.provideWithCoordinates(ctx, image)
 		if saCoords != nil {
 			keyring.Add(&credentialprovider.CredentialSource{ServiceAccount: saCoords}, dockerConfig)
 		} else {
@@ -100,5 +101,5 @@ func (k *externalCredentialProviderKeyring) Lookup(image string) ([]credentialpr
 		}
 	}
 
-	return keyring.Lookup(image)
+	return keyring.Lookup(ctx, image)
 }

--- a/pkg/credentialprovider/plugin/plugins_test.go
+++ b/pkg/credentialprovider/plugin/plugins_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package plugin
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -40,7 +41,7 @@ type fakedockerConfigProviderWithCoordinates struct {
 	mu                   sync.Mutex
 }
 
-func (f *fakedockerConfigProviderWithCoordinates) provideWithCoordinates(image string) (credentialprovider.DockerConfig, *credentialprovider.ServiceAccountCoordinates) {
+func (f *fakedockerConfigProviderWithCoordinates) provideWithCoordinates(ctx context.Context, image string) (credentialprovider.DockerConfig, *credentialprovider.ServiceAccountCoordinates) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.callCount++
@@ -257,7 +258,7 @@ func TestNewExternalCredentialProviderDockerKeyring(t *testing.T) {
 
 			tc.setupProviders()
 
-			keyring := NewExternalCredentialProviderDockerKeyring("test-namespace", "test-pod", "test-uid", "test-sa")
+			keyring := NewExternalCredentialProviderDockerKeyring(t.Context(), "test-namespace", "test-pod", "test-uid", "test-sa")
 
 			externalKeyring, ok := keyring.(*externalCredentialProviderKeyring)
 			if !ok {
@@ -296,7 +297,7 @@ func TestExternalCredentialProviderKeyringLookupNoProviders(t *testing.T) {
 		providers: []dockerConfigProviderWithCoordinates{},
 	}
 
-	configs, found := keyring.Lookup("test.registry.io/image:tag")
+	configs, found := keyring.Lookup(t.Context(), "test.registry.io/image:tag")
 
 	if found {
 		t.Errorf("Expected not found, got found=true")
@@ -413,7 +414,7 @@ func TestExternalCredentialProviderKeyringLookupWithProviders(t *testing.T) {
 				providers: tc.providers,
 			}
 
-			configs, found := keyring.Lookup(tc.image)
+			configs, found := keyring.Lookup(t.Context(), tc.image)
 
 			if found != tc.expectedFound {
 				t.Errorf("Expected found=%v, got found=%v", tc.expectedFound, found)
@@ -485,7 +486,7 @@ func TestExternalCredentialProviderKeyringLookupConcurrency(t *testing.T) {
 			defer wg.Done()
 			for j := range numCallsPerGoroutine {
 				image := "test.registry.io/image:tag"
-				configs, found := keyring.Lookup(image)
+				configs, found := keyring.Lookup(t.Context(), image)
 
 				if !found {
 					mu.Lock()

--- a/pkg/credentialprovider/secrets/secrets_test.go
+++ b/pkg/credentialprovider/secrets/secrets_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package secrets
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -36,7 +37,7 @@ type FakeKeyring struct {
 
 // Lookup implements the DockerKeyring method for fetching credentials based on image name
 // return fake auth and ok
-func (f *FakeKeyring) Lookup(image string) ([]credentialprovider.TrackedAuthConfig, bool) {
+func (f *FakeKeyring) Lookup(ctx context.Context, image string) ([]credentialprovider.TrackedAuthConfig, bool) {
 	return f.auth, f.ok
 }
 
@@ -342,7 +343,7 @@ func Test_MakeDockerKeyring(t *testing.T) {
 				t.Fatalf("error creating secret-based docker keyring: %v", err)
 			}
 
-			authConfigs, found := keyring.Lookup(testcase.image)
+			authConfigs, found := keyring.Lookup(t.Context(), testcase.image)
 			if found != testcase.found {
 				t.Logf("actual lookup status: %v", found)
 				t.Logf("expected lookup status: %v", testcase.found)

--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -207,7 +207,7 @@ func (m *imageManager) EnsureImageExists(ctx context.Context, objRef *v1.ObjectR
 	}
 
 	// wrap the lookup in a function to ensure that we only look up credentials once and no earlier than needed
-	lookupPullCredentials := m.makeLookupPullCredentialsFunc(spec.Image, pod, pullSecrets, podSandboxConfig)
+	lookupPullCredentials := m.makeLookupPullCredentialsFunc(ctx, spec.Image, pod, pullSecrets, podSandboxConfig)
 
 	getPodCredentials := func() ([]kubeletconfiginternal.ImagePullSecret, *kubeletconfiginternal.ImagePullServiceAccount, error) {
 		pullCredentials, err := lookupPullCredentials()
@@ -288,7 +288,7 @@ func (m *imageManager) EnsureImageExists(ctx context.Context, objRef *v1.ObjectR
 	return m.pullImage(ctx, logPrefix, objRef, pod.UID, requestedImage, spec, pullCredentials, podSandboxConfig)
 }
 
-func (m *imageManager) makeLookupPullCredentialsFunc(image string, pod *v1.Pod, pullSecrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig) func() ([]credentialprovider.TrackedAuthConfig, error) {
+func (m *imageManager) makeLookupPullCredentialsFunc(ctx context.Context, image string, pod *v1.Pod, pullSecrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig) func() ([]credentialprovider.TrackedAuthConfig, error) {
 	return sync.OnceValues(func() ([]credentialprovider.TrackedAuthConfig, error) {
 		repoToPull, _, _, err := parsers.ParseImageName(image)
 		if err != nil {
@@ -306,6 +306,7 @@ func (m *imageManager) makeLookupPullCredentialsFunc(image string, pod *v1.Pod, 
 		}
 
 		externalCredentialProviderKeyring := credentialproviderplugin.NewExternalCredentialProviderDockerKeyring(
+			ctx,
 			podNamespace,
 			podName,
 			podUID,
@@ -316,7 +317,7 @@ func (m *imageManager) makeLookupPullCredentialsFunc(image string, pod *v1.Pod, 
 			return nil, err
 		}
 
-		pullCredentials, _ := keyring.Lookup(repoToPull)
+		pullCredentials, _ := keyring.Lookup(ctx, repoToPull)
 		return pullCredentials, nil
 	})
 }

--- a/pkg/kubelet/images/image_manager_test.go
+++ b/pkg/kubelet/images/image_manager_test.go
@@ -812,12 +812,12 @@ type mockDockerKeyringWithTrackedCreds struct {
 	trackedCreds map[string][]credentialprovider.TrackedAuthConfig
 }
 
-func (m *mockDockerKeyringWithTrackedCreds) Lookup(image string) ([]credentialprovider.TrackedAuthConfig, bool) {
+func (m *mockDockerKeyringWithTrackedCreds) Lookup(ctx context.Context, image string) ([]credentialprovider.TrackedAuthConfig, bool) {
 	if creds, ok := m.trackedCreds[image]; ok {
 		return creds, true
 	}
 	// Fall back to basic keyring lookup - it already returns TrackedAuthConfig
-	return m.BasicDockerKeyring.Lookup(image)
+	return m.BasicDockerKeyring.Lookup(ctx, image)
 }
 
 func pullerTestEnv(


### PR DESCRIPTION
#### What this PR does / why we need it

Continuing the contextual logging migration (#126379), this one takes care of the credential provider plugin package.

The tricky part is that `DockerKeyring.Lookup` doesn't take a context, so the ctx from kubelet's `EnsureImageExists` never reached the plugin code. This adds a ctx parameter to `Lookup` and threads it through the implementations and callers (kubelet is the only real caller).

Nice side effect: `ExecPlugin` no longer runs with a fresh `context.Background()` — it inherits the kubelet ctx now, so if the image pull gets cancelled, the plugin execution gets cancelled too.

`registerCredentialProviderPlugin` uses `klog.Background()` since there's no request context around at registration time.

Also moved `Test_ProvideWithCoordinates` off global klog state (SetOutput + v flag) over to ktesting, matching how other already-migrated packages test logging.

#### Which issue(s) this PR fixes

Part of #126379.

#### Special notes for your reviewer

hack/logcheck.conf moves pkg/credentialprovider/plugin from structured to contextual; `hack/update-golangci-lint-config.sh` was re-run afterwards.

Verified locally:
- `go build` + `go test` for ./pkg/credentialprovider/... and ./pkg/kubelet/images/...
- `golangci-lint run` with the regenerated config on the affected packages: clean

#### Does this PR introduce a user-facing change?

No. `DockerKeyring.Lookup` is internal and kubelet is the only caller.

/kind cleanup
/sig node
/release-note-none
