### PR TITLE
StatefulSet: require canonical pod names in podInOrdinalRange

### DIFF
--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -113,7 +113,9 @@ func getEndOrdinal(set *apps.StatefulSet) int {
 // range of ordinals that this StatefulSet is set to control.
 func podInOrdinalRange(pod *v1.Pod, set *apps.StatefulSet) bool {
 	ordinal := getOrdinal(pod)
-	return ordinal >= getStartOrdinal(set) && ordinal <= getEndOrdinal(set)
+	return ordinal >= getStartOrdinal(set) &&
+		ordinal <= getEndOrdinal(set) &&
+		pod.Name == getPodName(set, ordinal)
 }
 
 // getPodName gets the name of set's child Pod with an ordinal index of ordinal

--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -197,6 +197,18 @@ func TestIsMemberOf(t *testing.T) {
 	}
 }
 
+func TestPodInOrdinalRange(t *testing.T) {
+	set := newStatefulSet(3)
+	pod := newStatefulSetPod(set, 1)
+	if !podInOrdinalRange(pod, set) {
+		t.Error("podInOrdinalRange returned false for a canonical Pod name")
+	}
+	pod.Name = set.Name + "-01"
+	if podInOrdinalRange(pod, set) {
+		t.Error("podInOrdinalRange returned true for a non-canonical Pod name")
+	}
+}
+
 func TestIdentityMatches(t *testing.T) {
 	set := newStatefulSet(3)
 	pod := newStatefulSetPod(set, 1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`podInOrdinalRange` decides whether a pod's ordinal falls in the StatefulSet's controlled range (used for PVC owner-ref / scale-down logic). It previously only checked the parsed ordinal against start/end.

Before this PR, a pod whose name has a leading-zero ordinal was treated as in-range, e.g. `sts-01`:

```
func podInOrdinalRange(pod *v1.Pod, set *apps.StatefulSet) bool {
	ordinal := getOrdinal(pod)
	return ordinal >= getStartOrdinal(set) && ordinal <= getEndOrdinal(set) // "sts-01" parses as ordinal 1 and is treated as in-range
}
```

The same class of bug was fixed for membership checks in kubernetes/kubernetes#141094 (`isMemberOf` / `identityMatches`).

This PR requires a canonical name as well:

```
func podInOrdinalRange(pod *v1.Pod, set *apps.StatefulSet) bool {
	ordinal := getOrdinal(pod)
	return ordinal >= getStartOrdinal(set) &&
		ordinal <= getEndOrdinal(set) &&
		pod.Name == getPodName(set, ordinal) // rejects leading-zero ordinals
}
```

So pods like `sts-01` are no longer treated as in-range replicas.

This PR also adds a unit test covering the leading-zero case.

/sig apps

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Same leading-zero / canonical-name check as `identityMatches` and the `isMemberOf` fix in kubernetes/kubernetes#141094, applied to `podInOrdinalRange`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
StatefulSet: podInOrdinalRange no longer treats pods with leading-zero ordinals in their names (e.g. sts-01) as in-range replicas.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A

#### AI usage disclosure:

YES. AI-assisted tools were used during implementation, test planning, and review; I reviewed and validated the final change.
