### PR TITLE
Refine watch event dispatch latency metrics to distinguish storage bottlenecks

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
@@ -576,10 +576,12 @@ func TestCacheWatcherDrainingNoBookmarkAfterResourceVersionSent(t *testing.T) {
 	if !w.add(&watchCacheEvent{
 		Object:          makePod(5),
 		ResourceVersion: 5,
-		RecordTime:      fakeClock.Now().Add(-2 * time.Second),
+		RecordTime:      fakeClock.Now().Add(-4 * time.Second),
 		timeline: metrics.DispatchTimeline{
-			metrics.PointStorageDecoded: fakeClock.Now().Add(-2 * time.Second),
-			metrics.PointCacheReceived:  fakeClock.Now().Add(-1 * time.Second),
+			metrics.PointStorageReceived:      fakeClock.Now().Add(-4 * time.Second),
+			metrics.PointStorageDecodeStarted: fakeClock.Now().Add(-3 * time.Second),
+			metrics.PointStorageDecoded:       fakeClock.Now().Add(-2 * time.Second),
+			metrics.PointCacheReceived:        fakeClock.Now().Add(-1 * time.Second),
 		},
 	}, time.NewTimer(1*time.Second)) {
 		t.Fatal("failed adding an even to the watcher")
@@ -590,10 +592,12 @@ func TestCacheWatcherDrainingNoBookmarkAfterResourceVersionSent(t *testing.T) {
 	if !w.add(&watchCacheEvent{
 		Object:          makePod(15),
 		ResourceVersion: 15,
-		RecordTime:      fakeClock.Now().Add(-2 * time.Second),
+		RecordTime:      fakeClock.Now().Add(-4 * time.Second),
 		timeline: metrics.DispatchTimeline{
-			metrics.PointStorageDecoded: fakeClock.Now().Add(-2 * time.Second),
-			metrics.PointCacheReceived:  fakeClock.Now().Add(-1 * time.Second),
+			metrics.PointStorageReceived:      fakeClock.Now().Add(-4 * time.Second),
+			metrics.PointStorageDecodeStarted: fakeClock.Now().Add(-3 * time.Second),
+			metrics.PointStorageDecoded:       fakeClock.Now().Add(-2 * time.Second),
+			metrics.PointCacheReceived:        fakeClock.Now().Add(-1 * time.Second),
 		},
 	}, time.NewTimer(1*time.Second)) {
 		t.Fatal("failed adding an even to the watcher")
@@ -634,17 +638,23 @@ func TestCacheWatcherDrainingNoBookmarkAfterResourceVersionSent(t *testing.T) {
 	}
 
 	expected := `
-# HELP apiserver_watch_events_dispatch_duration_seconds [ALPHA] Histogram of watch event dispatch latency broken by resource type and pipeline stage. The 'total' stage is the end-to-end latency of a delivered event.
+# HELP apiserver_watch_events_dispatch_duration_seconds [ALPHA] Histogram of watch event dispatch latency broken down by resource type and pipeline stage. Stages: storage_incoming_queue (received from etcd until decoding begins), storage_decode (transform and decode), storage_result_queue (decoded until the watch cache's reflector takes the event), watcher_result_send (blocked handing the event to the HTTP handler), total (received from etcd until handed to the HTTP handler). The stages do not cover the whole pipeline and need not sum to total.
 # TYPE apiserver_watch_events_dispatch_duration_seconds histogram
-apiserver_watch_events_dispatch_duration_seconds_bucket{group="",resource="pods",stage="storage_to_cache",le="+Inf"} 2
-apiserver_watch_events_dispatch_duration_seconds_sum{group="",resource="pods",stage="storage_to_cache"} 2
-apiserver_watch_events_dispatch_duration_seconds_count{group="",resource="pods",stage="storage_to_cache"} 2
+apiserver_watch_events_dispatch_duration_seconds_bucket{group="",resource="pods",stage="storage_decode",le="+Inf"} 2
+apiserver_watch_events_dispatch_duration_seconds_sum{group="",resource="pods",stage="storage_decode"} 2
+apiserver_watch_events_dispatch_duration_seconds_count{group="",resource="pods",stage="storage_decode"} 2
+apiserver_watch_events_dispatch_duration_seconds_bucket{group="",resource="pods",stage="storage_incoming_queue",le="+Inf"} 2
+apiserver_watch_events_dispatch_duration_seconds_sum{group="",resource="pods",stage="storage_incoming_queue"} 2
+apiserver_watch_events_dispatch_duration_seconds_count{group="",resource="pods",stage="storage_incoming_queue"} 2
+apiserver_watch_events_dispatch_duration_seconds_bucket{group="",resource="pods",stage="storage_result_queue",le="+Inf"} 2
+apiserver_watch_events_dispatch_duration_seconds_sum{group="",resource="pods",stage="storage_result_queue"} 2
+apiserver_watch_events_dispatch_duration_seconds_count{group="",resource="pods",stage="storage_result_queue"} 2
 apiserver_watch_events_dispatch_duration_seconds_bucket{group="",resource="pods",stage="total",le="+Inf"} 2
-apiserver_watch_events_dispatch_duration_seconds_sum{group="",resource="pods",stage="total"} 4
+apiserver_watch_events_dispatch_duration_seconds_sum{group="",resource="pods",stage="total"} 8
 apiserver_watch_events_dispatch_duration_seconds_count{group="",resource="pods",stage="total"} 2
-apiserver_watch_events_dispatch_duration_seconds_bucket{group="",resource="pods",stage="watcher_to_client_handler",le="+Inf"} 2
-apiserver_watch_events_dispatch_duration_seconds_sum{group="",resource="pods",stage="watcher_to_client_handler"} 0
-apiserver_watch_events_dispatch_duration_seconds_count{group="",resource="pods",stage="watcher_to_client_handler"} 2
+apiserver_watch_events_dispatch_duration_seconds_bucket{group="",resource="pods",stage="watcher_result_send",le="+Inf"} 2
+apiserver_watch_events_dispatch_duration_seconds_sum{group="",resource="pods",stage="watcher_result_send"} 0
+apiserver_watch_events_dispatch_duration_seconds_count{group="",resource="pods",stage="watcher_result_send"} 2
 `
 	if err := testutil.GatherAndCompare(gatherWithoutBuckets(registry), strings.NewReader(expected), "apiserver_watch_events_dispatch_duration_seconds"); err != nil {
 		t.Fatal(err)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -39,8 +39,15 @@ const (
 type DispatchPoint int
 
 const (
-	// PointStorageDecoded: the event was decoded from the storage backend (etcd).
-	PointStorageDecoded DispatchPoint = iota
+	// PointStorageReceived: the backend (etcd) response carrying the event was
+	// received by the storage layer. This is the start of the timeline.
+	PointStorageReceived DispatchPoint = iota
+	// PointStorageDecodeStarted: the storage layer dequeued the event from its
+	// incoming channel and began transforming and decoding it.
+	PointStorageDecodeStarted
+	// PointStorageDecoded: the event was fully transformed and decoded, and is
+	// about to be sent on the storage layer's result channel.
+	PointStorageDecoded
 	// PointCacheReceived: the event was first processed by the cacher's reflector loop.
 	PointCacheReceived
 	// PointEventBuilt: the outgoing watch.Event was built (filter + convert).
@@ -69,13 +76,32 @@ func (tl *DispatchTimeline) MarkAt(p DispatchPoint, t time.Time) { tl[p] = t }
 // dispatchStages declares the labeled intervals emitted from a DispatchTimeline.
 // Adding a stage is a single entry here; "total" spans the whole delivery. The
 // additive stages need not partition "total" (only a subset of points may be set).
+//
+// Stages are named after the queue or work where the time is spent, not after
+// their endpoints, so that a label alone says what a growing value means.
+//
+// The three storage_* stages partition the storage layer's share of the
+// delivery: an event waits in the storage layer's incoming channel, is
+// transformed and decoded, then waits in its result channel until the cacher's
+// reflector picks it up. Which of the three grows tells which goroutine is
+// behind: the decoder (storage_incoming_queue), the decode cost itself
+// (storage_decode), or the reflector (storage_result_queue), which stalls
+// whenever the watch cache or the dispatch loop behind it is slow.
+//
+// watcher_result_send only measures time blocked sending on the watcher's
+// result channel; while that buffer has room it is near zero regardless of how
+// far behind the HTTP handler is. The span from PointCacheReceived to
+// PointEventBuilt (watch cache update, dispatch loop, per-watcher input queue)
+// has no stage yet.
 var dispatchStages = []struct {
 	label    string
 	from, to DispatchPoint
 }{
-	{"storage_to_cache", PointStorageDecoded, PointCacheReceived},
-	{"watcher_to_client_handler", PointEventBuilt, PointSentToClient},
-	{"total", PointStorageDecoded, PointSentToClient},
+	{"storage_incoming_queue", PointStorageReceived, PointStorageDecodeStarted},
+	{"storage_decode", PointStorageDecodeStarted, PointStorageDecoded},
+	{"storage_result_queue", PointStorageDecoded, PointCacheReceived},
+	{"watcher_result_send", PointEventBuilt, PointSentToClient},
+	{"total", PointStorageReceived, PointSentToClient},
 }
 
 /*
@@ -286,7 +312,7 @@ var (
 			Namespace:      namespace,
 			Subsystem:      "watch_events",
 			Name:           "dispatch_duration_seconds",
-			Help:           "Histogram of watch event dispatch latency broken by resource type and pipeline stage. The 'total' stage is the end-to-end latency of a delivered event.",
+			Help:           "Histogram of watch event dispatch latency broken down by resource type and pipeline stage. Stages: storage_incoming_queue (received from etcd until decoding begins), storage_decode (transform and decode), storage_result_queue (decoded until the watch cache's reflector takes the event), watcher_result_send (blocked handing the event to the HTTP handler), total (received from etcd until handed to the HTTP handler). The stages do not cover the whole pipeline and need not sum to total.",
 			StabilityLevel: compbasemetrics.ALPHA,
 			Buckets:        []float64{0.0001, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5},
 		}, []string{"group", "resource", "stage"})

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -69,8 +69,8 @@ type watchCacheEvent struct {
 	ResourceVersion uint64
 	RecordTime      time.Time
 	// timeline carries the shared, pre-fan-out dispatch-lifecycle timestamps of
-	// this event (currently PointCacheReceived). Per-watcher points are filled in
-	// on delivery.
+	// this event (the storage-layer points and PointCacheReceived). Per-watcher
+	// points are filled in on delivery.
 	timeline metrics.DispatchTimeline
 }
 
@@ -212,10 +212,14 @@ func (w *watchCache) objectToVersionedRuntimeObject(obj interface{}) (runtime.Ob
 // at any point in time.
 func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64) error {
 	cacheReceived := w.config.clock.Now()
-	recordTime := cacheReceived
-	if withRecordTime, ok := event.Object.(storage.WatchEventWithRecordTime); ok {
-		recordTime = withRecordTime.RecordTime()
-		event.Object = withRecordTime.Unwrap()
+	var storageTimestamps storage.WatchEventTimestamps
+	if withTimestamps, ok := event.Object.(storage.WatchEventWithTimestamps); ok {
+		storageTimestamps = withTimestamps.Timestamps()
+		event.Object = withTimestamps.Unwrap()
+	}
+	recordTime := storageTimestamps.Received
+	if recordTime.IsZero() {
+		recordTime = cacheReceived
 	}
 
 	metrics.EventsReceivedCounter.WithLabelValues(w.config.groupResource.Group, w.config.groupResource.Resource).Inc()
@@ -239,7 +243,9 @@ func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64) err
 		ResourceVersion: resourceVersion,
 		RecordTime:      recordTime,
 	}
-	wcEvent.timeline.MarkAt(metrics.PointStorageDecoded, recordTime)
+	wcEvent.timeline.MarkAt(metrics.PointStorageReceived, recordTime)
+	wcEvent.timeline.MarkAt(metrics.PointStorageDecodeStarted, storageTimestamps.DecodeStarted)
+	wcEvent.timeline.MarkAt(metrics.PointStorageDecoded, storageTimestamps.Decoded)
 	wcEvent.timeline.MarkAt(metrics.PointCacheReceived, cacheReceived)
 
 	// We can call w.storage.Get() outside of a critical section,

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/event.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/event.go
@@ -45,7 +45,9 @@ type event struct {
 	isInitialEventsEndBookmark bool
 	// isInitialEvent indicates the event was generated from an initial state sync.
 	isInitialEvent bool
-	recordTime     time.Time
+	// receivedAt is when the backend response carrying this event was received.
+	// It is shared by every event of that response.
+	receivedAt time.Time
 }
 
 // parseKV converts a KeyValue retrieved from an initial sync() listing to a synthetic isCreated event.
@@ -61,7 +63,9 @@ func parseKV(kv *mvccpb.KeyValue) *event {
 	}
 }
 
-func parseEvent(e *clientv3.Event) (*event, error) {
+// parseEvent converts a raw etcd event into an event. receivedAt is the time
+// at which the WatchResponse carrying e was received.
+func parseEvent(e *clientv3.Event, receivedAt time.Time) (*event, error) {
 	if !e.IsCreate() && e.PrevKv == nil {
 		// If the previous value is nil, error. One example of how this is possible is if the previous value has been compacted already.
 		return nil, fmt.Errorf("etcd event received with PrevKv=nil (key=%q, modRevision=%d, type=%s)", string(e.Kv.Key), e.Kv.ModRevision, e.Type.String())
@@ -73,7 +77,7 @@ func parseEvent(e *clientv3.Event) (*event, error) {
 		rev:        e.Kv.ModRevision,
 		isDeleted:  e.Type == clientv3.EventTypeDelete,
 		isCreated:  e.IsCreate(),
-		recordTime: time.Now(),
+		receivedAt: receivedAt,
 	}
 	if e.PrevKv != nil {
 		ret.prevValue = e.PrevKv.Value
@@ -81,10 +85,10 @@ func parseEvent(e *clientv3.Event) (*event, error) {
 	return ret, nil
 }
 
-func progressNotifyEvent(rev int64) *event {
+func progressNotifyEvent(rev int64, receivedAt time.Time) *event {
 	return &event{
 		rev:              rev,
 		isProgressNotify: true,
-		recordTime:       time.Now(),
+		receivedAt:       receivedAt,
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/event_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/event_test.go
@@ -99,13 +99,14 @@ func TestParseEvent(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			actualEvent, err := parseEvent(tc.etcdEvent)
+			receivedAt := time.Now()
+			actualEvent, err := parseEvent(tc.etcdEvent, receivedAt)
 			if tc.expectedErr != "" {
 				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.expectedErr)
 			} else {
 				require.NoError(t, err)
-				actualEvent.recordTime = time.Time{}
+				tc.expectedEvent.receivedAt = receivedAt
 				assert.Equal(t, tc.expectedEvent, actualEvent)
 			}
 		})

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
@@ -106,8 +106,10 @@ type watchChan struct {
 	initialRev     int64
 	recursive      bool
 	progressNotify bool
-	// recordTimestamps enables wrapping watch events with decode timestamps and
-	// etcd client-side watch response buffer logging.
+	// recordTimestamps enables wrapping watch events with their storage-layer
+	// lifecycle timestamps (see storage.WatchEventTimestamps) for dispatch
+	// latency telemetry, and etcd client-side watch response buffer logging.
+	// Set only by the watch cache's ingest path.
 	recordTimestamps         bool
 	internalPred             storage.SelectionPredicate
 	ctx                      context.Context
@@ -464,7 +466,7 @@ func (wc *watchChan) startWatching(watchClosedCh chan struct{}, initialEventsEnd
 	}
 	if initialEventsEndBookmarkRequired {
 		wc.queueEvent(func() *event {
-			e := progressNotifyEvent(wc.initialRev)
+			e := progressNotifyEvent(wc.initialRev, time.Now())
 			e.isInitialEventsEndBookmark = true
 			return e
 		}())
@@ -484,6 +486,7 @@ func (wc *watchChan) startWatching(watchClosedCh chan struct{}, initialEventsEnd
 	wch := wc.watcher.client.Watch(wc.ctx, wc.key, opts...)
 	estimator := wc.getResourceSizeEstimator()
 	for wres := range wch {
+		receivedAt := time.Now()
 		if wres.Err() != nil {
 			err := wres.Err()
 			// If there is an error on server (e.g. compaction), the channel will return it before closed.
@@ -497,7 +500,7 @@ func (wc *watchChan) startWatching(watchClosedCh chan struct{}, initialEventsEnd
 			return
 		}
 		if wres.IsProgressNotify() {
-			wc.queueEvent(progressNotifyEvent(wres.Header.GetRevision()))
+			wc.queueEvent(progressNotifyEvent(wres.Header.GetRevision(), receivedAt))
 			metrics.RecordEtcdBookmark(wc.watcher.groupResource)
 			continue
 		}
@@ -512,7 +515,7 @@ func (wc *watchChan) startWatching(watchClosedCh chan struct{}, initialEventsEnd
 				}
 			}
 			metrics.RecordEtcdEvent(wc.watcher.groupResource)
-			parsedEvent, err := parseEvent(e)
+			parsedEvent, err := parseEvent(e, receivedAt)
 			if err != nil {
 				logWatchChannelErr(err)
 				// sendError doesn't guarantee that no more items will be put into resultChan.
@@ -666,6 +669,10 @@ func (wc *watchChan) acceptAll() bool {
 
 // transform transforms an event into a result for user if not filtered.
 func (wc *watchChan) transform(e *event) (res *watch.Event, err error) {
+	var decodeStartedAt time.Time
+	if wc.recordTimestamps {
+		decodeStartedAt = time.Now()
+	}
 	curObj, oldObj, err := wc.prepareObjs(e)
 	if err != nil {
 		klog.Errorf("failed to prepare current and previous objects: %v", err)
@@ -733,22 +740,29 @@ func (wc *watchChan) transform(e *event) (res *watch.Event, err error) {
 		}
 	}
 	if res != nil && wc.recordTimestamps && !e.isInitialEvent {
-		res.Object = &timedWatchEvent{Object: res.Object, recordTime: e.recordTime}
+		res.Object = &timedWatchEvent{
+			Object: res.Object,
+			timestamps: storage.WatchEventTimestamps{
+				Received:      e.receivedAt,
+				DecodeStarted: decodeStartedAt,
+				Decoded:       time.Now(),
+			},
+		}
 	}
 	return res, nil
 }
 
-// timedWatchEvent wraps a decoded watch object with the timestamp at which the
-// storage layer decoded it, so the watch cache can measure end-to-end dispatch
-// latency. It exists only on the watch cache's ingest path (opened with
-// ListOptions.RecordTimestamps) and MUST be unwrapped by the watch cache before
-// the object is stored or serialized.
+// timedWatchEvent wraps a decoded watch object with the storage-layer
+// timestamps of its lifecycle, so the watch cache can measure per-stage and
+// end-to-end dispatch latency. It exists only on the watch cache's ingest path
+// (opened with ListOptions.RecordTimestamps) and MUST be unwrapped by the watch
+// cache before the object is stored or serialized.
 type timedWatchEvent struct {
 	runtime.Object
-	recordTime time.Time
+	timestamps storage.WatchEventTimestamps
 }
 
-var _ storage.WatchEventWithRecordTime = &timedWatchEvent{}
+var _ storage.WatchEventWithTimestamps = &timedWatchEvent{}
 
 func (t *timedWatchEvent) GetObjectMeta() metav1.Object {
 	m, _ := meta.Accessor(t.Object)
@@ -756,11 +770,11 @@ func (t *timedWatchEvent) GetObjectMeta() metav1.Object {
 }
 
 func (t *timedWatchEvent) DeepCopyObject() runtime.Object {
-	return &timedWatchEvent{Object: t.Object.DeepCopyObject(), recordTime: t.recordTime}
+	return &timedWatchEvent{Object: t.Object.DeepCopyObject(), timestamps: t.timestamps}
 }
 
-func (t *timedWatchEvent) RecordTime() time.Time {
-	return t.recordTime
+func (t *timedWatchEvent) Timestamps() storage.WatchEventTimestamps {
+	return t.timestamps
 }
 
 func (t *timedWatchEvent) Unwrap() runtime.Object {

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -381,7 +381,7 @@ func TestWatchChanSyncStreamMatchesPaginated(t *testing.T) {
 	if len(stream) != len(want) {
 		t.Errorf("syncStreamRecursive queued %d events, expected %d", len(stream), len(want))
 	}
-	if diff := cmp.Diff(paginated, stream, cmp.AllowUnexported(event{}), cmpopts.IgnoreFields(event{}, "recordTime")); diff != "" {
+	if diff := cmp.Diff(paginated, stream, cmp.AllowUnexported(event{}), cmpopts.IgnoreFields(event{}, "receivedAt")); diff != "" {
 		t.Errorf("syncStreamRecursive and syncPaginated queued different events (-paginated +stream):\n%s", diff)
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -338,22 +338,44 @@ type ListOptions struct {
 	// continues streaming events.
 	SendInitialEvents *bool
 	// RecordTimestamps requests that the storage layer wrap each emitted watch
-	// object in a WatchEventWithRecordTime carrying its decode timestamp, for dispatch
-	// latency telemetry. This is intended for internal clients only (the watch
-	// cache); external clients cannot set it. The watch cache strips the wrapper
-	// before storing or serializing the object, so it never reaches other watchers.
+	// object in a WatchEventWithTimestamps carrying the timestamps of its
+	// storage-layer lifecycle, for dispatch latency telemetry. This is intended
+	// for internal clients only (the watch cache); external clients cannot set
+	// it. The watch cache strips the wrapper before storing or serializing the
+	// object, so it never reaches other watchers.
 	RecordTimestamps bool
 }
 
-// WatchEventWithRecordTime wraps a runtime.Object with the timestamp at which the
-// storage layer decoded the corresponding watch event. It is produced by the
+// WatchEventTimestamps records when a watch event passed through the stages of
+// the storage layer, before it was handed to the watch cache. Each stage of the
+// storage pipeline is bounded by two of these points:
+//
+//	Received -> DecodeStarted : wait in the storage layer's incoming queue
+//	DecodeStarted -> Decoded  : transform (e.g. decrypt) and decode
+//	Decoded -> (cache)        : wait in the storage layer's result channel
+type WatchEventTimestamps struct {
+	// Received is when the backend response carrying the raw event was
+	// received. Events delivered in the same backend response share this
+	// timestamp, so that time spent queueing earlier events of the response
+	// is attributed to the later ones rather than hidden.
+	Received time.Time
+	// DecodeStarted is when the storage layer began transforming and decoding
+	// the event.
+	DecodeStarted time.Time
+	// Decoded is when the event was fully transformed and decoded, immediately
+	// before being sent on the storage layer's result channel.
+	Decoded time.Time
+}
+
+// WatchEventWithTimestamps wraps a runtime.Object with the storage-layer
+// lifecycle timestamps of the corresponding watch event. It is produced by the
 // storage layer only when ListOptions.RecordTimestamps is set, and is consumed
 // and stripped by the watch cache before the underlying object is stored or
 // serialized. It is never sent to watch clients.
-type WatchEventWithRecordTime interface {
+type WatchEventWithTimestamps interface {
 	runtime.Object
-	// RecordTime returns the decode timestamp of the wrapped event.
-	RecordTime() time.Time
+	// Timestamps returns the storage-layer timestamps of the wrapped event.
+	Timestamps() WatchEventTimestamps
 	// Unwrap returns the underlying object.
 	Unwrap() runtime.Object
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/utils.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/utils.go
@@ -166,8 +166,8 @@ func testCheckResultFunc(t *testing.T, w watch.Interface, check func(actualEvent
 		if co, ok := obj.(runtime.CacheableObject); ok {
 			res.Object = co.GetObject()
 		}
-		if withRecordTime, ok := res.Object.(storage.WatchEventWithRecordTime); ok {
-			res.Object = withRecordTime.Unwrap()
+		if withTimestamps, ok := res.Object.(storage.WatchEventWithTimestamps); ok {
+			res.Object = withTimestamps.Unwrap()
 		}
 		check(res)
 	case <-time.After(wait.ForeverTestTimeout):
@@ -184,8 +184,8 @@ func testCheckResultWithIgnoreFunc(t *testing.T, w watch.Interface, expectedEven
 			if co, ok := obj.(runtime.CacheableObject); ok {
 				event.Object = co.GetObject()
 			}
-			if withRecordTime, ok := event.Object.(storage.WatchEventWithRecordTime); ok {
-				event.Object = withRecordTime.Unwrap()
+			if withTimestamps, ok := event.Object.(storage.WatchEventWithTimestamps); ok {
+				event.Object = withTimestamps.Unwrap()
 			}
 			if ignore != nil && ignore(event) {
 				continue


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature



#### What this PR does / why we need it:

This PR refines watch event dispatch latency metrics to help locate storage bottlenecks. It separates incoming queue wait, transformation and decoding, and delivery to the watch cache, making it easier to distinguish processing costs from queue delays.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

https://github.com/kubernetes/kubernetes/issues/138774

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
