### PR TITLE
[WIP] Fix ResourceQuota admission admitting denied requests after a conflict retry

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/controller.go
@@ -259,7 +259,8 @@ func (e *quotaEvaluator) checkQuotas(quotas []corev1.ResourceQuota, admissionAtt
 			}
 		}
 
-		if !atLeastOneChangeForThisWaiter {
+		// keep determined results: a conflict retry re-runs this loop with only the conflicted subset
+		if !atLeastOneChangeForThisWaiter && IsDefaultDeny(admissionAttribute.result) {
 			admissionAttribute.result = nil
 		}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

- Guard the waiter re-resolution in `quotaEvaluator.checkQuotas` with `IsDefaultDeny`, matching the other re-resolution sites in the same function.

#### Which issue(s) this PR is related to:

Fixes #141904

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where ResourceQuota admission could admit a request that exceeds quota when, in the same admission batch, a status update on another quota in the namespace hit a conflict and triggered a retry.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```

#### AI usage disclosure:

YES. AI assisted with the code analysis and the reproduction script; I reviewed and verified the change and the reproduction myself.
