### PR TITLE
kubelet: use contextual logging in Windows-only files

### DIFF
--- a/pkg/kubelet/apis/config/validation/validation_windows.go
+++ b/pkg/kubelet/apis/config/validation/validation_windows.go
@@ -30,10 +30,8 @@ import (
 
 // validateKubeletOSConfiguration validates os specific kubelet configuration and returns an error if it is invalid.
 func validateKubeletOSConfiguration(kc *kubeletconfig.KubeletConfiguration) error {
-	message := "ignored configuration option: %v (%v) %v is not supported on Windows"
-
 	if kc.CgroupsPerQOS {
-		klog.Warningf(message, "CgroupsPerQOS", "--cgroups-per-qos", kc.CgroupsPerQOS)
+		klog.Background().Info("Ignoring configuration option not supported on Windows", "option", "CgroupsPerQOS", "flag", "--cgroups-per-qos", "value", kc.CgroupsPerQOS)
 	}
 
 	if kc.SingleProcessOOMKill != nil {
@@ -42,7 +40,7 @@ func validateKubeletOSConfiguration(kc *kubeletconfig.KubeletConfiguration) erro
 
 	enforceNodeAllocatableWithoutNone := sets.New(kc.EnforceNodeAllocatable...).Delete(kubetypes.NodeAllocatableNoneKey)
 	if len(enforceNodeAllocatableWithoutNone) > 0 {
-		klog.Warningf(message, "EnforceNodeAllocatable", "--enforce-node-allocatable", kc.EnforceNodeAllocatable)
+		klog.Background().Info("Ignoring configuration option not supported on Windows", "option", "EnforceNodeAllocatable", "flag", "--enforce-node-allocatable", "value", kc.EnforceNodeAllocatable)
 	}
 
 	if kc.UserNamespaces != nil {

--- a/pkg/kubelet/server/stats/summary_sys_containers_windows.go
+++ b/pkg/kubelet/server/stats/summary_sys_containers_windows.go
@@ -29,15 +29,15 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/winstats"
 )
 
-func (sp *summaryProviderImpl) GetSystemContainersStats(_ context.Context, nodeConfig cm.NodeConfig, podStats []statsapi.PodStats, updateStats bool) (stats []statsapi.ContainerStats) {
+func (sp *summaryProviderImpl) GetSystemContainersStats(ctx context.Context, nodeConfig cm.NodeConfig, podStats []statsapi.PodStats, updateStats bool) (stats []statsapi.ContainerStats) {
 	stats = append(stats, sp.getSystemPodsCPUAndMemoryStats(nodeConfig, podStats, updateStats))
-	stats = append(stats, sp.getSystemWindowsGlobalmemoryStats())
+	stats = append(stats, sp.getSystemWindowsGlobalmemoryStats(ctx))
 	return stats
 }
 
-func (sp *summaryProviderImpl) GetSystemContainersCPUAndMemoryStats(_ context.Context, nodeConfig cm.NodeConfig, podStats []statsapi.PodStats, updateStats bool) (stats []statsapi.ContainerStats) {
+func (sp *summaryProviderImpl) GetSystemContainersCPUAndMemoryStats(ctx context.Context, nodeConfig cm.NodeConfig, podStats []statsapi.PodStats, updateStats bool) (stats []statsapi.ContainerStats) {
 	stats = append(stats, sp.getSystemPodsCPUAndMemoryStats(nodeConfig, podStats, updateStats))
-	stats = append(stats, sp.getSystemWindowsGlobalmemoryStats())
+	stats = append(stats, sp.getSystemWindowsGlobalmemoryStats(ctx))
 	return stats
 }
 
@@ -101,7 +101,7 @@ func (sp *summaryProviderImpl) getSystemPodsCPUAndMemoryStats(nodeConfig cm.Node
 	return podsSummary
 }
 
-func (sp *summaryProviderImpl) getSystemWindowsGlobalmemoryStats() statsapi.ContainerStats {
+func (sp *summaryProviderImpl) getSystemWindowsGlobalmemoryStats(ctx context.Context) statsapi.ContainerStats {
 	now := metav1.NewTime(time.Now())
 	globalMemorySummary := statsapi.ContainerStats{
 		StartTime: now,
@@ -111,7 +111,7 @@ func (sp *summaryProviderImpl) getSystemWindowsGlobalmemoryStats() statsapi.Cont
 
 	perfInfo, err := winstats.GetPerformanceInfo()
 	if err != nil {
-		klog.Errorf("Failed to get Windows performance info: %v", err)
+		klog.FromContext(ctx).Error(err, "Failed to get Windows performance info")
 		return globalMemorySummary
 	}
 

--- a/pkg/kubelet/server/stats/summary_windows_test.go
+++ b/pkg/kubelet/server/stats/summary_windows_test.go
@@ -86,9 +86,9 @@ func TestSummaryProvider(t *testing.T) {
 	assert.Equal(podStats[0].Memory.UsageBytes, summary.Node.SystemContainers[0].Memory.UsageBytes)
 	assert.Equal(podStats[0].Memory.AvailableBytes, summary.Node.SystemContainers[0].Memory.AvailableBytes)
 	assert.Equal(statsapi.SystemContainerWindowsGlobalCommitMemory, summary.Node.SystemContainers[1].Name)
-	assert.NotEqual(nil, summary.Node.SystemContainers[1].Memory)
-	assert.NotEqual(nil, summary.Node.SystemContainers[1].Memory.AvailableBytes)
-	assert.NotEqual(nil, summary.Node.SystemContainers[1].Memory.UsageBytes)
+	assert.NotNil(summary.Node.SystemContainers[1].Memory)
+	assert.NotNil(summary.Node.SystemContainers[1].Memory.AvailableBytes)
+	assert.NotNil(summary.Node.SystemContainers[1].Memory.UsageBytes)
 	assert.Equal(summary.Pods, podStats)
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it

While working on #126379 I noticed pkg/kubelet is already listed as contextual in hack/logcheck.conf, but three calls in Windows-only files were still on the global klog functions. They had slipped through because golangci-lint on linux never compiles those files.

- `validation_windows.go`: two `klog.Warningf` during config validation. There's no ctx around at that point, so they now use `klog.Background()` and structured key/values. logr has no warning level, so these become Info — the message still spells out that the option isn't supported on Windows.
- `summary_sys_containers_windows.go`: one `klog.Errorf` where the callers already receive a ctx and were dropping it on the floor (`_ context.Context`). The ctx is now threaded through and used via `klog.FromContext`.

Also fixed three pre-existing testifylint nil-compare findings in `summary_windows_test.go` that showed up when linting these packages with GOOS=windows.

#### Which issue(s) this PR fixes

Part of #126379

#### Special notes for your reviewer

Verified locally:
- `GOOS=windows go build ./pkg/kubelet/...`
- `GOOS=windows go vet` on the two touched packages
- `GOOS=windows golangci-lint run --config hack/golangci.yaml` on the two touched packages — clean. This is the check linux CI can't do for windows-only files, so it may be worth a quick look at whether CI should run the linter for windows at some point (out of scope here).

#### Does this PR introduce a user-facing change?

No.

/kind cleanup
/sig node
/sig windows
/release-note-none
