### PR TITLE
Move GenericPodGroup to staging

### DIFF
--- a/pkg/scheduler/backend/cache/cache.go
+++ b/pkg/scheduler/backend/cache/cache.go
@@ -1127,7 +1127,7 @@ func (cache *cacheImpl) applyPVCRefCountDelta(snapshot *Snapshot) error {
 
 // AddGenericPodGroup adds a generic pod group object to the cache,
 // and links it to its parent composite pod group if one is specified.
-func (cache *cacheImpl) AddGenericPodGroup(gpg *framework.GenericPodGroup) {
+func (cache *cacheImpl) AddGenericPodGroup(gpg *fwk.GenericPodGroup) {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
@@ -1170,7 +1170,7 @@ func (cache *cacheImpl) AddGenericPodGroup(gpg *framework.GenericPodGroup) {
 }
 
 // UpdateGenericPodGroup updates an existing generic pod group object in the cache.
-func (cache *cacheImpl) UpdateGenericPodGroup(logger klog.Logger, gpg *framework.GenericPodGroup) {
+func (cache *cacheImpl) UpdateGenericPodGroup(logger klog.Logger, gpg *fwk.GenericPodGroup) {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
@@ -1197,7 +1197,7 @@ func (cache *cacheImpl) UpdateGenericPodGroup(logger klog.Logger, gpg *framework
 }
 
 // RemoveGenericPodGroup removes a generic pod group object from the cache.
-func (cache *cacheImpl) RemoveGenericPodGroup(logger klog.Logger, gpg *framework.GenericPodGroup) {
+func (cache *cacheImpl) RemoveGenericPodGroup(logger klog.Logger, gpg *fwk.GenericPodGroup) {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 

--- a/pkg/scheduler/backend/cache/cache_test.go
+++ b/pkg/scheduler/backend/cache/cache_test.go
@@ -744,7 +744,7 @@ func Test_AddPodGroupMember(t *testing.T) {
 			t.Run(fmt.Sprintf("%v, cpgEnabled=%v", tt.name, cpgEnabled), func(t *testing.T) {
 				cache := newCache(context.Background(), time.Second, nil, tt.genericWorkloadEnabled, cpgEnabled)
 				if tt.initPodGroup != nil {
-					cache.AddGenericPodGroup(framework.NewGenericPodGroup(tt.initPodGroup))
+					cache.AddGenericPodGroup(fwk.NewGenericPodGroup(tt.initPodGroup))
 				}
 
 				cache.AddPodGroupMember(tt.pod)
@@ -937,7 +937,7 @@ func Test_RemovePodGroupMember(t *testing.T) {
 				cache := newCache(context.Background(), time.Second, nil, tt.genericWorkloadEnabled, cpgEnabled)
 
 				if tt.initPodGroup != nil {
-					cache.AddGenericPodGroup(framework.NewGenericPodGroup(tt.initPodGroup))
+					cache.AddGenericPodGroup(fwk.NewGenericPodGroup(tt.initPodGroup))
 				}
 
 				for _, pod := range tt.initPods {
@@ -1087,10 +1087,10 @@ func Test_AddPodGroup(t *testing.T) {
 				cache.AddPodGroupMember(tt.initPod)
 			}
 			for _, cpg := range tt.initialCPGs {
-				cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+				cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.podGroupsToAdd {
-				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
+				cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 
 			gotPodGroups := make(map[fwk.EntityKey]*schedulingv1beta1.PodGroup)
@@ -1141,9 +1141,9 @@ func Test_UpdatePodGroup(t *testing.T) {
 			t.Run(fmt.Sprintf("%v, cpgEnabled=%v", tt.name, cpgEnabled), func(t *testing.T) {
 				logger, ctx := ktesting.NewTestContext(t)
 				cache := newCache(ctx, time.Second, nil, true, cpgEnabled)
-				cache.AddGenericPodGroup(framework.NewGenericPodGroup(tt.oldPodGroup))
+				cache.AddGenericPodGroup(fwk.NewGenericPodGroup(tt.oldPodGroup))
 
-				cache.UpdateGenericPodGroup(logger, framework.NewGenericPodGroup(tt.newPodGroup))
+				cache.UpdateGenericPodGroup(logger, fwk.NewGenericPodGroup(tt.newPodGroup))
 
 				gotPodGroup, err := cache.PodGroups().Get(tt.newPodGroup.Namespace, tt.newPodGroup.Name)
 				if tt.expectPodGroup != nil {
@@ -1231,13 +1231,13 @@ func Test_RemovePodGroup(t *testing.T) {
 				cache.AddPodGroupMember(tt.initPod)
 			}
 			for _, cpg := range tt.initialCPGs {
-				cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+				cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.initialPodGroups {
-				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
+				cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 
-			cache.RemoveGenericPodGroup(klog.FromContext(ctx), framework.NewGenericPodGroup(tt.podGroupToDelete))
+			cache.RemoveGenericPodGroup(klog.FromContext(ctx), fwk.NewGenericPodGroup(tt.podGroupToDelete))
 
 			_, err := cache.PodGroups().Get(tt.podGroupToDelete.Namespace, tt.podGroupToDelete.Name)
 			if err == nil {
@@ -3326,10 +3326,10 @@ func Test_AddCompositePodGroup(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
 			cache := newCache(ctx, time.Second, nil, true, true)
 			for _, pg := range tt.initialPGs {
-				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
+				cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.cpgsToAdd {
-				cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+				cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 			}
 
 			gotCPGs := make(map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup)
@@ -3416,13 +3416,13 @@ func Test_RemoveCompositePodGroup(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
 			cache := newCache(ctx, time.Second, nil, true, true)
 			for _, pg := range tt.initialPGs {
-				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
+				cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+				cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 			}
 
-			cache.RemoveGenericPodGroup(klog.FromContext(ctx), framework.NewGenericCompositePodGroup(tt.cpgToDelete))
+			cache.RemoveGenericPodGroup(klog.FromContext(ctx), fwk.NewGenericCompositePodGroup(tt.cpgToDelete))
 
 			gotCPGs := make(map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup)
 			gotChildren := make(map[fwk.EntityKey]sets.Set[fwk.EntityKey])
@@ -3555,10 +3555,10 @@ func Test_BuildHierarchySnapshotFromPod(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
 			cache := newCache(ctx, time.Second, nil, tt.genericWorkloadEnabled, tt.compositePodGroupEnabled)
 			for _, pg := range tt.initialPGs {
-				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
+				cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+				cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 			}
 
 			snapshot, err := cache.BuildHierarchySnapshotFromPod(tt.pod)

--- a/pkg/scheduler/backend/cache/interface.go
+++ b/pkg/scheduler/backend/cache/interface.go
@@ -138,13 +138,13 @@ type Cache interface {
 	RemovePodGroupMember(pod *v1.Pod)
 
 	// AddGenericPodGroup adds a generic pod group object to the cache.
-	AddGenericPodGroup(apg *framework.GenericPodGroup)
+	AddGenericPodGroup(gpg *fwk.GenericPodGroup)
 
 	// UpdateGenericPodGroup updates a generic pod group object in the cache.
-	UpdateGenericPodGroup(logger klog.Logger, apg *framework.GenericPodGroup)
+	UpdateGenericPodGroup(logger klog.Logger, gpg *fwk.GenericPodGroup)
 
 	// RemoveGenericPodGroup removes a generic pod group object from the cache.
-	RemoveGenericPodGroup(logger klog.Logger, apg *framework.GenericPodGroup)
+	RemoveGenericPodGroup(logger klog.Logger, gpg *fwk.GenericPodGroup)
 
 	// BuildHierarchySnapshotFromPod returns a snapshot of the pod group hierarchy for the given pod.
 	BuildHierarchySnapshotFromPod(pod *v1.Pod) (fwk.PodGroupManager, error)

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -134,11 +134,11 @@ type SchedulingQueue interface {
 	MoveAllToActiveOrBackoffQueue(logger klog.Logger, event fwk.ClusterEvent, oldObj, newObj interface{}, preCheck PreEnqueueCheck)
 	// AddGenericPodGroup adds a PodGroup or CompositePodGroup object to the queue,
 	// requeuing all pods associated with the group.
-	AddGenericPodGroup(logger klog.Logger, gpg *framework.GenericPodGroup)
+	AddGenericPodGroup(logger klog.Logger, gpg *fwk.GenericPodGroup)
 	// UpdateGenericPodGroup updates an existing PodGroup or CompositePodGroup object in the queue.
-	UpdateGenericPodGroup(logger klog.Logger, gpg *framework.GenericPodGroup)
+	UpdateGenericPodGroup(logger klog.Logger, gpg *fwk.GenericPodGroup)
 	// DeleteGenericPodGroup removes a PodGroup or CompositePodGroup object from the queue.
-	DeleteGenericPodGroup(logger klog.Logger, gpg *framework.GenericPodGroup)
+	DeleteGenericPodGroup(logger klog.Logger, gpg *fwk.GenericPodGroup)
 
 	// Close closes the SchedulingQueue so that the goroutine which is
 	// waiting to pop items can exit gracefully.
@@ -1567,7 +1567,7 @@ func (p *PriorityQueue) deletePod(pod *v1.Pod) {
 
 // AddGenericPodGroup adds a PodGroup or CompositePodGroup object to the queue,
 // requeuing all pods associated with the group.
-func (p *PriorityQueue) AddGenericPodGroup(logger klog.Logger, gpg *framework.GenericPodGroup) {
+func (p *PriorityQueue) AddGenericPodGroup(logger klog.Logger, gpg *fwk.GenericPodGroup) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -1607,7 +1607,7 @@ func (p *PriorityQueue) AddGenericPodGroup(logger klog.Logger, gpg *framework.Ge
 }
 
 // UpdateGenericPodGroup updates an existing PodGroup or CompositePodGroup object in the queue.
-func (p *PriorityQueue) UpdateGenericPodGroup(logger klog.Logger, gpg *framework.GenericPodGroup) {
+func (p *PriorityQueue) UpdateGenericPodGroup(logger klog.Logger, gpg *fwk.GenericPodGroup) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -1629,7 +1629,7 @@ func (p *PriorityQueue) UpdateGenericPodGroup(logger klog.Logger, gpg *framework
 }
 
 // DeleteGenericPodGroup removes a PodGroup or CompositePodGroup object from the queue.
-func (p *PriorityQueue) DeleteGenericPodGroup(logger klog.Logger, gpg *framework.GenericPodGroup) {
+func (p *PriorityQueue) DeleteGenericPodGroup(logger klog.Logger, gpg *fwk.GenericPodGroup) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -2195,7 +2195,7 @@ func (p *PriorityQueue) runPreQueueingHintPlugins(logger klog.Logger, event fwk.
 func newPodGroupInfoForLookup(namespace, name string) *framework.QueuedPodGroupInfo {
 	return &framework.QueuedPodGroupInfo{
 		PodGroupInfo: &framework.PodGroupInfo{
-			GenericPodGroup: framework.NewGenericPodGroup(&schedulingv1beta1.PodGroup{
+			GenericPodGroup: fwk.NewGenericPodGroup(&schedulingv1beta1.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
 					Name:      name,
@@ -2208,7 +2208,7 @@ func newPodGroupInfoForLookup(namespace, name string) *framework.QueuedPodGroupI
 func newCompositePodGroupInfoForLookup(namespace, name string) *framework.QueuedPodGroupInfo {
 	return &framework.QueuedPodGroupInfo{
 		PodGroupInfo: &framework.PodGroupInfo{
-			GenericPodGroup: framework.NewGenericCompositePodGroup(&schedulingv1alpha3.CompositePodGroup{
+			GenericPodGroup: fwk.NewGenericCompositePodGroup(&schedulingv1alpha3.CompositePodGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
 					Name:      name,

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -221,7 +221,7 @@ func TestPriorityQueue_Add(t *testing.T) {
 					st.MakePodGroup().Name("pg-high").Namespace(highPod.Namespace).Priority(highPriority).Obj(),
 				}
 				for _, podGroup := range podGroups {
-					q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(podGroup))
+					q.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(podGroup))
 				}
 			}
 			q.Add(ctx, medPod)
@@ -1101,7 +1101,7 @@ func Test_InFlightPods(t *testing.T) {
 				sortOpt := cmpopts.SortSlices(func(a, b string) bool { return a < b })
 				if genericWorkloadEnabled {
 					for _, pg := range podGroupsToAdd {
-						q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
+						q.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(pg))
 					}
 				}
 
@@ -1137,7 +1137,7 @@ func Test_InFlightPods(t *testing.T) {
 							t.Fatalf("unexpected error from AddAttemptedPodGroupIfNeeded: %v", err)
 						}
 					case action.podGroupAdded != nil:
-						q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(action.podGroupAdded))
+						q.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(action.podGroupAdded))
 					case action.callback != nil:
 						action.callback(t, q)
 					}
@@ -3695,7 +3695,7 @@ func TestGatedPodFlushFrequency(t *testing.T) {
 			name: "queued pod group",
 			entityInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					GenericPodGroup: framework.NewGenericPodGroup(&schedulingv1beta1.PodGroup{
+					GenericPodGroup: fwk.NewGenericPodGroup(&schedulingv1beta1.PodGroup{
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: gatedPod.GetNamespace(),
 							Name:      "pg",
@@ -3942,7 +3942,7 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 			q := NewTestQueue(tCtx, newDefaultQueueSort(), opts...)
 			podGroup := st.MakePodGroup().Name(pgName).Namespace("ns1").Obj()
 			if !test.skipAddPodGroup {
-				q.AddGenericPodGroup(tCtx.Logger(), framework.NewGenericPodGroup(podGroup))
+				q.AddGenericPodGroup(tCtx.Logger(), fwk.NewGenericPodGroup(podGroup))
 			}
 
 			pgInfo := newSingleLevelPodGroupInfo(q.newQueuedPodInfo(tCtx, pod1), podGroup)
@@ -4196,7 +4196,7 @@ var (
 	addPodGroupForPod = func(tCtx ktesting.TContext, queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
 		pgName := *pInfo.Pod.Spec.SchedulingGroup.PodGroupName
 		pg := st.MakePodGroup().Name(pgName).Namespace(pInfo.Pod.Namespace).Obj()
-		queue.AddGenericPodGroup(klog.FromContext(tCtx), framework.NewGenericPodGroup(pg))
+		queue.AddGenericPodGroup(klog.FromContext(tCtx), fwk.NewGenericPodGroup(pg))
 	}
 )
 
@@ -5275,11 +5275,11 @@ func TestIncomingEntitiesMetrics(t *testing.T) {
 					tCtx := ktesting.Init(t)
 					metrics.SchedulerQueueIncomingEntities.Reset()
 					queue := NewTestQueue(tCtx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)))
-					queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(st.MakePodGroup().Name("pg-1").Namespace("ns-pg").Obj()))
+					queue.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(st.MakePodGroup().Name("pg-1").Namespace("ns-pg").Obj()))
 					if setup.cpgEnabled {
-						queue.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(st.MakeCompositePodGroup().Name("cpg-root").Namespace("ns-pg").Obj()))
-						queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(st.MakePodGroup().Name("pg-cpg-1").Namespace("ns-pg").ParentCompositePodGroup("cpg-root").Obj()))
-						queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(st.MakePodGroup().Name("pg-cpg-2").Namespace("ns-pg").ParentCompositePodGroup("cpg-root").Obj()))
+						queue.AddGenericPodGroup(logger, fwk.NewGenericCompositePodGroup(st.MakeCompositePodGroup().Name("cpg-root").Namespace("ns-pg").Obj()))
+						queue.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(st.MakePodGroup().Name("pg-cpg-1").Namespace("ns-pg").ParentCompositePodGroup("cpg-root").Obj()))
+						queue.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(st.MakePodGroup().Name("pg-cpg-2").Namespace("ns-pg").ParentCompositePodGroup("cpg-root").Obj()))
 					}
 					test.run(tCtx, queue)
 					if err := testutil.CollectAndCompare(metrics.SchedulerQueueIncomingEntities, strings.NewReader(queueIncomingEntitiesMetricMetadata+test.want), metricName); err != nil {
@@ -5677,11 +5677,11 @@ func TestQueuedEntitiesMetrics(t *testing.T) {
 					tCtx := ktesting.Init(t)
 					metrics.QueuedEntities.Reset()
 					queue := NewTestQueue(tCtx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)))
-					queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(st.MakePodGroup().Name("pg-1").Namespace("ns-pg").Obj()))
+					queue.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(st.MakePodGroup().Name("pg-1").Namespace("ns-pg").Obj()))
 					if setup.cpgEnabled {
-						queue.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(st.MakeCompositePodGroup().Name("cpg-root").Namespace("ns-pg").Obj()))
-						queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(st.MakePodGroup().Name("pg-cpg-1").Namespace("ns-pg").ParentCompositePodGroup("cpg-root").Obj()))
-						queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(st.MakePodGroup().Name("pg-cpg-2").Namespace("ns-pg").ParentCompositePodGroup("cpg-root").Obj()))
+						queue.AddGenericPodGroup(logger, fwk.NewGenericCompositePodGroup(st.MakeCompositePodGroup().Name("cpg-root").Namespace("ns-pg").Obj()))
+						queue.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(st.MakePodGroup().Name("pg-cpg-1").Namespace("ns-pg").ParentCompositePodGroup("cpg-root").Obj()))
+						queue.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(st.MakePodGroup().Name("pg-cpg-2").Namespace("ns-pg").ParentCompositePodGroup("cpg-root").Obj()))
 					}
 					test.run(tCtx, queue)
 
@@ -6814,7 +6814,7 @@ func setupInitialPodGroupState(t *testing.T, ctx context.Context, q *PriorityQue
 
 	if initialState != stateIncomplete {
 		logger := klog.FromContext(ctx)
-		q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(initialPodGroup))
+		q.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(initialPodGroup))
 	}
 
 	if len(initialPods) == 0 {
@@ -8278,7 +8278,7 @@ func TestAddUnschedulablePodIfNotPresentPodGroupMember(t *testing.T) {
 			}
 
 			if tt.deletePodGroup {
-				q.DeleteGenericPodGroup(logger, framework.NewGenericPodGroup(podGroup))
+				q.DeleteGenericPodGroup(logger, fwk.NewGenericPodGroup(podGroup))
 			}
 
 			// Add unschedulable pods
@@ -8399,7 +8399,7 @@ func TestAddPodGroup(t *testing.T) {
 
 			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState, podGroup)
 
-			q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(podGroup))
+			q.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(podGroup))
 
 			pgLookup := newPodGroupInfoForLookup(podGroup.Namespace, podGroup.Name)
 			gotGPG, ok := q.workloadForest.podGroups[fwk.PodGroupKey(podGroup.Namespace, podGroup.Name)]
@@ -8523,7 +8523,7 @@ func TestUpdatePodGroup(t *testing.T) {
 
 			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState, podGroup)
 
-			q.UpdateGenericPodGroup(logger, framework.NewGenericPodGroup(updatedPodGroup))
+			q.UpdateGenericPodGroup(logger, fwk.NewGenericPodGroup(updatedPodGroup))
 
 			gotGPG, ok := q.workloadForest.podGroups[fwk.PodGroupKey(podGroup.Namespace, podGroup.Name)]
 			if !ok {
@@ -8651,7 +8651,7 @@ func TestDeletePodGroup(t *testing.T) {
 				q.Add(ctx, pod)
 			}
 
-			q.DeleteGenericPodGroup(logger, framework.NewGenericPodGroup(podGroup))
+			q.DeleteGenericPodGroup(logger, fwk.NewGenericPodGroup(podGroup))
 
 			_, ok := q.workloadForest.podGroups[fwk.PodGroupKey(podGroup.Namespace, podGroup.Name)]
 			if ok {
@@ -8859,10 +8859,10 @@ func TestPriorityQueue_AddCompositePodGroup(t *testing.T) {
 			defer q.Close()
 
 			for _, pg := range tt.initialPodGroups {
-				q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
+				q.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				q.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(cpg))
+				q.AddGenericPodGroup(logger, fwk.NewGenericCompositePodGroup(cpg))
 			}
 			for _, pod := range tt.initialPods {
 				q.Add(ctx, pod)
@@ -8871,7 +8871,7 @@ func TestPriorityQueue_AddCompositePodGroup(t *testing.T) {
 				tt.beforeAdd(ctx, q)
 			}
 
-			q.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(tt.cpgToAdd))
+			q.AddGenericPodGroup(logger, fwk.NewGenericCompositePodGroup(tt.cpgToAdd))
 
 			cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b string) bool { return a < b })}
 			if diff := cmp.Diff(tt.expectedActiveQ, getActivePodGroups(q), cmpOpts...); diff != "" {
@@ -8958,16 +8958,16 @@ func TestPriorityQueue_UpdateCompositePodGroup(t *testing.T) {
 			defer q.Close()
 
 			for _, cpg := range tt.initialCPGs {
-				q.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(cpg))
+				q.AddGenericPodGroup(logger, fwk.NewGenericCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.initialPodGroups {
-				q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
+				q.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(pg))
 			}
 			for _, pod := range tt.initialPods {
 				q.Add(ctx, pod)
 			}
 
-			q.UpdateGenericPodGroup(logger, framework.NewGenericCompositePodGroup(tt.cpgToUpdate))
+			q.UpdateGenericPodGroup(logger, fwk.NewGenericCompositePodGroup(tt.cpgToUpdate))
 
 			cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b string) bool { return a < b })}
 			if diff := cmp.Diff(tt.expectedActiveQ, getActivePodGroups(q), cmpOpts...); diff != "" {
@@ -9186,10 +9186,10 @@ func TestPriorityQueue_DeleteCompositePodGroup(t *testing.T) {
 			defer q.Close()
 
 			for _, cpg := range tt.initialCPGs {
-				q.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(cpg))
+				q.AddGenericPodGroup(logger, fwk.NewGenericCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.initialPodGroups {
-				q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
+				q.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(pg))
 			}
 			for _, pod := range tt.initialPods {
 				q.Add(ctx, pod)
@@ -9198,7 +9198,7 @@ func TestPriorityQueue_DeleteCompositePodGroup(t *testing.T) {
 				tt.beforeDelete(ctx, q)
 			}
 
-			q.DeleteGenericPodGroup(logger, framework.NewGenericCompositePodGroup(tt.cpgToDelete))
+			q.DeleteGenericPodGroup(logger, fwk.NewGenericCompositePodGroup(tt.cpgToDelete))
 
 			cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b string) bool { return a < b })}
 			if diff := cmp.Diff(tt.expectedActiveQ, getActivePodGroups(q), cmpOpts...); diff != "" {
@@ -9412,10 +9412,10 @@ func TestPriorityQueue_AddPodGroup_Hierarchical(t *testing.T) {
 			defer q.Close()
 
 			for _, cpg := range tt.initialCPGs {
-				q.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(cpg))
+				q.AddGenericPodGroup(logger, fwk.NewGenericCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.initialPodGroups {
-				q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
+				q.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(pg))
 			}
 			for _, pod := range tt.initialPods {
 				q.Add(ctx, pod)
@@ -9424,7 +9424,7 @@ func TestPriorityQueue_AddPodGroup_Hierarchical(t *testing.T) {
 				tt.beforeAdd(ctx, q)
 			}
 
-			q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(tt.pgToAdd))
+			q.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(tt.pgToAdd))
 
 			cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b string) bool { return a < b })}
 			if diff := cmp.Diff(tt.expectedActiveQ, getActivePodGroups(q), cmpOpts...); diff != "" {
@@ -9522,16 +9522,16 @@ func TestPriorityQueue_UpdatePodGroup_Hierarchical(t *testing.T) {
 			defer q.Close()
 
 			for _, cpg := range tt.initialCPGs {
-				q.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(cpg))
+				q.AddGenericPodGroup(logger, fwk.NewGenericCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.initialPodGroups {
-				q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
+				q.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(pg))
 			}
 			for _, pod := range tt.initialPods {
 				q.Add(ctx, pod)
 			}
 
-			q.UpdateGenericPodGroup(logger, framework.NewGenericPodGroup(tt.pgToUpdate))
+			q.UpdateGenericPodGroup(logger, fwk.NewGenericPodGroup(tt.pgToUpdate))
 
 			cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b string) bool { return a < b })}
 			if diff := cmp.Diff(tt.expectedActiveQ, getActivePodGroups(q), cmpOpts...); diff != "" {
@@ -9727,10 +9727,10 @@ func TestPriorityQueue_DeletePodGroup_Hierarchical(t *testing.T) {
 			defer q.Close()
 
 			for _, cpg := range tt.initialCPGs {
-				q.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(cpg))
+				q.AddGenericPodGroup(logger, fwk.NewGenericCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.initialPodGroups {
-				q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
+				q.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(pg))
 			}
 			for _, pod := range tt.initialPods {
 				q.Add(ctx, pod)
@@ -9739,7 +9739,7 @@ func TestPriorityQueue_DeletePodGroup_Hierarchical(t *testing.T) {
 				tt.beforeDelete(ctx, q)
 			}
 
-			q.DeleteGenericPodGroup(logger, framework.NewGenericPodGroup(tt.pgToDelete))
+			q.DeleteGenericPodGroup(logger, fwk.NewGenericPodGroup(tt.pgToDelete))
 
 			cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b string) bool { return a < b })}
 			if diff := cmp.Diff(tt.expectedActiveQ, getActivePodGroups(q), cmpOpts...); diff != "" {
@@ -9849,7 +9849,7 @@ func newSingleLevelPodGroupInfo(podInfo *framework.QueuedPodInfo, podGroup *sche
 	}
 	return &framework.QueuedPodGroupInfo{
 		PodGroupInfo: &framework.PodGroupInfo{
-			GenericPodGroup: framework.NewGenericPodGroup(pgObj),
+			GenericPodGroup: fwk.NewGenericPodGroup(pgObj),
 			UnscheduledPods: []*v1.Pod{podInfo.Pod},
 		},
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{key: {podInfo}},
@@ -9893,7 +9893,7 @@ func TestPriorityQueue_DeferredPodGroupCompatibility(t *testing.T) {
 
 			if tt.pod.Spec.SchedulingGroup != nil && tt.pod.Spec.SchedulingGroup.PodGroupName != nil {
 				pg := st.MakePodGroup().Name(*tt.pod.Spec.SchedulingGroup.PodGroupName).Namespace(tt.pod.Namespace).Obj()
-				q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
+				q.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(pg))
 			}
 
 			q.Add(ctx, tt.pod)

--- a/pkg/scheduler/backend/queue/unschedulable_entities_test.go
+++ b/pkg/scheduler/backend/queue/unschedulable_entities_test.go
@@ -246,7 +246,7 @@ func TestUnschedulablePodGroups_Unified(t *testing.T) {
 
 	pgInfo := &framework.QueuedPodGroupInfo{
 		PodGroupInfo: &framework.PodGroupInfo{
-			GenericPodGroup: framework.NewGenericPodGroup(st.MakePodGroup().Name("pg1").Namespace("ns1").Obj()),
+			GenericPodGroup: fwk.NewGenericPodGroup(st.MakePodGroup().Name("pg1").Namespace("ns1").Obj()),
 		},
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{
 			fwk.PodGroupKey("ns1", "pg1"): {

--- a/pkg/scheduler/backend/queue/workload_forest.go
+++ b/pkg/scheduler/backend/queue/workload_forest.go
@@ -34,7 +34,7 @@ import (
 // Outside of the scheduling queue, cache should be used as the source of truth.
 // This structure is not thread-safe and should be accessed only under the lock of the PriorityQueue.
 type workloadForest struct {
-	podGroups map[fwk.EntityKey]*framework.GenericPodGroup
+	podGroups map[fwk.EntityKey]*fwk.GenericPodGroup
 	// children maps a parent CompositePodGroup key to its direct children keys (PodGroups or CompositePodGroups).
 	// As an invariant of this structure, a child-to-parent relationship is populated here regardless of whether
 	// the parent object has been explicitly observed yet. This prevents the need to iterate over all existing
@@ -45,14 +45,14 @@ type workloadForest struct {
 
 func newWorkloadForest(isCompositePodGroupEnabled bool) *workloadForest {
 	return &workloadForest{
-		podGroups:                  make(map[fwk.EntityKey]*framework.GenericPodGroup),
+		podGroups:                  make(map[fwk.EntityKey]*fwk.GenericPodGroup),
 		children:                   make(map[fwk.EntityKey]sets.Set[fwk.EntityKey]),
 		isCompositePodGroupEnabled: isCompositePodGroupEnabled,
 	}
 }
 
 // addGenericPodGroup adds a GenericPodGroup to the forest.
-func (wf *workloadForest) addGenericPodGroup(gpg *framework.GenericPodGroup) {
+func (wf *workloadForest) addGenericPodGroup(gpg *fwk.GenericPodGroup) {
 	key := gpg.GetKey()
 	wf.podGroups[key] = gpg
 
@@ -72,12 +72,12 @@ func (wf *workloadForest) addGenericPodGroup(gpg *framework.GenericPodGroup) {
 }
 
 // updateGenericPodGroup updates a GenericPodGroup in the forest.
-func (wf *workloadForest) updateGenericPodGroup(gpg *framework.GenericPodGroup) {
+func (wf *workloadForest) updateGenericPodGroup(gpg *fwk.GenericPodGroup) {
 	wf.podGroups[gpg.GetKey()] = gpg
 }
 
 // deleteGenericPodGroup removes a GenericPodGroup from the forest.
-func (wf *workloadForest) deleteGenericPodGroup(gpg *framework.GenericPodGroup) {
+func (wf *workloadForest) deleteGenericPodGroup(gpg *fwk.GenericPodGroup) {
 	key := gpg.GetKey()
 	delete(wf.podGroups, key)
 
@@ -109,7 +109,7 @@ func (wf *workloadForest) getRootLookupInfoForPod(pod *v1.Pod) (*framework.Queue
 }
 
 // getRootLookupInfo returns the lookup info of the current root PodGroup or CompositePodGroup for a given GenericPodGroup.
-func (wf *workloadForest) getRootLookupInfo(gpg *framework.GenericPodGroup) (*framework.QueuedPodGroupInfo, bool) {
+func (wf *workloadForest) getRootLookupInfo(gpg *fwk.GenericPodGroup) (*framework.QueuedPodGroupInfo, bool) {
 	storedGPG, exists := wf.podGroups[gpg.GetKey()]
 	if !exists {
 		return nil, false
@@ -199,7 +199,7 @@ func (wf *workloadForest) getLeafPodGroups(logger klog.Logger, rootLookupInfo *f
 
 // buildPodGroupInfo recursively constructs a PodGroupInfo representation for a given GenericPodGroup
 // and all its children, using the provided visited set to detect cycles in the hierarchy.
-func (wf *workloadForest) buildPodGroupInfo(logger klog.Logger, gpg *framework.GenericPodGroup, visited sets.Set[fwk.EntityKey]) *framework.PodGroupInfo {
+func (wf *workloadForest) buildPodGroupInfo(logger klog.Logger, gpg *fwk.GenericPodGroup, visited sets.Set[fwk.EntityKey]) *framework.PodGroupInfo {
 	key := gpg.GetKey()
 	if visited.Has(key) {
 		utilruntime.HandleErrorWithLogger(logger, nil, "Cycle detected in composite pod group hierarchy when building PodGroupInfo", "groupType", gpg.GetType(), "group", klog.KObj(gpg))

--- a/pkg/scheduler/backend/queue/workload_forest_test.go
+++ b/pkg/scheduler/backend/queue/workload_forest_test.go
@@ -42,15 +42,15 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 		isCompositePodGroupEnabled bool
 		initialCPGs                []*schedulingv1alpha3.CompositePodGroup
 		podGroupsToAdd             []*schedulingv1beta1.PodGroup
-		wantPodGroups              map[fwk.EntityKey]*framework.GenericPodGroup
+		wantPodGroups              map[fwk.EntityKey]*fwk.GenericPodGroup
 		wantChildren               map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
 			name:                       "add single pod group",
 			isCompositePodGroupEnabled: true,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg1},
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.PodGroupKey("ns1", "pg1"): framework.NewGenericPodGroup(pg1),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg1"): fwk.NewGenericPodGroup(pg1),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -58,9 +58,9 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add multiple pod groups",
 			isCompositePodGroupEnabled: true,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg1, pg2},
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.PodGroupKey("ns1", "pg1"): framework.NewGenericPodGroup(pg1),
-				fwk.PodGroupKey("ns1", "pg2"): framework.NewGenericPodGroup(pg2),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg1"): fwk.NewGenericPodGroup(pg1),
+				fwk.PodGroupKey("ns1", "pg2"): fwk.NewGenericPodGroup(pg2),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -68,8 +68,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add pod group with parent, parent not in children",
 			isCompositePodGroupEnabled: true,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.PodGroupKey("ns1", "pg3"): framework.NewGenericPodGroup(pg3WithParent),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg3"): fwk.NewGenericPodGroup(pg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.PodGroupKey("ns1", "pg3")),
@@ -79,9 +79,9 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add pod group with parent, parent already in children",
 			isCompositePodGroupEnabled: true,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent, pg4WithParent},
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.PodGroupKey("ns1", "pg3"): framework.NewGenericPodGroup(pg3WithParent),
-				fwk.PodGroupKey("ns1", "pg4"): framework.NewGenericPodGroup(pg4WithParent),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg3"): fwk.NewGenericPodGroup(pg3WithParent),
+				fwk.PodGroupKey("ns1", "pg4"): fwk.NewGenericPodGroup(pg4WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.PodGroupKey("ns1", "pg3"), fwk.PodGroupKey("ns1", "pg4")),
@@ -92,9 +92,9 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			isCompositePodGroupEnabled: true,
 			initialCPGs:                []*schedulingv1alpha3.CompositePodGroup{cpgChild},
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpgChild"): framework.NewGenericCompositePodGroup(cpgChild),
-				fwk.PodGroupKey("ns1", "pg3"):               framework.NewGenericPodGroup(pg3WithParent),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpgChild"): fwk.NewGenericCompositePodGroup(cpgChild),
+				fwk.PodGroupKey("ns1", "pg3"):               fwk.NewGenericPodGroup(pg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.CompositePodGroupKey("ns1", "cpgChild"), fwk.PodGroupKey("ns1", "pg3")),
@@ -104,8 +104,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add pod group with parent, feature disabled",
 			isCompositePodGroupEnabled: false,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.PodGroupKey("ns1", "pg3"): framework.NewGenericPodGroup(pg3WithParent),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg3"): fwk.NewGenericPodGroup(pg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -113,8 +113,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add same pod group again, feature enabled",
 			isCompositePodGroupEnabled: true,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg1, pg1},
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.PodGroupKey("ns1", "pg1"): framework.NewGenericPodGroup(pg1),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg1"): fwk.NewGenericPodGroup(pg1),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -122,8 +122,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add same pod group again, feature disabled",
 			isCompositePodGroupEnabled: false,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg1, pg1},
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.PodGroupKey("ns1", "pg1"): framework.NewGenericPodGroup(pg1),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg1"): fwk.NewGenericPodGroup(pg1),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -131,8 +131,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add same pod group with parent again, feature enabled",
 			isCompositePodGroupEnabled: true,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent, pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.PodGroupKey("ns1", "pg3"): framework.NewGenericPodGroup(pg3WithParent),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg3"): fwk.NewGenericPodGroup(pg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.PodGroupKey("ns1", "pg3")),
@@ -142,8 +142,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add same pod group with parent again, feature disabled",
 			isCompositePodGroupEnabled: false,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent, pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.PodGroupKey("ns1", "pg3"): framework.NewGenericPodGroup(pg3WithParent),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg3"): fwk.NewGenericPodGroup(pg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -153,10 +153,10 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, cpg := range tt.initialCPGs {
-				wf.addGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+				wf.addGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.podGroupsToAdd {
-				wf.addGenericPodGroup(framework.NewGenericPodGroup(pg))
+				wf.addGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 
 			if diff := cmp.Diff(tt.wantPodGroups, wf.podGroups); diff != "" {
@@ -178,23 +178,23 @@ func TestWorkloadForest_UpdatePodGroup(t *testing.T) {
 		name             string
 		initialPodGroups []*schedulingv1beta1.PodGroup
 		podGroupToUpdate *schedulingv1beta1.PodGroup
-		wantPodGroups    map[fwk.EntityKey]*framework.GenericPodGroup
+		wantPodGroups    map[fwk.EntityKey]*fwk.GenericPodGroup
 	}{
 		{
 			name:             "update existing pod group",
 			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
 			podGroupToUpdate: updatedPG1,
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.PodGroupKey("ns1", "pg1"): framework.NewGenericPodGroup(updatedPG1),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg1"): fwk.NewGenericPodGroup(updatedPG1),
 			},
 		},
 		{
 			name:             "update non-existent pod group adds it",
 			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
 			podGroupToUpdate: pg2,
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.PodGroupKey("ns1", "pg1"): framework.NewGenericPodGroup(pg1),
-				fwk.PodGroupKey("ns1", "pg2"): framework.NewGenericPodGroup(pg2),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg1"): fwk.NewGenericPodGroup(pg1),
+				fwk.PodGroupKey("ns1", "pg2"): fwk.NewGenericPodGroup(pg2),
 			},
 		},
 	}
@@ -203,10 +203,10 @@ func TestWorkloadForest_UpdatePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(true)
 			for _, pg := range tt.initialPodGroups {
-				wf.addGenericPodGroup(framework.NewGenericPodGroup(pg))
+				wf.addGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 
-			wf.updateGenericPodGroup(framework.NewGenericPodGroup(tt.podGroupToUpdate))
+			wf.updateGenericPodGroup(fwk.NewGenericPodGroup(tt.podGroupToUpdate))
 
 			if diff := cmp.Diff(tt.wantPodGroups, wf.podGroups); diff != "" {
 				t.Errorf("Unexpected podGroups (-want,+got)\n%s", diff)
@@ -230,7 +230,7 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 		initialPodGroups           []*schedulingv1beta1.PodGroup
 		initialCPGs                []*schedulingv1alpha3.CompositePodGroup
 		podGroupToDelete           *schedulingv1beta1.PodGroup
-		wantPodGroups              map[fwk.EntityKey]*framework.GenericPodGroup
+		wantPodGroups              map[fwk.EntityKey]*fwk.GenericPodGroup
 		wantChildren               map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
@@ -238,8 +238,8 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 			isCompositePodGroupEnabled: true,
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2},
 			podGroupToDelete:           pg1,
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.PodGroupKey("ns1", "pg2"): framework.NewGenericPodGroup(pg2),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg2"): fwk.NewGenericPodGroup(pg2),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -248,8 +248,8 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 			isCompositePodGroupEnabled: true,
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1},
 			podGroupToDelete:           pg2,
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.PodGroupKey("ns1", "pg1"): framework.NewGenericPodGroup(pg1),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg1"): fwk.NewGenericPodGroup(pg1),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -258,7 +258,7 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 			isCompositePodGroupEnabled: true,
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg3WithParent},
 			podGroupToDelete:           pg3WithParent,
-			wantPodGroups:              map[fwk.EntityKey]*framework.GenericPodGroup{},
+			wantPodGroups:              map[fwk.EntityKey]*fwk.GenericPodGroup{},
 			wantChildren:               map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
@@ -267,8 +267,8 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg3WithParent},
 			initialCPGs:                []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			podGroupToDelete:           pg3WithParent,
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg1"): framework.NewGenericCompositePodGroup(cpg1),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg1"): fwk.NewGenericCompositePodGroup(cpg1),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -277,8 +277,8 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 			isCompositePodGroupEnabled: true,
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg3WithParent, pg4WithParent},
 			podGroupToDelete:           pg3WithParent,
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.PodGroupKey("ns1", "pg4"): framework.NewGenericPodGroup(pg4WithParent),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg4"): fwk.NewGenericPodGroup(pg4WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.PodGroupKey("ns1", "pg4")),
@@ -290,8 +290,8 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg3WithParent},
 			initialCPGs:                []*schedulingv1alpha3.CompositePodGroup{cpgChild},
 			podGroupToDelete:           pg3WithParent,
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpgChild"): framework.NewGenericCompositePodGroup(cpgChild),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpgChild"): fwk.NewGenericCompositePodGroup(cpgChild),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.CompositePodGroupKey("ns1", "cpgChild")),
@@ -302,7 +302,7 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 			isCompositePodGroupEnabled: false,
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg3WithParent},
 			podGroupToDelete:           pg3WithParent,
-			wantPodGroups:              map[fwk.EntityKey]*framework.GenericPodGroup{},
+			wantPodGroups:              map[fwk.EntityKey]*fwk.GenericPodGroup{},
 			wantChildren:               map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 	}
@@ -311,13 +311,13 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, pg := range tt.initialPodGroups {
-				wf.addGenericPodGroup(framework.NewGenericPodGroup(pg))
+				wf.addGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				wf.addGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+				wf.addGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 			}
 
-			wf.deleteGenericPodGroup(framework.NewGenericPodGroup(tt.podGroupToDelete))
+			wf.deleteGenericPodGroup(fwk.NewGenericPodGroup(tt.podGroupToDelete))
 
 			if diff := cmp.Diff(tt.wantPodGroups, wf.podGroups); diff != "" {
 				t.Errorf("Unexpected podGroups (-want,+got)\n%s", diff)
@@ -373,10 +373,10 @@ func TestWorkloadForest_GetPodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, pg := range tt.initialPodGroups {
-				wf.addGenericPodGroup(framework.NewGenericPodGroup(pg))
+				wf.addGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 
-			gotGPG, gotFound := wf.podGroups[framework.NewGenericPodGroup(tt.podGroupLookup).GetKey()]
+			gotGPG, gotFound := wf.podGroups[fwk.NewGenericPodGroup(tt.podGroupLookup).GetKey()]
 			var gotPG *schedulingv1beta1.PodGroup
 			if gotFound && gotGPG.PodGroup != nil {
 				gotPG = gotGPG.PodGroup
@@ -420,10 +420,10 @@ func TestWorkloadForest_GetCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(true)
 			for _, cpg := range tt.initialCompositePodGroups {
-				wf.addGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+				wf.addGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 			}
 
-			gotGPG, gotFound := wf.podGroups[framework.NewGenericCompositePodGroup(tt.cpgLookup).GetKey()]
+			gotGPG, gotFound := wf.podGroups[fwk.NewGenericCompositePodGroup(tt.cpgLookup).GetKey()]
 			var gotCPG *schedulingv1alpha3.CompositePodGroup
 			if gotFound && gotGPG.CompositePodGroup != nil {
 				gotCPG = gotGPG.CompositePodGroup
@@ -452,31 +452,31 @@ func TestWorkloadForest_AddCompositePodGroup(t *testing.T) {
 		name          string
 		initialPGs    []*schedulingv1beta1.PodGroup
 		cpgsToAdd     []*schedulingv1alpha3.CompositePodGroup
-		wantPodGroups map[fwk.EntityKey]*framework.GenericPodGroup
+		wantPodGroups map[fwk.EntityKey]*fwk.GenericPodGroup
 		wantChildren  map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
 			name:      "add single composite pod group",
 			cpgsToAdd: []*schedulingv1alpha3.CompositePodGroup{cpg1},
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg1"): framework.NewGenericCompositePodGroup(cpg1),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg1"): fwk.NewGenericCompositePodGroup(cpg1),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
 			name:      "add multiple composite pod groups",
 			cpgsToAdd: []*schedulingv1alpha3.CompositePodGroup{cpg1, cpg2},
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg1"): framework.NewGenericCompositePodGroup(cpg1),
-				fwk.CompositePodGroupKey("ns1", "cpg2"): framework.NewGenericCompositePodGroup(cpg2),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg1"): fwk.NewGenericCompositePodGroup(cpg1),
+				fwk.CompositePodGroupKey("ns1", "cpg2"): fwk.NewGenericCompositePodGroup(cpg2),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
 			name:      "add composite pod group with parent, parent not in children",
 			cpgsToAdd: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg3"): framework.NewGenericCompositePodGroup(cpg3WithParent),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg3"): fwk.NewGenericCompositePodGroup(cpg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.CompositePodGroupKey("ns1", "cpg3")),
@@ -485,9 +485,9 @@ func TestWorkloadForest_AddCompositePodGroup(t *testing.T) {
 		{
 			name:      "add composite pod group with parent, parent already has other composite pod group child",
 			cpgsToAdd: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent, cpg4WithParent},
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg3"): framework.NewGenericCompositePodGroup(cpg3WithParent),
-				fwk.CompositePodGroupKey("ns1", "cpg4"): framework.NewGenericCompositePodGroup(cpg4WithParent),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg3"): fwk.NewGenericCompositePodGroup(cpg3WithParent),
+				fwk.CompositePodGroupKey("ns1", "cpg4"): fwk.NewGenericCompositePodGroup(cpg4WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.CompositePodGroupKey("ns1", "cpg3"), fwk.CompositePodGroupKey("ns1", "cpg4")),
@@ -497,9 +497,9 @@ func TestWorkloadForest_AddCompositePodGroup(t *testing.T) {
 			name:       "add composite pod group with parent, parent already has pod group child",
 			initialPGs: []*schedulingv1beta1.PodGroup{pgChild},
 			cpgsToAdd:  []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.PodGroupKey("ns1", "pgChild"):       framework.NewGenericPodGroup(pgChild),
-				fwk.CompositePodGroupKey("ns1", "cpg3"): framework.NewGenericCompositePodGroup(cpg3WithParent),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pgChild"):       fwk.NewGenericPodGroup(pgChild),
+				fwk.CompositePodGroupKey("ns1", "cpg3"): fwk.NewGenericCompositePodGroup(cpg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.PodGroupKey("ns1", "pgChild"), fwk.CompositePodGroupKey("ns1", "cpg3")),
@@ -508,16 +508,16 @@ func TestWorkloadForest_AddCompositePodGroup(t *testing.T) {
 		{
 			name:      "add same composite pod group again",
 			cpgsToAdd: []*schedulingv1alpha3.CompositePodGroup{cpg1, cpg1},
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg1"): framework.NewGenericCompositePodGroup(cpg1),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg1"): fwk.NewGenericCompositePodGroup(cpg1),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
 			name:      "add same composite pod group with parent again",
 			cpgsToAdd: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent, cpg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg3"): framework.NewGenericCompositePodGroup(cpg3WithParent),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg3"): fwk.NewGenericCompositePodGroup(cpg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.CompositePodGroupKey("ns1", "cpg3")),
@@ -529,10 +529,10 @@ func TestWorkloadForest_AddCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(true)
 			for _, pg := range tt.initialPGs {
-				wf.addGenericPodGroup(framework.NewGenericPodGroup(pg))
+				wf.addGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.cpgsToAdd {
-				wf.addGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+				wf.addGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 			}
 
 			if diff := cmp.Diff(tt.wantPodGroups, wf.podGroups); diff != "" {
@@ -554,23 +554,23 @@ func TestWorkloadForest_UpdateCompositePodGroup(t *testing.T) {
 		name          string
 		initialCPGs   []*schedulingv1alpha3.CompositePodGroup
 		cpgToUpdate   *schedulingv1alpha3.CompositePodGroup
-		wantPodGroups map[fwk.EntityKey]*framework.GenericPodGroup
+		wantPodGroups map[fwk.EntityKey]*fwk.GenericPodGroup
 	}{
 		{
 			name:        "update existing composite pod group",
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			cpgToUpdate: updatedCPG1,
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg1"): framework.NewGenericCompositePodGroup(updatedCPG1),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg1"): fwk.NewGenericCompositePodGroup(updatedCPG1),
 			},
 		},
 		{
 			name:        "update non-existent composite pod group adds it",
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			cpgToUpdate: cpg2,
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg1"): framework.NewGenericCompositePodGroup(cpg1),
-				fwk.CompositePodGroupKey("ns1", "cpg2"): framework.NewGenericCompositePodGroup(cpg2),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg1"): fwk.NewGenericCompositePodGroup(cpg1),
+				fwk.CompositePodGroupKey("ns1", "cpg2"): fwk.NewGenericCompositePodGroup(cpg2),
 			},
 		},
 	}
@@ -579,10 +579,10 @@ func TestWorkloadForest_UpdateCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(true)
 			for _, cpg := range tt.initialCPGs {
-				wf.addGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+				wf.addGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 			}
 
-			wf.updateGenericPodGroup(framework.NewGenericCompositePodGroup(tt.cpgToUpdate))
+			wf.updateGenericPodGroup(fwk.NewGenericCompositePodGroup(tt.cpgToUpdate))
 
 			if diff := cmp.Diff(tt.wantPodGroups, wf.podGroups); diff != "" {
 				t.Errorf("Unexpected podGroups (-want,+got)\n%s", diff)
@@ -606,21 +606,21 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 		initialPGs    []*schedulingv1beta1.PodGroup
 		initialCPGs   []*schedulingv1alpha3.CompositePodGroup
 		cpgToDelete   *schedulingv1alpha3.CompositePodGroup
-		wantPodGroups map[fwk.EntityKey]*framework.GenericPodGroup
+		wantPodGroups map[fwk.EntityKey]*fwk.GenericPodGroup
 		wantChildren  map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
 			name:          "delete existing composite pod group without parent",
 			initialCPGs:   []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			cpgToDelete:   cpg1,
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{},
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{},
 			wantChildren:  map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
 			name:          "delete composite pod group with parent, cleans up children map",
 			initialCPGs:   []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
 			cpgToDelete:   cpg3WithParent,
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{},
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{},
 			wantChildren:  map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
@@ -628,8 +628,8 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 			initialPGs:  []*schedulingv1beta1.PodGroup{pgChild},
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
 			cpgToDelete: cpg3WithParent,
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.PodGroupKey("ns1", "pgChild"): framework.NewGenericPodGroup(pgChild),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pgChild"): fwk.NewGenericPodGroup(pgChild),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.PodGroupKey("ns1", "pgChild")),
@@ -639,8 +639,8 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 			name:        "delete composite pod group with parent, parent has other composite pod group child",
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent, cpg4WithParent},
 			cpgToDelete: cpg3WithParent,
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg4"): framework.NewGenericCompositePodGroup(cpg4WithParent),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg4"): fwk.NewGenericCompositePodGroup(cpg4WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.CompositePodGroupKey("ns1", "cpg4")),
@@ -651,9 +651,9 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 			initialPGs:  []*schedulingv1beta1.PodGroup{pgChild},
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent, cpg4WithParent},
 			cpgToDelete: cpg3WithParent,
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.PodGroupKey("ns1", "pgChild"):       framework.NewGenericPodGroup(pgChild),
-				fwk.CompositePodGroupKey("ns1", "cpg4"): framework.NewGenericCompositePodGroup(cpg4WithParent),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pgChild"):       fwk.NewGenericPodGroup(pgChild),
+				fwk.CompositePodGroupKey("ns1", "cpg4"): fwk.NewGenericCompositePodGroup(cpg4WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.PodGroupKey("ns1", "pgChild"), fwk.CompositePodGroupKey("ns1", "cpg4")),
@@ -664,9 +664,9 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 			initialPGs:  []*schedulingv1beta1.PodGroup{pgLeaf},
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg1, cpgMid},
 			cpgToDelete: cpgMid,
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg1"): framework.NewGenericCompositePodGroup(cpg1),
-				fwk.PodGroupKey("ns1", "pgLeaf"):        framework.NewGenericPodGroup(pgLeaf),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg1"): fwk.NewGenericCompositePodGroup(cpg1),
+				fwk.PodGroupKey("ns1", "pgLeaf"):        fwk.NewGenericPodGroup(pgLeaf),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpgMid"): sets.New(fwk.PodGroupKey("ns1", "pgLeaf")),
@@ -676,8 +676,8 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 			name:        "delete non-existent composite pod group",
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
 			cpgToDelete: cpg1,
-			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg3"): framework.NewGenericCompositePodGroup(cpg3WithParent),
+			wantPodGroups: map[fwk.EntityKey]*fwk.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg3"): fwk.NewGenericCompositePodGroup(cpg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.CompositePodGroupKey("ns1", "cpg3")),
@@ -689,13 +689,13 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(true)
 			for _, pg := range tt.initialPGs {
-				wf.addGenericPodGroup(framework.NewGenericPodGroup(pg))
+				wf.addGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				wf.addGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+				wf.addGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 			}
 
-			wf.deleteGenericPodGroup(framework.NewGenericCompositePodGroup(tt.cpgToDelete))
+			wf.deleteGenericPodGroup(fwk.NewGenericCompositePodGroup(tt.cpgToDelete))
 
 			if diff := cmp.Diff(tt.wantPodGroups, wf.podGroups); diff != "" {
 				t.Errorf("Unexpected podGroups (-want,+got)\n%s", diff)
@@ -730,7 +730,7 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 			pod:              podWithPG1,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					GenericPodGroup: framework.NewGenericPodGroup(pg1),
+					GenericPodGroup: fwk.NewGenericPodGroup(pg1),
 				},
 			},
 			isCompositePodGroupEnabled: true,
@@ -742,7 +742,7 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 			pod:              podWithPG2,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					GenericPodGroup: framework.NewGenericCompositePodGroup(cpg1),
+					GenericPodGroup: fwk.NewGenericCompositePodGroup(cpg1),
 				},
 			},
 			isCompositePodGroupEnabled: true,
@@ -760,7 +760,7 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 			pod:              podWithPG1,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					GenericPodGroup: framework.NewGenericPodGroup(pg1),
+					GenericPodGroup: fwk.NewGenericPodGroup(pg1),
 				},
 			},
 			isCompositePodGroupEnabled: false,
@@ -772,7 +772,7 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 			pod:              podWithPG2,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					GenericPodGroup: framework.NewGenericPodGroup(pg2WithParent),
+					GenericPodGroup: fwk.NewGenericPodGroup(pg2WithParent),
 				},
 			},
 			isCompositePodGroupEnabled: false,
@@ -790,10 +790,10 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, pg := range tt.initialPodGroups {
-				wf.addGenericPodGroup(framework.NewGenericPodGroup(pg))
+				wf.addGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				wf.addGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+				wf.addGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 			}
 
 			gotInfo, gotFound := wf.getRootLookupInfoForPod(tt.pod)
@@ -828,7 +828,7 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 			podGroup:         pg1,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					GenericPodGroup: framework.NewGenericPodGroup(pg1),
+					GenericPodGroup: fwk.NewGenericPodGroup(pg1),
 				},
 			},
 			isCompositePodGroupEnabled: true,
@@ -840,7 +840,7 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 			podGroup:         pg2WithParent,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					GenericPodGroup: framework.NewGenericCompositePodGroup(cpg1),
+					GenericPodGroup: fwk.NewGenericCompositePodGroup(cpg1),
 				},
 			},
 			isCompositePodGroupEnabled: true,
@@ -865,7 +865,7 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 			podGroup:         pg1,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					GenericPodGroup: framework.NewGenericPodGroup(pg1),
+					GenericPodGroup: fwk.NewGenericPodGroup(pg1),
 				},
 			},
 			isCompositePodGroupEnabled: false,
@@ -877,7 +877,7 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 			podGroup:         pg2WithParent,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					GenericPodGroup: framework.NewGenericPodGroup(pg2WithParent),
+					GenericPodGroup: fwk.NewGenericPodGroup(pg2WithParent),
 				},
 			},
 			isCompositePodGroupEnabled: false,
@@ -888,7 +888,7 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 			podGroup:         pg3WithNonExistentParent,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					GenericPodGroup: framework.NewGenericPodGroup(pg3WithNonExistentParent),
+					GenericPodGroup: fwk.NewGenericPodGroup(pg3WithNonExistentParent),
 				},
 			},
 			isCompositePodGroupEnabled: false,
@@ -906,13 +906,13 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, pg := range tt.initialPodGroups {
-				wf.addGenericPodGroup(framework.NewGenericPodGroup(pg))
+				wf.addGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				wf.addGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+				wf.addGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 			}
 
-			gotInfo, gotFound := wf.getRootLookupInfo(framework.NewGenericPodGroup(tt.podGroup))
+			gotInfo, gotFound := wf.getRootLookupInfo(fwk.NewGenericPodGroup(tt.podGroup))
 			if wantFound := tt.wantInfo != nil; gotFound != wantFound {
 				t.Errorf("Expected found: %v, got: %v", wantFound, gotFound)
 			}
@@ -941,7 +941,7 @@ func TestWorkloadForest_GetRootLookupInfoForCPG(t *testing.T) {
 			cpg:         cpg1,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					GenericPodGroup: framework.NewGenericCompositePodGroup(cpg1),
+					GenericPodGroup: fwk.NewGenericCompositePodGroup(cpg1),
 				},
 			},
 		},
@@ -951,7 +951,7 @@ func TestWorkloadForest_GetRootLookupInfoForCPG(t *testing.T) {
 			cpg:         cpg2WithParent,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					GenericPodGroup: framework.NewGenericCompositePodGroup(cpg1),
+					GenericPodGroup: fwk.NewGenericCompositePodGroup(cpg1),
 				},
 			},
 		},
@@ -973,10 +973,10 @@ func TestWorkloadForest_GetRootLookupInfoForCPG(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(true)
 			for _, cpg := range tt.initialCPGs {
-				wf.addGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+				wf.addGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 			}
 
-			gotInfo, gotFound := wf.getRootLookupInfo(framework.NewGenericCompositePodGroup(tt.cpg))
+			gotInfo, gotFound := wf.getRootLookupInfo(fwk.NewGenericCompositePodGroup(tt.cpg))
 			if wantFound := tt.wantInfo != nil; gotFound != wantFound {
 				t.Errorf("Expected found: %v, got: %v", wantFound, gotFound)
 			}
@@ -1061,10 +1061,10 @@ func TestWorkloadForest_GetLeafPodGroups(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, pg := range tt.initialPodGroups {
-				wf.addGenericPodGroup(framework.NewGenericPodGroup(pg))
+				wf.addGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				wf.addGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+				wf.addGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 			}
 
 			logger, _ := ktesting.NewTestContext(t)
@@ -1101,7 +1101,7 @@ func TestWorkloadForest_BuildPodGroupInfoForPG(t *testing.T) {
 			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
 			pg:               pg1,
 			wantInfo: &framework.PodGroupInfo{
-				GenericPodGroup: framework.NewGenericPodGroup(pg1),
+				GenericPodGroup: fwk.NewGenericPodGroup(pg1),
 				Children:        []*framework.PodGroupInfo{},
 			},
 			isCompositePodGroupEnabled: true,
@@ -1111,7 +1111,7 @@ func TestWorkloadForest_BuildPodGroupInfoForPG(t *testing.T) {
 			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
 			pg:               pg1,
 			wantInfo: &framework.PodGroupInfo{
-				GenericPodGroup: framework.NewGenericPodGroup(pg1),
+				GenericPodGroup: fwk.NewGenericPodGroup(pg1),
 				Children:        []*framework.PodGroupInfo{},
 			},
 			isCompositePodGroupEnabled: false,
@@ -1122,12 +1122,12 @@ func TestWorkloadForest_BuildPodGroupInfoForPG(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, pg := range tt.initialPodGroups {
-				wf.addGenericPodGroup(framework.NewGenericPodGroup(pg))
+				wf.addGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 
 			logger, _ := ktesting.NewTestContext(t)
 			visited := sets.New[fwk.EntityKey]()
-			gotInfo := wf.buildPodGroupInfo(logger, framework.NewGenericPodGroup(tt.pg), visited)
+			gotInfo := wf.buildPodGroupInfo(logger, fwk.NewGenericPodGroup(tt.pg), visited)
 
 			if diff := cmp.Diff(tt.wantInfo, gotInfo); diff != "" {
 				t.Errorf("Unexpected PodGroupInfo (-want,+got)\n%s", diff)
@@ -1154,10 +1154,10 @@ func TestWorkloadForest_BuildPodGroupInfoForCPG(t *testing.T) {
 			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			cpg:              cpg1,
 			wantInfo: &framework.PodGroupInfo{
-				GenericPodGroup: framework.NewGenericCompositePodGroup(cpg1),
+				GenericPodGroup: fwk.NewGenericCompositePodGroup(cpg1),
 				Children: []*framework.PodGroupInfo{
 					{
-						GenericPodGroup: framework.NewGenericPodGroup(pg1WithParent),
+						GenericPodGroup: fwk.NewGenericPodGroup(pg1WithParent),
 						Children:        []*framework.PodGroupInfo{},
 					},
 				},
@@ -1170,7 +1170,7 @@ func TestWorkloadForest_BuildPodGroupInfoForCPG(t *testing.T) {
 			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			cpg:              cpg1,
 			wantInfo: &framework.PodGroupInfo{
-				GenericPodGroup: framework.NewGenericCompositePodGroup(cpg1),
+				GenericPodGroup: fwk.NewGenericCompositePodGroup(cpg1),
 				Children:        []*framework.PodGroupInfo{},
 			},
 			isCompositePodGroupEnabled: false,
@@ -1181,15 +1181,15 @@ func TestWorkloadForest_BuildPodGroupInfoForCPG(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, pg := range tt.initialPodGroups {
-				wf.addGenericPodGroup(framework.NewGenericPodGroup(pg))
+				wf.addGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				wf.addGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+				wf.addGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 			}
 
 			logger, _ := ktesting.NewTestContext(t)
 			visited := sets.New[fwk.EntityKey]()
-			gotInfo := wf.buildPodGroupInfo(logger, framework.NewGenericCompositePodGroup(tt.cpg), visited)
+			gotInfo := wf.buildPodGroupInfo(logger, fwk.NewGenericCompositePodGroup(tt.cpg), visited)
 
 			// Note: Children are sorted by name in buildPodGroupInfoForCPG, so it is deterministic.
 			if diff := cmp.Diff(tt.wantInfo, gotInfo); diff != "" {

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -476,9 +476,9 @@ func (sched *Scheduler) addPodGroup(obj any) {
 	}
 
 	logger.V(3).Info("Add event for pod group", "podGroup", klog.KObj(pg))
-	apg := framework.NewGenericPodGroup(pg)
-	sched.Cache.AddGenericPodGroup(apg)
-	sched.SchedulingQueue.AddGenericPodGroup(logger, apg)
+	gpg := fwk.NewGenericPodGroup(pg)
+	sched.Cache.AddGenericPodGroup(gpg)
+	sched.SchedulingQueue.AddGenericPodGroup(logger, gpg)
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, nil, pg, nil)
 }
 
@@ -502,9 +502,9 @@ func (sched *Scheduler) updatePodGroup(oldObj, newObj any) {
 	}
 
 	logger.V(4).Info("Update event for pod group", "podGroup", klog.KObj(newPG))
-	apg := framework.NewGenericPodGroup(newPG)
-	sched.Cache.UpdateGenericPodGroup(logger, apg)
-	sched.SchedulingQueue.UpdateGenericPodGroup(logger, apg)
+	gpg := fwk.NewGenericPodGroup(newPG)
+	sched.Cache.UpdateGenericPodGroup(logger, gpg)
+	sched.SchedulingQueue.UpdateGenericPodGroup(logger, gpg)
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, oldPG, newPG, nil)
 }
 
@@ -530,9 +530,9 @@ func (sched *Scheduler) deletePodGroup(obj any) {
 	}
 
 	logger.V(3).Info("Delete event for pod group", "podGroup", klog.KObj(pg))
-	apg := framework.NewGenericPodGroup(pg)
-	sched.Cache.RemoveGenericPodGroup(logger, apg)
-	sched.SchedulingQueue.DeleteGenericPodGroup(logger, apg)
+	gpg := fwk.NewGenericPodGroup(pg)
+	sched.Cache.RemoveGenericPodGroup(logger, gpg)
+	sched.SchedulingQueue.DeleteGenericPodGroup(logger, gpg)
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, pg, nil, nil)
 }
 
@@ -547,9 +547,9 @@ func (sched *Scheduler) addCompositePodGroup(obj any) {
 	}
 
 	logger.V(3).Info("Add event for composite pod group", "compositePodGroup", klog.KObj(cpg))
-	apg := framework.NewGenericCompositePodGroup(cpg)
-	sched.Cache.AddGenericPodGroup(apg)
-	sched.SchedulingQueue.AddGenericPodGroup(logger, apg)
+	gpg := fwk.NewGenericCompositePodGroup(cpg)
+	sched.Cache.AddGenericPodGroup(gpg)
+	sched.SchedulingQueue.AddGenericPodGroup(logger, gpg)
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, nil, cpg, nil)
 }
 
@@ -573,9 +573,9 @@ func (sched *Scheduler) updateCompositePodGroup(oldObj, newObj any) {
 	}
 
 	logger.V(4).Info("Update event for composite pod group", "compositePodGroup", klog.KObj(newCPG))
-	apg := framework.NewGenericCompositePodGroup(newCPG)
-	sched.Cache.UpdateGenericPodGroup(logger, apg)
-	sched.SchedulingQueue.UpdateGenericPodGroup(logger, apg)
+	gpg := fwk.NewGenericCompositePodGroup(newCPG)
+	sched.Cache.UpdateGenericPodGroup(logger, gpg)
+	sched.SchedulingQueue.UpdateGenericPodGroup(logger, gpg)
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, oldCPG, newCPG, nil)
 }
 
@@ -601,9 +601,9 @@ func (sched *Scheduler) deleteCompositePodGroup(obj any) {
 	}
 
 	logger.V(3).Info("Delete event for composite pod group", "compositePodGroup", klog.KObj(cpg))
-	apg := framework.NewGenericCompositePodGroup(cpg)
-	sched.Cache.RemoveGenericPodGroup(logger, apg)
-	sched.SchedulingQueue.DeleteGenericPodGroup(logger, apg)
+	gpg := fwk.NewGenericCompositePodGroup(cpg)
+	sched.Cache.RemoveGenericPodGroup(logger, gpg)
+	sched.SchedulingQueue.DeleteGenericPodGroup(logger, gpg)
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, cpg, nil, nil)
 }
 

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -1580,7 +1580,7 @@ func TestUpdatePodGroup(t *testing.T) {
 				logger:          logger,
 			}
 
-			sched.Cache.AddGenericPodGroup(framework.NewGenericPodGroup(tt.oldPodGroup))
+			sched.Cache.AddGenericPodGroup(fwk.NewGenericPodGroup(tt.oldPodGroup))
 
 			sched.updatePodGroup(tt.oldPodGroup, tt.newPodGroup)
 
@@ -1628,7 +1628,7 @@ func TestDeletePodGroup(t *testing.T) {
 			}
 
 			if tt.initPodGroup != nil {
-				sched.Cache.AddGenericPodGroup(framework.NewGenericPodGroup(tt.initPodGroup))
+				sched.Cache.AddGenericPodGroup(fwk.NewGenericPodGroup(tt.initPodGroup))
 			}
 
 			sched.deletePodGroup(tt.podGroupToDelete)
@@ -1726,9 +1726,9 @@ func TestAddCompositePodGroup(t *testing.T) {
 
 			if tt.triggerQueueingHint {
 				cpgObj := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg1").Obj()
-				queue.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(cpgObj))
+				queue.AddGenericPodGroup(logger, fwk.NewGenericCompositePodGroup(cpgObj))
 				pg := st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("cpg1").Obj()
-				queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
+				queue.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(pg))
 
 				queue.Add(ctx, pod)
 				poppedEntity, _ := queue.Pop(logger)
@@ -1882,14 +1882,14 @@ func TestUpdateCompositePodGroup(t *testing.T) {
 			}
 
 			if tt.cpgEnabled {
-				sched.Cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(oldCPG))
+				sched.Cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(oldCPG))
 			}
 
 			if tt.triggerQueueingHint {
 				cpgObj := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg1").Obj()
-				queue.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(cpgObj))
+				queue.AddGenericPodGroup(logger, fwk.NewGenericCompositePodGroup(cpgObj))
 				pg := st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("cpg1").Obj()
-				queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
+				queue.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(pg))
 
 				queue.Add(ctx, pod)
 				poppedEntity, _ := queue.Pop(logger)
@@ -2021,9 +2021,9 @@ func TestDeleteCompositePodGroup(t *testing.T) {
 
 			if tt.triggerQueueingHint {
 				cpgObj := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg1").Obj()
-				queue.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(cpgObj))
+				queue.AddGenericPodGroup(logger, fwk.NewGenericCompositePodGroup(cpgObj))
 				pg := st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("cpg1").Obj()
-				queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
+				queue.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(pg))
 
 				queue.Add(ctx, pod)
 				poppedEntity, _ := queue.Pop(logger)
@@ -2036,7 +2036,7 @@ func TestDeleteCompositePodGroup(t *testing.T) {
 			}
 
 			if tt.initCPG != nil && tt.cpgEnabled {
-				sched.Cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(tt.initCPG))
+				sched.Cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(tt.initCPG))
 			}
 
 			sched.deleteCompositePodGroup(tt.cpgToDelete)

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -612,7 +612,7 @@ func TestPostFilter(t *testing.T) {
 
 				cache := internalcache.New(ctx, apiDispatcher, tt.features.EnableGenericWorkload, false)
 				for _, podGroup := range tt.podGroups {
-					cache.AddGenericPodGroup(framework.NewGenericPodGroup(podGroup))
+					cache.AddGenericPodGroup(fwk.NewGenericPodGroup(podGroup))
 				}
 				snapshot := internalcache.NewTestSnapshotWithPodGroups(tt.pods, tt.nodes, tt.podGroups)
 
@@ -2028,10 +2028,10 @@ func TestCustomSelection(t *testing.T) {
 			informerFactory.WaitForCacheSync(ctx.Done())
 			cache := internalcache.New(ctx, nil, tt.features.EnableGenericWorkload, tt.features.EnableCompositePodGroup)
 			for _, pg := range tt.podGroups {
-				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
+				cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.compositePodGroups {
-				cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+				cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 			}
 			snapshot := internalcache.NewTestSnapshotWithCompositePodGroups(tt.pods, nodes, tt.podGroups, tt.compositePodGroups)
 			fwk, err := tf.NewFramework(
@@ -2351,10 +2351,10 @@ func TestCustomOrdering(t *testing.T) {
 
 			cache := internalcache.New(ctx, nil, tt.features.EnableGenericWorkload, tt.features.EnableCompositePodGroup)
 			for _, pg := range tt.podGroups {
-				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
+				cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.compositePodGroups {
-				cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+				cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 			}
 
 			fwk, err := tf.NewFramework(
@@ -2581,10 +2581,10 @@ func TestPodEligibleToPreemptOthers(t *testing.T) {
 			}
 			cache := internalcache.New(ctx, nil, test.features.EnableGenericWorkload, test.features.EnableCompositePodGroup)
 			for _, pg := range test.podGroups {
-				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
+				cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range test.compositePodGroups {
-				cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+				cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 			}
 			snapshot := internalcache.NewTestSnapshotWithCompositePodGroups(test.pods, nodes, test.podGroups, test.compositePodGroups)
 			f, err := tf.NewFramework(ctx, registeredPlugins, "",
@@ -3447,7 +3447,7 @@ func TestSelectVictimsOnNode(t *testing.T) {
 
 			cache := internalcache.New(ctx, nil, tt.features.EnableGenericWorkload, false /* CompositePodGroup */)
 			for _, pg := range tt.podGroups {
-				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
+				cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 			snapshot := internalcache.NewTestSnapshotWithPodGroups(tt.initPods, nodes, tt.podGroups)
 
@@ -3753,10 +3753,10 @@ func TestPreEnqueue(t *testing.T) {
 
 			cache := internalcache.New(ctx, nil, tt.features.EnableGenericWorkload, tt.features.EnableCompositePodGroup)
 			for _, podGroup := range allPgs {
-				cache.AddGenericPodGroup(framework.NewGenericPodGroup(podGroup))
+				cache.AddGenericPodGroup(fwk.NewGenericPodGroup(podGroup))
 			}
 			for _, cpg := range allCpgs {
-				cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+				cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 			}
 
 			snapshot := internalcache.NewTestSnapshotWithCompositePodGroups(pods, []*v1.Node{st.MakeNode().Name("node1").Capacity(onePodRes).Obj()}, allPgs, allCpgs)
@@ -3894,10 +3894,10 @@ func TestDefaultPreemption_PodGroupPostFilter_ErrorWrapping(t *testing.T) {
 
 			cache := internalcache.New(ctx, nil, true, tt.enableCompositePodGroup)
 			for _, pg := range pgs {
-				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
+				cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range cpgs {
-				cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+				cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 			}
 
 			snapshot := internalcache.NewTestSnapshotWithCompositePodGroups(testPods, nodes, pgs, cpgs)
@@ -4007,7 +4007,7 @@ func TestDefaultPreemption_PodGroupPostFilter_InvalidSnapshot(t *testing.T) {
 				pg = st.MakePodGroup().Name("preemptor-pg-ok").Priority(highPriority).Obj()
 				client = clientsetfake.NewClientset(pod, pg)
 				cache = internalcache.New(ctx, nil, true, false)
-				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
+				cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
 				snapshot = internalcache.NewTestSnapshotWithPodGroups(testPods, nodes, []*v1beta1.PodGroup{pg})
 			} else {
 				priorityVal := highPriority
@@ -4061,12 +4061,12 @@ func TestDefaultPreemption_PodGroupPostFilter_InvalidSnapshot(t *testing.T) {
 			var pgInfo *framework.PodGroupInfo
 			if !tt.isCPG {
 				pgInfo = &framework.PodGroupInfo{
-					GenericPodGroup: framework.NewGenericPodGroup(pg),
+					GenericPodGroup: fwk.NewGenericPodGroup(pg),
 					UnscheduledPods: preemptorPods,
 				}
 			} else {
 				pgInfo = &framework.PodGroupInfo{
-					GenericPodGroup: framework.NewGenericCompositePodGroup(cpg),
+					GenericPodGroup: fwk.NewGenericCompositePodGroup(cpg),
 					UnscheduledPods: preemptorPods,
 				}
 			}
@@ -4096,7 +4096,7 @@ func TestDefaultPreemption_PodGroupPostFilter_CompositePodGroup(t *testing.T) {
 	}
 
 	cache := internalcache.New(ctx, nil, true, true /* compositePodGroupEnabled */)
-	cache.AddGenericPodGroup(framework.NewGenericPodGroup(pgOk))
+	cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pgOk))
 
 	snapshot := internalcache.NewEmptySnapshot()
 	f, err := tf.NewFramework(ctx, registeredPlugins, "",
@@ -4133,7 +4133,7 @@ func TestDefaultPreemption_PodGroupPostFilter_CompositePodGroup(t *testing.T) {
 		},
 	}
 	pgInfo := &framework.PodGroupInfo{
-		GenericPodGroup: framework.NewGenericCompositePodGroup(cpg),
+		GenericPodGroup: fwk.NewGenericCompositePodGroup(cpg),
 		UnscheduledPods: preemptorPods,
 	}
 
@@ -4218,7 +4218,7 @@ func TestDefaultPreemption_PodGroupPostFilter_WorkloadPreemptionAttempts(t *test
 			expectedStatus := tt.status.Code().String()
 			stateBefore := captureWorkloadPreemptionAttempts(testRegistry, expectedStatus)
 
-			pgInfo := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericPodGroup(st.MakePodGroup().Obj())}
+			pgInfo := &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericPodGroup(st.MakePodGroup().Obj())}
 			pl.PodGroupPostFilter(ctx, nil, pgInfo, nil)
 
 			stateAfter := captureWorkloadPreemptionAttempts(testRegistry, expectedStatus)
@@ -4253,7 +4253,7 @@ func getCounterFromGatherer(g componentmetrics.Gatherer, name string, resultLabe
 
 func newPGInfo(pg *v1beta1.PodGroup, pods ...*v1.Pod) *framework.PodGroupInfo {
 	return &framework.PodGroupInfo{
-		GenericPodGroup: framework.NewGenericPodGroup(pg),
+		GenericPodGroup: fwk.NewGenericPodGroup(pg),
 		UnscheduledPods: pods,
 	}
 }
@@ -4261,7 +4261,7 @@ func newPGInfo(pg *v1beta1.PodGroup, pods ...*v1.Pod) *framework.PodGroupInfo {
 // newCPGInfo creates a PodGroupInfo representing a CompositePodGroup hierarchy.
 func newCPGInfo(cpg *v1alpha3.CompositePodGroup, children []*framework.PodGroupInfo, pods ...*v1.Pod) *framework.PodGroupInfo {
 	return &framework.PodGroupInfo{
-		GenericPodGroup: framework.NewGenericCompositePodGroup(cpg),
+		GenericPodGroup: fwk.NewGenericCompositePodGroup(cpg),
 		UnscheduledPods: pods,
 		Children:        children,
 	}

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -4302,7 +4302,7 @@ func testPlugin(tCtx ktesting.TContext) {
 				initialObjects = testCtx.updateAPIServer(tCtx, initialObjects, tc.prepare.postfilter)
 				if len(tc.podGroups) > 0 {
 					pgInfo := &framework.PodGroupInfo{
-						GenericPodGroup: framework.NewGenericPodGroup(tc.podGroups[0]),
+						GenericPodGroup: fwk.NewGenericPodGroup(tc.podGroups[0]),
 						UnscheduledPods: []*v1.Pod{tc.pod},
 					}
 					mockSchedulingFunc := func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
@@ -4642,7 +4642,7 @@ func setup(tCtx ktesting.TContext, args *config.DynamicResourcesArgs, nodes []*v
 		}
 	}
 	for _, podGroup := range podGroups {
-		tc.podGroupManager.AddGenericPodGroup(framework.NewGenericPodGroup(podGroup))
+		tc.podGroupManager.AddGenericPodGroup(fwk.NewGenericPodGroup(podGroup))
 	}
 	snapshot := internalcache.NewTestSnapshotWithPodGroups(nil, nil, podGroups)
 
@@ -6169,7 +6169,7 @@ func TestPodGroupPostFilter(t *testing.T) {
 			}
 
 			pgInfo := &framework.PodGroupInfo{
-				GenericPodGroup: framework.NewGenericPodGroup(tc.podGroups[0]),
+				GenericPodGroup: fwk.NewGenericPodGroup(tc.podGroups[0]),
 				UnscheduledPods: tc.unscheduledPods,
 			}
 

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -837,7 +837,7 @@ func TestPreEnqueue(t *testing.T) {
 					if err != nil {
 						t.Fatalf("Failed to add podGroup %s to store: %v", pg.Name, err)
 					}
-					cache.AddGenericPodGroup(schedulerframework.NewGenericPodGroup(pg))
+					cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
 				}
 				if isCPGEnabled {
 					for _, cpg := range tt.initialCompositePodGroups {
@@ -845,7 +845,7 @@ func TestPreEnqueue(t *testing.T) {
 						if err != nil {
 							t.Fatalf("Failed to add podGroup %s to store: %v", cpg.Name, err)
 						}
-						cache.AddGenericPodGroup(schedulerframework.NewGenericCompositePodGroup(cpg))
+						cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 					}
 				}
 
@@ -1029,7 +1029,7 @@ func TestPlacementFeasible(t *testing.T) {
 						} else {
 							cpg.Spec.SchedulingPolicy.Basic = &schedulingv1alpha3.CompositeBasicSchedulingPolicy{}
 						}
-						pgInfo.GenericPodGroup = schedulerframework.NewGenericCompositePodGroup(cpg)
+						pgInfo.GenericPodGroup = fwk.NewGenericCompositePodGroup(cpg)
 						objs = append(objs, cpg)
 					} else {
 						pg := st.MakePodGroup().Namespace(namespace).Name(pgName).ParentCompositePodGroup("cpg-root").Obj()
@@ -1038,7 +1038,7 @@ func TestPlacementFeasible(t *testing.T) {
 						} else {
 							pg.Spec.SchedulingPolicy.Basic = &schedulingv1beta1.BasicSchedulingPolicy{}
 						}
-						pgInfo.GenericPodGroup = schedulerframework.NewGenericPodGroup(pg)
+						pgInfo.GenericPodGroup = fwk.NewGenericPodGroup(pg)
 						objs = append(objs, pg)
 					}
 

--- a/pkg/scheduler/framework/plugins/noderesources/fit_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit_test.go
@@ -2718,7 +2718,7 @@ func TestScorePlacement_Resources(t *testing.T) {
 				}
 			}
 			podGroupInfo := &framework.PodGroupInfo{
-				GenericPodGroup: framework.NewGenericPodGroup(&schedulingv1beta1.PodGroup{}),
+				GenericPodGroup: fwk.NewGenericPodGroup(&schedulingv1beta1.PodGroup{}),
 				UnscheduledPods: tc.podGroupPods,
 			}
 			podGroupAssignments := &fwk.PodGroupAssignments{

--- a/pkg/scheduler/framework/plugins/podgrouppodscount/podgroup_pods_count_test.go
+++ b/pkg/scheduler/framework/plugins/podgrouppodscount/podgroup_pods_count_test.go
@@ -382,7 +382,7 @@ func TestNormalizePlacementScore(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			pl := &PodGroupPodsCount{}
 			pgInfo := &framework.PodGroupInfo{
-				GenericPodGroup: framework.NewGenericPodGroup(&schedulingapi.PodGroup{
+				GenericPodGroup: fwk.NewGenericPodGroup(&schedulingapi.PodGroup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pg1",
 					},
@@ -412,13 +412,13 @@ func TestNormalizePlacementScore(t *testing.T) {
 
 func makePodGroupInfoFromPG(pg *schedulingapi.PodGroup) fwk.PodGroupInfo {
 	return &framework.PodGroupInfo{
-		GenericPodGroup: framework.NewGenericPodGroup(pg),
+		GenericPodGroup: fwk.NewGenericPodGroup(pg),
 	}
 }
 
 func makePodGroupInfoFromCPG(cpg *schedulingv1alpha3.CompositePodGroup) fwk.PodGroupInfo {
 	return &framework.PodGroupInfo{
-		GenericPodGroup: framework.NewGenericCompositePodGroup(cpg),
+		GenericPodGroup: fwk.NewGenericCompositePodGroup(cpg),
 	}
 }
 

--- a/pkg/scheduler/framework/plugins/topologyaware/topology_placement_test.go
+++ b/pkg/scheduler/framework/plugins/topologyaware/topology_placement_test.go
@@ -476,13 +476,13 @@ func TestGeneratePlacements(t *testing.T) {
 
 func makePodGroupInfoFromPG(pg *schedulingapi.PodGroup) fwk.PodGroupInfo {
 	return &framework.PodGroupInfo{
-		GenericPodGroup: framework.NewGenericPodGroup(pg),
+		GenericPodGroup: fwk.NewGenericPodGroup(pg),
 	}
 }
 
 func makePodGroupInfoFromCPG(cpg *schedulingv1alphav3.CompositePodGroup) fwk.PodGroupInfo {
 	return &framework.PodGroupInfo{
-		GenericPodGroup: framework.NewGenericCompositePodGroup(cpg),
+		GenericPodGroup: fwk.NewGenericCompositePodGroup(cpg),
 	}
 }
 

--- a/pkg/scheduler/framework/preemption/executor.go
+++ b/pkg/scheduler/framework/preemption/executor.go
@@ -36,11 +36,12 @@ import (
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kube-scheduler/util"
 	apipod "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
-	"k8s.io/kubernetes/pkg/scheduler/util"
+	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
 )
 
 type pendingVictim struct {
@@ -133,7 +134,7 @@ func NewExecutor(fh fwk.Handle, fts feature.Features) *Executor {
 			newStatus := victim.Status.DeepCopy()
 			updated := apipod.UpdatePodCondition(newStatus, condition)
 			if updated {
-				if err := util.PatchPodStatus(ctx, fh.ClientSet(), victim.Name, victim.Namespace, &victim.Status, newStatus); err != nil {
+				if err := schedutil.PatchPodStatus(ctx, fh.ClientSet(), victim.Name, victim.Namespace, &victim.Status, newStatus); err != nil {
 					if !apierrors.IsNotFound(err) {
 						logger.Error(err, "Could not add DisruptionTarget condition due to preemption", "preemptor", klog.KObj(preemptor), "victim", klog.KObj(victim))
 						return false, err
@@ -142,7 +143,7 @@ func NewExecutor(fh fwk.Handle, fts feature.Features) *Executor {
 					return false, nil
 				}
 			}
-			if err := util.DeletePod(ctx, fh.ClientSet(), victim); err != nil {
+			if err := schedutil.DeletePod(ctx, fh.ClientSet(), victim); err != nil {
 				if !apierrors.IsNotFound(err) {
 					logger.Error(err, "Tried to preempted pod", "pod", klog.KObj(victim), "preemptor", klog.KObj(preemptor))
 					return false, err
@@ -432,7 +433,7 @@ func clearNominatedNodeName(ctx context.Context, cs clientset.Interface, apiCach
 			}
 			podStatusCopy := p.Status.DeepCopy()
 			podStatusCopy.NominatedNodeName = ""
-			if err := util.PatchPodStatus(ctx, cs, p.Name, p.Namespace, &p.Status, podStatusCopy); err != nil {
+			if err := schedutil.PatchPodStatus(ctx, cs, p.Name, p.Namespace, &p.Status, podStatusCopy); err != nil {
 				errs = append(errs, err)
 			}
 		}

--- a/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
@@ -39,6 +39,7 @@ import (
 	componentmetrics "k8s.io/component-base/metrics"
 	"k8s.io/klog/v2/ktesting"
 	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kube-scheduler/util"
 	"k8s.io/kubernetes/pkg/features"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	internalqueue "k8s.io/kubernetes/pkg/scheduler/backend/queue"
@@ -50,7 +51,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	tf "k8s.io/kubernetes/pkg/scheduler/testing/framework"
-	"k8s.io/kubernetes/pkg/scheduler/util"
 )
 
 type mockFilterPlugin struct {

--- a/pkg/scheduler/framework/preemption/preemption_test.go
+++ b/pkg/scheduler/framework/preemption/preemption_test.go
@@ -983,10 +983,10 @@ func TestGetVictimsOnNode(t *testing.T) {
 
 			cache := internalcache.New(ctx, nil, tt.enableGenericWorkload, tt.enableCompositePodGroup)
 			for _, pg := range tt.podGroups {
-				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
+				cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.compositePodGroups {
-				cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+				cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 			}
 			snapshot := internalcache.NewTestSnapshotWithCompositePodGroups(tt.pods, tt.nodes, tt.podGroups, tt.compositePodGroups)
 

--- a/pkg/scheduler/framework/preemption/types.go
+++ b/pkg/scheduler/framework/preemption/types.go
@@ -28,9 +28,10 @@ import (
 	"k8s.io/klog/v2"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kube-scheduler/util"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper"
-	"k8s.io/kubernetes/pkg/scheduler/util"
+	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
 )
 
 type podGroupPreemptor struct {
@@ -427,7 +428,7 @@ func NewVictim(pods []fwk.PodInfo, priority int32, keyType fwk.EntityKeyType) (V
 
 	var earliest *metav1.Time
 	for _, pInfo := range pods {
-		t := util.GetPodStartTime(pInfo.GetPod())
+		t := schedutil.GetPodStartTime(pInfo.GetPod())
 		if earliest == nil || (t != nil && t.Before(earliest)) {
 			earliest = t
 		}

--- a/pkg/scheduler/framework/preemption/types_test.go
+++ b/pkg/scheduler/framework/preemption/types_test.go
@@ -894,11 +894,11 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 			}
 
 			for _, pg := range pgs {
-				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
+				cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
 			}
 			if tt.enableCompositePodGroup {
 				for _, cpg := range cpgs {
-					cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+					cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 				}
 			}
 
@@ -1156,18 +1156,18 @@ func TestNewDomainVictim(t *testing.T) {
 func newTestPodGroupInfo(pg *schedulingv1beta1.PodGroup, cpg *schedulingv1alpha3.CompositePodGroup, pods []*v1.Pod) *framework.PodGroupInfo {
 	if cpg != nil {
 		return &framework.PodGroupInfo{
-			GenericPodGroup: framework.NewGenericCompositePodGroup(cpg),
+			GenericPodGroup: fwk.NewGenericCompositePodGroup(cpg),
 			UnscheduledPods: pods,
 			Children: []*framework.PodGroupInfo{
 				{
-					GenericPodGroup: framework.NewGenericPodGroup(&schedulingv1beta1.PodGroup{}),
+					GenericPodGroup: fwk.NewGenericPodGroup(&schedulingv1beta1.PodGroup{}),
 					UnscheduledPods: pods,
 				},
 			},
 		}
 	}
 	return &framework.PodGroupInfo{
-		GenericPodGroup: framework.NewGenericPodGroup(pg),
+		GenericPodGroup: fwk.NewGenericPodGroup(pg),
 		UnscheduledPods: pods,
 	}
 }

--- a/pkg/scheduler/framework/preemption/util.go
+++ b/pkg/scheduler/framework/preemption/util.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	fwk "k8s.io/kube-scheduler/framework"
-	"k8s.io/kubernetes/pkg/scheduler/util"
+	"k8s.io/kube-scheduler/util"
 )
 
 // PodTerminatingByPreemption returns true if the pod is in the termination state caused by scheduler preemption.

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -5768,7 +5768,7 @@ scheduler_plugin_evaluation_total{extension_point="Score",plugin="plugin-eval-sc
 func newQueuedPodGroupInfoForTest(ns, name string) *framework.QueuedPodGroupInfo {
 	return &framework.QueuedPodGroupInfo{
 		PodGroupInfo: &framework.PodGroupInfo{
-			GenericPodGroup: framework.NewGenericPodGroup(&schedulingv1beta1.PodGroup{
+			GenericPodGroup: fwk.NewGenericPodGroup(&schedulingv1beta1.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: ns,
 					Name:      name,

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -27,8 +27,6 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -1021,7 +1019,7 @@ func (pgqi *QueuedPodGroupInfo) AddSubtree(subtree *PodGroupInfo) {
 }
 
 // UpdateGenericPodGroup updates a generic pod group in the queued pod group info hierarchy.
-func (pgqi *QueuedPodGroupInfo) UpdateGenericPodGroup(gpg *GenericPodGroup) {
+func (pgqi *QueuedPodGroupInfo) UpdateGenericPodGroup(gpg *fwk.GenericPodGroup) {
 	node, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, gpg.GetName())
 	if node != nil {
 		node.GenericPodGroup = gpg
@@ -1030,7 +1028,7 @@ func (pgqi *QueuedPodGroupInfo) UpdateGenericPodGroup(gpg *GenericPodGroup) {
 
 // RemoveGenericPodGroup removes a generic pod group from the queued pod group info hierarchy.
 // It returns a slice of all pods within the hierarchy of the removed pod group / composite pod group.
-func (pgqi *QueuedPodGroupInfo) RemoveGenericPodGroup(gpg *GenericPodGroup) []*QueuedPodInfo {
+func (pgqi *QueuedPodGroupInfo) RemoveGenericPodGroup(gpg *fwk.GenericPodGroup) []*QueuedPodInfo {
 	node, parent := findNodeAndParent(pgqi.PodGroupInfo, nil, gpg.GetName())
 	if node == nil {
 		return nil
@@ -1081,107 +1079,12 @@ func (pgqi *QueuedPodGroupInfo) deleteSubtreePods(curr *PodGroupInfo) []*QueuedP
 	return removedPods
 }
 
-// GenericPodGroup is a wrapper around either a PodGroup or a CompositePodGroup API object,
-// providing a unified interface for scheduler's internal operations on PodGroup objects.
-type GenericPodGroup struct {
-	// PodGroup is a PodGroup API object.
-	PodGroup *schedulingv1beta1.PodGroup
-	// CompositePodGroup is a CompositePodGroup API object.
-	// It can be set only when CompositePodGroup feature is enabled.
-	CompositePodGroup *schedulingv1alpha3.CompositePodGroup
-}
-
-// NewGenericPodGroup returns a GenericPodGroup for a PodGroup.
-func NewGenericPodGroup(pg *schedulingv1beta1.PodGroup) *GenericPodGroup {
-	return &GenericPodGroup{PodGroup: pg}
-}
-
-// NewGenericCompositePodGroup returns a GenericPodGroup for a CompositePodGroup.
-func NewGenericCompositePodGroup(cpg *schedulingv1alpha3.CompositePodGroup) *GenericPodGroup {
-	return &GenericPodGroup{CompositePodGroup: cpg}
-}
-
-func (gpg *GenericPodGroup) GetPodGroup() *schedulingv1beta1.PodGroup {
-	return gpg.PodGroup
-}
-
-func (gpg *GenericPodGroup) GetCompositePodGroup() *schedulingv1alpha3.CompositePodGroup {
-	return gpg.CompositePodGroup
-}
-
-func (gpg *GenericPodGroup) GetName() string {
-	if gpg.PodGroup != nil {
-		return gpg.PodGroup.Name
-	}
-	return gpg.CompositePodGroup.Name
-}
-
-func (gpg *GenericPodGroup) GetNamespace() string {
-	if gpg.PodGroup != nil {
-		return gpg.PodGroup.Namespace
-	}
-	return gpg.CompositePodGroup.Namespace
-}
-
-func (gpg *GenericPodGroup) GetType() fwk.EntityKeyType {
-	if gpg.PodGroup != nil {
-		return fwk.PodGroupKeyType
-	}
-	return fwk.CompositePodGroupKeyType
-}
-
-func (gpg *GenericPodGroup) GetKey() fwk.EntityKey {
-	if gpg.PodGroup != nil {
-		return fwk.PodGroupKey(gpg.PodGroup.Namespace, gpg.PodGroup.Name)
-	}
-	return fwk.CompositePodGroupKey(gpg.CompositePodGroup.Namespace, gpg.CompositePodGroup.Name)
-}
-
-// GetParentCompositePodGroupName returns the parent composite pod group name of the GenericPodGroup.
-// This should be used only when the feature feature gate CompositePodGroup is enabled.
-func (gpg *GenericPodGroup) GetParentCompositePodGroupName() *string {
-	if gpg.PodGroup != nil {
-		return gpg.PodGroup.Spec.ParentCompositePodGroupName
-	}
-	return gpg.CompositePodGroup.Spec.ParentCompositePodGroupName
-}
-
-// HasParent returns true if the GenericPodGroup has a parent.
-// This should be used only when the feature feature gate CompositePodGroup is enabled.
-func (gpg *GenericPodGroup) HasParent() bool {
-	return gpg.GetParentCompositePodGroupName() != nil
-}
-
-// GetParentKey returns the parent key of the GenericPodGroup.
-// This should be used only when the feature CompositePodGroup feature gate is enabled.
-func (gpg *GenericPodGroup) GetParentKey() (fwk.EntityKey, bool) {
-	parentName := gpg.GetParentCompositePodGroupName()
-	if parentName == nil {
-		return fwk.EntityKey{}, false
-	}
-	return fwk.CompositePodGroupKey(gpg.GetNamespace(), *parentName), true
-}
-
-func (gpg *GenericPodGroup) GetPriority() int32 {
-	if gpg.PodGroup != nil {
-		return schedutil.PodGroupPriority(gpg.PodGroup)
-	}
-	return schedutil.CompositePodGroupPriority(gpg.CompositePodGroup)
-}
-
-func (gpg *GenericPodGroup) GetCreationTimestamp() time.Time {
-	if gpg.PodGroup != nil {
-		return gpg.PodGroup.CreationTimestamp.Time
-	}
-	return gpg.CompositePodGroup.CreationTimestamp.Time
-}
-
 // PodGroupInfo enriches GenericPodGroup with information about pod group hierarchy.
 // For PodGroups, it contains a list of unscheduled pods.
 // For CompositePodGroups, it contains a list of children.
 // This type is typically used as an input to pod group scheduling cycle plugins.
 type PodGroupInfo struct {
-	*GenericPodGroup
+	*fwk.GenericPodGroup
 	// UnscheduledPods are pods that are currently being considered for scheduling.
 	// It can be useful to also retrieve the scheduled (assumed or assigned) pods.
 	// PodGroupManager.PodGroupState can be used for that.

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -328,7 +328,7 @@ func TestQueuedPodGroupInfoOrdering(t *testing.T) {
 			pg := st.MakePodGroup().Namespace("default").Name("pg1").Obj()
 			pgqi := &QueuedPodGroupInfo{
 				PodGroupInfo: &PodGroupInfo{
-					GenericPodGroup: NewGenericPodGroup(pg),
+					GenericPodGroup: fwk.NewGenericPodGroup(pg),
 				},
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			}
@@ -3577,7 +3577,7 @@ func TestPodGroupInfoGetChildrenSorting(t *testing.T) {
 	now := time.Now()
 	pgInfo := func(name, namespace string, creationTime time.Time) *PodGroupInfo {
 		return &PodGroupInfo{
-			GenericPodGroup: NewGenericPodGroup(&schedulingv1beta1.PodGroup{
+			GenericPodGroup: fwk.NewGenericPodGroup(&schedulingv1beta1.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              name,
 					Namespace:         namespace,
@@ -3595,7 +3595,7 @@ func TestPodGroupInfoGetChildrenSorting(t *testing.T) {
 	pgInfo4 := pgInfo("pg4", "default", now)
 
 	pgi := &PodGroupInfo{
-		GenericPodGroup: NewGenericCompositePodGroup(&schedulingv1alpha3.CompositePodGroup{
+		GenericPodGroup: fwk.NewGenericCompositePodGroup(&schedulingv1alpha3.CompositePodGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "parent-cpg",
 				Namespace: "default",
@@ -3699,7 +3699,7 @@ func TestQueuedPodGroupInfo_AddCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			qpgi := &QueuedPodGroupInfo{
 				PodGroupInfo: &PodGroupInfo{
-					GenericPodGroup: NewGenericCompositePodGroup(tt.initialCPG),
+					GenericPodGroup: fwk.NewGenericCompositePodGroup(tt.initialCPG),
 					Children:        make([]*PodGroupInfo, 0),
 				},
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
@@ -3761,13 +3761,13 @@ func TestQueuedPodGroupInfo_UpdateCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			qpgi := &QueuedPodGroupInfo{
 				PodGroupInfo: &PodGroupInfo{
-					GenericPodGroup: NewGenericCompositePodGroup(tt.initialCPG),
+					GenericPodGroup: fwk.NewGenericCompositePodGroup(tt.initialCPG),
 					Children:        make([]*PodGroupInfo, 0),
 				},
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			}
 			tt.setup(qpgi)
-			qpgi.UpdateGenericPodGroup(NewGenericCompositePodGroup(tt.updateCPG))
+			qpgi.UpdateGenericPodGroup(fwk.NewGenericCompositePodGroup(tt.updateCPG))
 			tt.verify(t, qpgi)
 		})
 	}
@@ -3871,13 +3871,13 @@ func TestQueuedPodGroupInfo_RemoveCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			qpgi := &QueuedPodGroupInfo{
 				PodGroupInfo: &PodGroupInfo{
-					GenericPodGroup: NewGenericCompositePodGroup(cpgRoot),
+					GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgRoot),
 					Children:        make([]*PodGroupInfo, 0),
 				},
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			}
 			tt.setup(qpgi)
-			removed := qpgi.RemoveGenericPodGroup(NewGenericCompositePodGroup(tt.removeCPG))
+			removed := qpgi.RemoveGenericPodGroup(fwk.NewGenericCompositePodGroup(tt.removeCPG))
 			tt.verify(t, qpgi, removed)
 		})
 	}
@@ -3938,7 +3938,7 @@ func TestQueuedPodGroupInfo_AddPodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			qpgi := &QueuedPodGroupInfo{
 				PodGroupInfo: &PodGroupInfo{
-					GenericPodGroup: NewGenericCompositePodGroup(tt.initialCPG),
+					GenericPodGroup: fwk.NewGenericCompositePodGroup(tt.initialCPG),
 					Children:        make([]*PodGroupInfo, 0),
 				},
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
@@ -4019,7 +4019,7 @@ func TestQueuedPodGroupInfo_UpdatePodGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			qpgi := tt.setup()
-			qpgi.UpdateGenericPodGroup(NewGenericPodGroup(tt.updatePG))
+			qpgi.UpdateGenericPodGroup(fwk.NewGenericPodGroup(tt.updatePG))
 			tt.verify(t, qpgi)
 		})
 	}
@@ -4094,7 +4094,7 @@ func TestQueuedPodGroupInfo_RemovePodGroup(t *testing.T) {
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			}
 			tt.setup(qpgi)
-			removed := qpgi.RemoveGenericPodGroup(NewGenericPodGroup(tt.removePG))
+			removed := qpgi.RemoveGenericPodGroup(fwk.NewGenericPodGroup(tt.removePG))
 			tt.verify(t, qpgi, removed)
 		})
 	}
@@ -4313,7 +4313,7 @@ func TestPodGroupInfo_GetUnscheduledPods(t *testing.T) {
 		{
 			name: "Standalone PodGroupInfo with unscheduled pods",
 			pgi: &PodGroupInfo{
-				GenericPodGroup: NewGenericPodGroup(pgStandalone),
+				GenericPodGroup: fwk.NewGenericPodGroup(pgStandalone),
 				UnscheduledPods: []*v1.Pod{pod1, pod2},
 			},
 			expected: []*v1.Pod{pod1, pod2},
@@ -4321,14 +4321,14 @@ func TestPodGroupInfo_GetUnscheduledPods(t *testing.T) {
 		{
 			name: "PodGroupInfo with children",
 			pgi: &PodGroupInfo{
-				GenericPodGroup: NewGenericCompositePodGroup(cpgParent),
+				GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgParent),
 				Children: []*PodGroupInfo{
 					{
-						GenericPodGroup: NewGenericPodGroup(pgChild1),
+						GenericPodGroup: fwk.NewGenericPodGroup(pgChild1),
 						UnscheduledPods: []*v1.Pod{pod1},
 					},
 					{
-						GenericPodGroup: NewGenericPodGroup(pgChild2),
+						GenericPodGroup: fwk.NewGenericPodGroup(pgChild2),
 						UnscheduledPods: []*v1.Pod{pod2, pod3},
 					},
 				},
@@ -4338,23 +4338,23 @@ func TestPodGroupInfo_GetUnscheduledPods(t *testing.T) {
 		{
 			name: "Multi-level PodGroupInfo with children",
 			pgi: &PodGroupInfo{
-				GenericPodGroup: NewGenericCompositePodGroup(cpgRoot),
+				GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgRoot),
 				Children: []*PodGroupInfo{
 					{
-						GenericPodGroup: NewGenericCompositePodGroup(cpgSub),
+						GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgSub),
 						Children: []*PodGroupInfo{
 							{
-								GenericPodGroup: NewGenericPodGroup(pgChild1),
+								GenericPodGroup: fwk.NewGenericPodGroup(pgChild1),
 								UnscheduledPods: []*v1.Pod{pod1},
 							},
 							{
-								GenericPodGroup: NewGenericPodGroup(pgChild2),
+								GenericPodGroup: fwk.NewGenericPodGroup(pgChild2),
 								UnscheduledPods: []*v1.Pod{pod2, pod3},
 							},
 						},
 					},
 					{
-						GenericPodGroup: NewGenericPodGroup(pgChild3),
+						GenericPodGroup: fwk.NewGenericPodGroup(pgChild3),
 						UnscheduledPods: []*v1.Pod{pod4},
 					},
 				},
@@ -4375,14 +4375,14 @@ func TestPodGroupInfo_GetUnscheduledPods(t *testing.T) {
 
 func newPodGroupInfoForTest(pg *schedulingv1beta1.PodGroup, children ...*PodGroupInfo) *PodGroupInfo {
 	return &PodGroupInfo{
-		GenericPodGroup: NewGenericPodGroup(pg),
+		GenericPodGroup: fwk.NewGenericPodGroup(pg),
 		Children:        children,
 	}
 }
 
 func newCompositePodGroupInfoForTest(cpg *schedulingv1alpha3.CompositePodGroup, children ...*PodGroupInfo) *PodGroupInfo {
 	return &PodGroupInfo{
-		GenericPodGroup: NewGenericCompositePodGroup(cpg),
+		GenericPodGroup: fwk.NewGenericCompositePodGroup(cpg),
 		Children:        children,
 	}
 }

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -117,7 +117,7 @@ func (sched *Scheduler) reconcilePodGroupWithSnapshot(pgi *framework.PodGroupInf
 				return err
 			}
 		}
-		pgi.GenericPodGroup = framework.NewGenericCompositePodGroup(compositePodGroup)
+		pgi.GenericPodGroup = fwk.NewGenericCompositePodGroup(compositePodGroup)
 	} else {
 		podGroup, err := sched.nodeInfoSnapshot.PodGroups().Get(pgi.GetNamespace(), pgi.GetName())
 		if err != nil {
@@ -129,7 +129,7 @@ func (sched *Scheduler) reconcilePodGroupWithSnapshot(pgi *framework.PodGroupInf
 				ptr.Deref(podGroup.Spec.ParentCompositePodGroupName, "[unset]"),
 				ptr.Deref(pgi.PodGroup.Spec.ParentCompositePodGroupName, "[unset]"))
 		}
-		pgi.GenericPodGroup = framework.NewGenericPodGroup(podGroup)
+		pgi.GenericPodGroup = fwk.NewGenericPodGroup(podGroup)
 	}
 	return nil
 }

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -580,7 +580,7 @@ func TestValidatePodGroup(t *testing.T) {
 			} else {
 				snapshot = internalcache.NewTestSnapshotWithPodGroups(tt.scheduledPods, nil, []*schedulingv1beta1.PodGroup{tt.podGroup})
 				podGroupInfo = &framework.QueuedPodGroupInfo{
-					PodGroupInfo:   &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericPodGroup(tt.podGroup)},
+					PodGroupInfo:   &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericPodGroup(tt.podGroup)},
 					QueuedPodInfos: make(map[fwk.EntityKey][]*framework.QueuedPodInfo),
 				}
 				for _, pod := range tt.pods {
@@ -632,7 +632,7 @@ func TestSkipPodGroupPodSchedule(t *testing.T) {
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2, qInfo3}},
 		PodGroupInfo: &framework.PodGroupInfo{
-			GenericPodGroup: framework.NewGenericPodGroup(testPodGroup),
+			GenericPodGroup: fwk.NewGenericPodGroup(testPodGroup),
 			UnscheduledPods: []*v1.Pod{p1, p2, p3},
 		},
 	}
@@ -735,7 +735,7 @@ func TestScheduleOnePodGroup_FinishesAttemptWhenAllPoppedPodsAreAssumed(t *testi
 			}
 
 			cache := internalcache.New(ctx, nil, true, false)
-			cache.AddGenericPodGroup(framework.NewGenericPodGroup(podGroup))
+			cache.AddGenericPodGroup(fwk.NewGenericPodGroup(podGroup))
 			cache.AddPodGroupMember(p1)
 			assumedP1 := p1.DeepCopy()
 			assumedP1.Spec.NodeName = "node1"
@@ -744,7 +744,7 @@ func TestScheduleOnePodGroup_FinishesAttemptWhenAllPoppedPodsAreAssumed(t *testi
 			}
 
 			queue := internalqueue.NewTestQueue(ctx, schedFwk.QueueSortFunc())
-			queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(podGroup))
+			queue.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(podGroup))
 			queue.Add(ctx, p1)
 			entity, err := queue.Pop(logger)
 			if err != nil {
@@ -804,7 +804,7 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
 		PodGroupInfo: &framework.PodGroupInfo{
-			GenericPodGroup: framework.NewGenericPodGroup(testPodGroup),
+			GenericPodGroup: fwk.NewGenericPodGroup(testPodGroup),
 			UnscheduledPods: []*v1.Pod{p1, p2},
 		},
 	}
@@ -886,7 +886,7 @@ func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): queuedPodInfos},
 		PodGroupInfo: &framework.PodGroupInfo{
-			GenericPodGroup: framework.NewGenericPodGroup(testPodGroup),
+			GenericPodGroup: fwk.NewGenericPodGroup(testPodGroup),
 			UnscheduledPods: []*v1.Pod{p1, p2, p3},
 		},
 	}
@@ -939,7 +939,7 @@ func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 	cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
 	logger, ctx := ktesting.NewTestContext(t)
 	cache.AddNode(logger, testNode)
-	cache.AddGenericPodGroup(framework.NewGenericPodGroup(testPodGroup))
+	cache.AddGenericPodGroup(fwk.NewGenericPodGroup(testPodGroup))
 
 	handledPods := make(map[string]*fwk.Status)
 	var lock sync.Mutex
@@ -1045,7 +1045,7 @@ func TestPodGroupCycle_PodGroupPostFilter(t *testing.T) {
 			podGroupInfo := &framework.QueuedPodGroupInfo{
 				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
 				PodGroupInfo: &framework.PodGroupInfo{
-					GenericPodGroup: framework.NewGenericPodGroup(testPodGroup),
+					GenericPodGroup: fwk.NewGenericPodGroup(testPodGroup),
 					UnscheduledPods: []*v1.Pod{p1, p2},
 				},
 			}
@@ -1125,7 +1125,7 @@ func TestPodGroupCycle_PodGroupPostFilter(t *testing.T) {
 			cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
 			logger, ctx := ktesting.NewTestContext(t)
 			cache.AddNode(logger, testNode)
-			cache.AddGenericPodGroup(framework.NewGenericPodGroup(testPodGroup))
+			cache.AddGenericPodGroup(fwk.NewGenericPodGroup(testPodGroup))
 
 			sched := &Scheduler{
 				Profiles:               profile.Map{"test-scheduler": schedFwk},
@@ -1170,7 +1170,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): queuedPodInfos},
 		PodGroupInfo: &framework.PodGroupInfo{
-			GenericPodGroup: framework.NewGenericPodGroup(testPodGroup),
+			GenericPodGroup: fwk.NewGenericPodGroup(testPodGroup),
 			UnscheduledPods: []*v1.Pod{p1, p2, p3},
 		},
 	}
@@ -1480,7 +1480,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 
 					cache := internalcache.New(ctx, nil, true, cpgEnabled /* CompositePodGroup */)
 					cache.AddNode(logger, testNode)
-					cache.AddGenericPodGroup(framework.NewGenericPodGroup(testPodGroup))
+					cache.AddGenericPodGroup(fwk.NewGenericPodGroup(testPodGroup))
 
 					sched := &Scheduler{
 						Cache:            cache,
@@ -1893,8 +1893,8 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 
 			cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
 			cache.AddNode(klog.FromContext(ctx), testNode)
-			apg := framework.NewGenericPodGroup(pg)
-			cache.AddGenericPodGroup(apg)
+			gpg := fwk.NewGenericPodGroup(pg)
+			cache.AddGenericPodGroup(gpg)
 
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			informerFactory.Start(ctx.Done())
@@ -1924,7 +1924,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			sched.initAlgorithm()
 
 			// Create the pod group and add the pods to queue and pop the group to set up internal queue state correctly.
-			schedulingQueue.AddGenericPodGroup(logger, apg)
+			schedulingQueue.AddGenericPodGroup(logger, gpg)
 			// Advance the clock between additions to keep pod ordering deterministic.
 			schedulingQueue.Add(ctx, p1)
 			fakeClock.Step(time.Second)
@@ -2339,8 +2339,8 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 			}
 			client := clientsetfake.NewClientset(objects...)
 			cache := internalcache.New(ctx, nil, true, true)
-			apg := framework.NewGenericPodGroup(tt.existingPodGroup)
-			cache.AddGenericPodGroup(apg)
+			gpg := fwk.NewGenericPodGroup(tt.existingPodGroup)
+			cache.AddGenericPodGroup(gpg)
 
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			informerFactory.Start(ctx.Done())
@@ -2353,7 +2353,7 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 			}
 
 			podGroupInfo := &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{GenericPodGroup: apg},
+				PodGroupInfo: &framework.PodGroupInfo{GenericPodGroup: gpg},
 			}
 			sched.updatePodGroupCondition(ctx, podGroupInfo.PodGroupInfo, tt.condition)
 
@@ -2508,7 +2508,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 	pgInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{pgKeyVal: queuedPodInfos},
 		PodGroupInfo: &framework.PodGroupInfo{
-			GenericPodGroup: framework.NewGenericPodGroup(testPodGroup),
+			GenericPodGroup: fwk.NewGenericPodGroup(testPodGroup),
 			UnscheduledPods: []*v1.Pod{podGroupPod},
 		},
 	}
@@ -2868,7 +2868,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 				for _, node := range nodes {
 					cache.AddNode(logger, node)
 				}
-				cache.AddGenericPodGroup(framework.NewGenericPodGroup(testPodGroup))
+				cache.AddGenericPodGroup(fwk.NewGenericPodGroup(testPodGroup))
 
 				sched := &Scheduler{
 					Cache:            cache,
@@ -3016,7 +3016,7 @@ func TestPodGroupSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 				pgInfo := &framework.QueuedPodGroupInfo{
 					QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{pgKeyVal: queuedPodInfos},
 					PodGroupInfo: &framework.PodGroupInfo{
-						GenericPodGroup: framework.NewGenericPodGroup(testPodGroup),
+						GenericPodGroup: fwk.NewGenericPodGroup(testPodGroup),
 						UnscheduledPods: []*v1.Pod{podGroupPod},
 					},
 				}
@@ -3073,7 +3073,7 @@ func TestPodGroupSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 				for _, node := range nodes {
 					cache.AddNode(logger, node)
 				}
-				cache.AddGenericPodGroup(framework.NewGenericPodGroup(testPodGroup))
+				cache.AddGenericPodGroup(fwk.NewGenericPodGroup(testPodGroup))
 
 				sched := &Scheduler{
 					Cache:            cache,
@@ -3243,7 +3243,7 @@ func TestPlacementCycleStateLifecycle(t *testing.T) {
 			testPodGroup := &schedulingv1beta1.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
 			}
-			cache.AddGenericPodGroup(framework.NewGenericPodGroup(testPodGroup))
+			cache.AddGenericPodGroup(fwk.NewGenericPodGroup(testPodGroup))
 
 			sched := &Scheduler{
 				Cache:            cache,
@@ -3261,7 +3261,7 @@ func TestPlacementCycleStateLifecycle(t *testing.T) {
 			pgInfo := &framework.QueuedPodGroupInfo{
 				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): queuedPodInfos},
 				PodGroupInfo: &framework.PodGroupInfo{
-					GenericPodGroup: framework.NewGenericPodGroup(testPodGroup),
+					GenericPodGroup: fwk.NewGenericPodGroup(testPodGroup),
 					UnscheduledPods: []*v1.Pod{podGroupPod},
 				},
 			}
@@ -3429,9 +3429,9 @@ func TestPlacementCycleStateLifecycle_MultiLevel(t *testing.T) {
 	}
 	queuedPodInfo1 := &framework.QueuedPodInfo{PodInfo: podInfo1}
 
-	leafPGInfo := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericPodGroup(pg), UnscheduledPods: []*v1.Pod{p1}}
-	midPGInfo := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericCompositePodGroup(midcpg), Children: []*framework.PodGroupInfo{leafPGInfo}}
-	rootPGInfo := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericCompositePodGroup(rootcpg), Children: []*framework.PodGroupInfo{midPGInfo}}
+	leafPGInfo := &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericPodGroup(pg), UnscheduledPods: []*v1.Pod{p1}}
+	midPGInfo := &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericCompositePodGroup(midcpg), Children: []*framework.PodGroupInfo{leafPGInfo}}
+	rootPGInfo := &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericCompositePodGroup(rootcpg), Children: []*framework.PodGroupInfo{midPGInfo}}
 
 	logger, ctx := ktesting.NewTestContext(t)
 
@@ -3489,9 +3489,9 @@ func TestPlacementCycleStateLifecycle_MultiLevel(t *testing.T) {
 	for _, node := range nodes {
 		cache.AddNode(logger, node)
 	}
-	cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(rootcpg))
-	cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(midcpg))
-	cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
+	cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(rootcpg))
+	cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(midcpg))
+	cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
 
 	sched := &Scheduler{
 		Cache:            cache,
@@ -3596,10 +3596,10 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 	queuedPodInfo1 := &framework.QueuedPodInfo{PodInfo: podInfo1}
 	queuedPodInfo2 := &framework.QueuedPodInfo{PodInfo: podInfo2}
 
-	childPGInfo1 := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericPodGroup(pg1), UnscheduledPods: []*v1.Pod{p1}}
-	childPGInfo2 := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericPodGroup(pg2), UnscheduledPods: []*v1.Pod{p2}}
+	childPGInfo1 := &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericPodGroup(pg1), UnscheduledPods: []*v1.Pod{p1}}
+	childPGInfo2 := &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericPodGroup(pg2), UnscheduledPods: []*v1.Pod{p2}}
 
-	rootPGInfo := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericCompositePodGroup(cpg), Children: []*framework.PodGroupInfo{childPGInfo1, childPGInfo2}}
+	rootPGInfo := &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericCompositePodGroup(cpg), Children: []*framework.PodGroupInfo{childPGInfo1, childPGInfo2}}
 
 	defaultPlacementResults := map[fwk.EntityKey]map[string][]string{
 		rootPGInfo.GetKey(): {
@@ -4007,9 +4007,9 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 			for _, node := range nodes {
 				cache.AddNode(logger, node)
 			}
-			cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
-			cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg1))
-			cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg2))
+			cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
+			cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg1))
+			cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg2))
 			cache.AddPodGroupMember(p1)
 			cache.AddPodGroupMember(p2)
 
@@ -4091,10 +4091,10 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 	queuedPodInfo1 := &framework.QueuedPodInfo{PodInfo: podInfo1}
 	queuedPodInfo2 := &framework.QueuedPodInfo{PodInfo: podInfo2}
 
-	childPGInfo1 := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericPodGroup(pg1), UnscheduledPods: []*v1.Pod{p1}}
-	childPGInfo2 := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericPodGroup(pg2), UnscheduledPods: []*v1.Pod{p2}}
+	childPGInfo1 := &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericPodGroup(pg1), UnscheduledPods: []*v1.Pod{p1}}
+	childPGInfo2 := &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericPodGroup(pg2), UnscheduledPods: []*v1.Pod{p2}}
 
-	rootPGInfo := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericCompositePodGroup(cpg), Children: []*framework.PodGroupInfo{childPGInfo1, childPGInfo2}}
+	rootPGInfo := &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericCompositePodGroup(cpg), Children: []*framework.PodGroupInfo{childPGInfo1, childPGInfo2}}
 
 	placements := map[fwk.EntityKey]map[string][]string{
 		rootPGInfo.GetKey(): {
@@ -4286,9 +4286,9 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 			for _, node := range nodes {
 				cache.AddNode(logger, node)
 			}
-			cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
-			cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg1))
-			cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg2))
+			cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
+			cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg1))
+			cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg2))
 			cache.AddPodGroupMember(p1)
 			cache.AddPodGroupMember(p2)
 
@@ -4348,7 +4348,7 @@ func TestPodGroupCycle_NominatedNodes(t *testing.T) {
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
 		PodGroupInfo: &framework.PodGroupInfo{
-			GenericPodGroup: framework.NewGenericPodGroup(testPodGroup),
+			GenericPodGroup: fwk.NewGenericPodGroup(testPodGroup),
 			UnscheduledPods: []*v1.Pod{p1, p2},
 		},
 	}
@@ -4407,7 +4407,7 @@ func TestPodGroupCycle_NominatedNodes(t *testing.T) {
 	}
 
 	cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
-	cache.AddGenericPodGroup(framework.NewGenericPodGroup(testPodGroup))
+	cache.AddGenericPodGroup(fwk.NewGenericPodGroup(testPodGroup))
 	sched := &Scheduler{
 		Profiles:         profile.Map{"test-scheduler": schedFwk},
 		Cache:            cache,
@@ -4471,7 +4471,7 @@ func TestScheduleOnePodGroup_PodGroupNotFound(t *testing.T) {
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
 		PodGroupInfo: &framework.PodGroupInfo{
-			GenericPodGroup: framework.NewGenericPodGroup(testPodGroup),
+			GenericPodGroup: fwk.NewGenericPodGroup(testPodGroup),
 			UnscheduledPods: []*v1.Pod{p1, p2},
 		},
 	}
@@ -4545,10 +4545,10 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 	qInfo1 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p1}}
 	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 	testPodGroup := st.MakePodGroup().Name("pg").Namespace("default").Obj()
-	apg := framework.NewGenericPodGroup(testPodGroup)
+	gpg := fwk.NewGenericPodGroup(testPodGroup)
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
-		PodGroupInfo:   &framework.PodGroupInfo{GenericPodGroup: apg},
+		PodGroupInfo:   &framework.PodGroupInfo{GenericPodGroup: gpg},
 	}
 	_, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancel(ctx)
@@ -4587,7 +4587,7 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 
 	client := clientsetfake.NewClientset(testPodGroup)
 	cache := internalcache.New(ctx, nil, true, false /* CompositePodGroup */)
-	cache.AddGenericPodGroup(apg)
+	cache.AddGenericPodGroup(gpg)
 
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	informerFactory.Start(ctx.Done())
@@ -4752,7 +4752,7 @@ func TestScheduleOnePodGroup_PodGroupStateAvailability(t *testing.T) {
 			podGroupInfo := &framework.QueuedPodGroupInfo{
 				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
 				PodGroupInfo: &framework.PodGroupInfo{
-					GenericPodGroup: framework.NewGenericPodGroup(testPodGroup),
+					GenericPodGroup: fwk.NewGenericPodGroup(testPodGroup),
 					UnscheduledPods: []*v1.Pod{p1, p2},
 				},
 			}
@@ -4795,7 +4795,7 @@ func TestScheduleOnePodGroup_PodGroupStateAvailability(t *testing.T) {
 			informerFactory.WaitForCacheSync(ctx.Done())
 
 			cache := internalcache.New(ctx, nil, true, false /* CompositePodGroup */)
-			cache.AddGenericPodGroup(framework.NewGenericPodGroup(testPodGroup))
+			cache.AddGenericPodGroup(fwk.NewGenericPodGroup(testPodGroup))
 			queue := internalqueue.NewTestQueue(ctx, nil)
 
 			schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
@@ -4922,10 +4922,10 @@ func TestCPGHierarchicalScheduling_ScheduleOnePodGroup(t *testing.T) {
 
 	cpgRootInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: queuedPodInfosMap,
-		PodGroupInfo: &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericCompositePodGroup(cpgRoot), UnscheduledPods: []*v1.Pod{p1, p2, p3}, Children: []*framework.PodGroupInfo{
-			{GenericPodGroup: framework.NewGenericPodGroup(pg1), UnscheduledPods: []*v1.Pod{p1}},
-			{GenericPodGroup: framework.NewGenericPodGroup(pg2), UnscheduledPods: []*v1.Pod{p2}},
-			{GenericPodGroup: framework.NewGenericPodGroup(pg3), UnscheduledPods: []*v1.Pod{p3}},
+		PodGroupInfo: &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgRoot), UnscheduledPods: []*v1.Pod{p1, p2, p3}, Children: []*framework.PodGroupInfo{
+			{GenericPodGroup: fwk.NewGenericPodGroup(pg1), UnscheduledPods: []*v1.Pod{p1}},
+			{GenericPodGroup: fwk.NewGenericPodGroup(pg2), UnscheduledPods: []*v1.Pod{p2}},
+			{GenericPodGroup: fwk.NewGenericPodGroup(pg3), UnscheduledPods: []*v1.Pod{p3}},
 		},
 		},
 		QueueingParams: framework.QueueingParams{
@@ -4990,10 +4990,10 @@ func TestCPGHierarchicalScheduling_ScheduleOnePodGroup(t *testing.T) {
 	}
 
 	cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
-	cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpgRoot))
-	cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg1))
-	cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg2))
-	cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg3))
+	cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpgRoot))
+	cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg1))
+	cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg2))
+	cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg3))
 
 	sched := &Scheduler{
 		Profiles:         profile.Map{"test-scheduler": schedFwk},
@@ -5111,7 +5111,7 @@ func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
 				ParentCompositePodGroupName: new(parentCPG),
 			},
 		}
-		cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
+		cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
 		return pg
 	}
 
@@ -5133,7 +5133,7 @@ func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
 				ParentCompositePodGroupName: parentCPG,
 			},
 		}
-		cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+		cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 		return cpg
 	}
 
@@ -5180,21 +5180,21 @@ func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: queuedPodInfos,
-		PodGroupInfo: &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericCompositePodGroup(rootCPG), UnscheduledPods: allPods, Children: []*framework.PodGroupInfo{
-			{GenericPodGroup: framework.NewGenericCompositePodGroup(cpgSub1), Children: []*framework.PodGroupInfo{
-				{GenericPodGroup: framework.NewGenericPodGroup(pg1), UnscheduledPods: pgPods["pg1"]},
-				{GenericPodGroup: framework.NewGenericPodGroup(pg2), UnscheduledPods: pgPods["pg2"]},
-				{GenericPodGroup: framework.NewGenericPodGroup(pg3), UnscheduledPods: pgPods["pg3"]},
+		PodGroupInfo: &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericCompositePodGroup(rootCPG), UnscheduledPods: allPods, Children: []*framework.PodGroupInfo{
+			{GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgSub1), Children: []*framework.PodGroupInfo{
+				{GenericPodGroup: fwk.NewGenericPodGroup(pg1), UnscheduledPods: pgPods["pg1"]},
+				{GenericPodGroup: fwk.NewGenericPodGroup(pg2), UnscheduledPods: pgPods["pg2"]},
+				{GenericPodGroup: fwk.NewGenericPodGroup(pg3), UnscheduledPods: pgPods["pg3"]},
 			},
 			},
-			{GenericPodGroup: framework.NewGenericCompositePodGroup(cpgSub2), Children: []*framework.PodGroupInfo{
-				{GenericPodGroup: framework.NewGenericPodGroup(pg4), UnscheduledPods: pgPods["pg4"]},
-				{GenericPodGroup: framework.NewGenericPodGroup(pg5), UnscheduledPods: pgPods["pg5"]},
+			{GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgSub2), Children: []*framework.PodGroupInfo{
+				{GenericPodGroup: fwk.NewGenericPodGroup(pg4), UnscheduledPods: pgPods["pg4"]},
+				{GenericPodGroup: fwk.NewGenericPodGroup(pg5), UnscheduledPods: pgPods["pg5"]},
 			},
 			},
-			{GenericPodGroup: framework.NewGenericCompositePodGroup(cpgSub3), Children: []*framework.PodGroupInfo{
-				{GenericPodGroup: framework.NewGenericPodGroup(pg6), UnscheduledPods: pgPods["pg6"]},
-				{GenericPodGroup: framework.NewGenericPodGroup(pg7), UnscheduledPods: pgPods["pg7"]},
+			{GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgSub3), Children: []*framework.PodGroupInfo{
+				{GenericPodGroup: fwk.NewGenericPodGroup(pg6), UnscheduledPods: pgPods["pg6"]},
+				{GenericPodGroup: fwk.NewGenericPodGroup(pg7), UnscheduledPods: pgPods["pg7"]},
 			},
 			},
 		},
@@ -5373,7 +5373,7 @@ func TestCPGMinGroupCount_Internal(t *testing.T) {
 				ParentCompositePodGroupName: parentCPG,
 			},
 		}
-		cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+		cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 		return cpg
 	}
 
@@ -5395,7 +5395,7 @@ func TestCPGMinGroupCount_Internal(t *testing.T) {
 				ParentCompositePodGroupName: new(parentCPG),
 			},
 		}
-		cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
+		cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
 		return pg
 	}
 
@@ -5513,10 +5513,10 @@ func TestCPGMinGroupCount_Internal(t *testing.T) {
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: queuedPodInfos,
-		PodGroupInfo: &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericCompositePodGroup(rootCPG), UnscheduledPods: allPods, Children: []*framework.PodGroupInfo{
-			{GenericPodGroup: framework.NewGenericPodGroup(pg1), UnscheduledPods: pgPods["pg1"]},
-			{GenericPodGroup: framework.NewGenericPodGroup(pg2), UnscheduledPods: pgPods["pg2"]},
-			{GenericPodGroup: framework.NewGenericPodGroup(pg3), UnscheduledPods: pgPods["pg3"]},
+		PodGroupInfo: &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericCompositePodGroup(rootCPG), UnscheduledPods: allPods, Children: []*framework.PodGroupInfo{
+			{GenericPodGroup: fwk.NewGenericPodGroup(pg1), UnscheduledPods: pgPods["pg1"]},
+			{GenericPodGroup: fwk.NewGenericPodGroup(pg2), UnscheduledPods: pgPods["pg2"]},
+			{GenericPodGroup: fwk.NewGenericPodGroup(pg3), UnscheduledPods: pgPods["pg3"]},
 		},
 		},
 	}
@@ -5598,7 +5598,7 @@ func TestCPGBasicWithGangChildren_Internal(t *testing.T) {
 				ParentCompositePodGroupName: parentCPG,
 			},
 		}
-		cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+		cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 		return cpg
 	}
 
@@ -5620,7 +5620,7 @@ func TestCPGBasicWithGangChildren_Internal(t *testing.T) {
 				ParentCompositePodGroupName: new(parentCPG),
 			},
 		}
-		cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
+		cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
 		return pg
 	}
 
@@ -5733,9 +5733,9 @@ func TestCPGBasicWithGangChildren_Internal(t *testing.T) {
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: queuedPodInfos,
-		PodGroupInfo: &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericCompositePodGroup(rootCPG), UnscheduledPods: allPods, Children: []*framework.PodGroupInfo{
-			{GenericPodGroup: framework.NewGenericPodGroup(pg1), UnscheduledPods: pgPods["pg1"]},
-			{GenericPodGroup: framework.NewGenericPodGroup(pg2), UnscheduledPods: pgPods["pg2"]},
+		PodGroupInfo: &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericCompositePodGroup(rootCPG), UnscheduledPods: allPods, Children: []*framework.PodGroupInfo{
+			{GenericPodGroup: fwk.NewGenericPodGroup(pg1), UnscheduledPods: pgPods["pg1"]},
+			{GenericPodGroup: fwk.NewGenericPodGroup(pg2), UnscheduledPods: pgPods["pg2"]},
 		},
 		},
 	}
@@ -6081,13 +6081,10 @@ func TestScorePlacementPodGroupAssignments(t *testing.T) {
 				pgi := &framework.PodGroupInfo{Children: children}
 				if len(children) > 0 {
 					cpg := st.MakeCompositePodGroup().Name(node.name).Namespace("default").Obj()
-					pgi.GenericPodGroup = framework.
-						NewGenericCompositePodGroup(cpg)
-
+					pgi.GenericPodGroup = fwk.NewGenericCompositePodGroup(cpg)
 				} else {
 					pg := st.MakePodGroup().Name(node.name).Namespace("default").Obj()
-					pgi.GenericPodGroup = framework.
-						NewGenericPodGroup(pg)
+					pgi.GenericPodGroup = fwk.NewGenericPodGroup(pg)
 				}
 				nameToKey[node.name] = pgi.GetKey()
 				return pgi
@@ -6164,13 +6161,13 @@ func buildHierarchicalQueuedPodGroupInfo(
 
 	var buildTree func(cpg *schedulingv1alpha3.CompositePodGroup) *framework.PodGroupInfo
 	buildTree = func(cpg *schedulingv1alpha3.CompositePodGroup) *framework.PodGroupInfo {
-		info := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericCompositePodGroup(cpg)}
+		info := &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericCompositePodGroup(cpg)}
 		for _, childCPG := range cpgChildren[cpg.Name] {
 			info.Children = append(info.Children, buildTree(childCPG))
 		}
 		for _, childPG := range pgChildren[cpg.Name] {
 			pgKey := fwk.PodGroupKey(childPG.Namespace, childPG.Name)
-			pgInfo := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericPodGroup(childPG), UnscheduledPods: podsByPG[pgKey]}
+			pgInfo := &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericPodGroup(childPG), UnscheduledPods: podsByPG[pgKey]}
 			info.Children = append(info.Children, pgInfo)
 		}
 		return info
@@ -6267,7 +6264,7 @@ func TestPodGroupPotentiallyFeasible(t *testing.T) {
 				UnscheduledPods: []*v1.Pod{
 					st.MakePod().Name("pod").UID("pod").PodGroupName("pg").Obj(),
 				},
-				GenericPodGroup: framework.NewGenericPodGroup(st.MakePodGroup().Name("pg").Obj()),
+				GenericPodGroup: fwk.NewGenericPodGroup(st.MakePodGroup().Name("pg").Obj()),
 			}
 			placementProgress := framework.PlacementProgress{
 				Remaining: 1,
@@ -6314,7 +6311,7 @@ func TestPodGroupCycle_PodStatusConditions(t *testing.T) {
 		},
 		PodGroupInfo: &framework.PodGroupInfo{
 			UnscheduledPods: pg1Pods,
-			GenericPodGroup: framework.NewGenericPodGroup(pg1),
+			GenericPodGroup: fwk.NewGenericPodGroup(pg1),
 		},
 	}
 
@@ -6324,15 +6321,15 @@ func TestPodGroupCycle_PodStatusConditions(t *testing.T) {
 			fwk.PodGroupKey("default", "pg3"): {qInfo5},
 		},
 		PodGroupInfo: &framework.PodGroupInfo{
-			GenericPodGroup: framework.NewGenericCompositePodGroup(cpg),
+			GenericPodGroup: fwk.NewGenericCompositePodGroup(cpg),
 			Children: []*framework.PodGroupInfo{
 				{
 					UnscheduledPods: pg2Pods,
-					GenericPodGroup: framework.NewGenericPodGroup(pg2),
+					GenericPodGroup: fwk.NewGenericPodGroup(pg2),
 				},
 				{
 					UnscheduledPods: pg3Pods,
-					GenericPodGroup: framework.NewGenericPodGroup(pg3),
+					GenericPodGroup: fwk.NewGenericPodGroup(pg3),
 				},
 			},
 		},
@@ -7332,10 +7329,10 @@ func TestPodGroupCycle_PodStatusConditions(t *testing.T) {
 					cache := internalcache.New(ctx, nil, true, cpgEnabled)
 					cache.AddNode(logger, testNode)
 					for _, cpg := range tt.compositePodGroups {
-						cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+						cache.AddGenericPodGroup(fwk.NewGenericCompositePodGroup(cpg))
 					}
 					for _, pg := range tt.podGroups {
-						cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
+						cache.AddGenericPodGroup(fwk.NewGenericPodGroup(pg))
 					}
 					for _, p := range tt.pods {
 						cache.AddPodGroupMember(p)

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -1084,7 +1084,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 
 		if scheduleAsPodGroup {
 			internalCache.AddPodGroupMember(item.sendPod)
-			internalCache.AddGenericPodGroup(framework.NewGenericPodGroup(podGroup))
+			internalCache.AddGenericPodGroup(fwk.NewGenericPodGroup(podGroup))
 		}
 		cache := &fakecache.Cache{
 			Cache: internalCache,
@@ -1170,7 +1170,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 		informerFactory.WaitForCacheSync(ctx.Done())
 
 		if scheduleAsPodGroup {
-			queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(podGroup))
+			queue.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(podGroup))
 		}
 		queue.Add(ctx, item.sendPod)
 
@@ -1533,7 +1533,7 @@ func TestHandleSchedulingFailure_PodGroupFitErrorCloned(t *testing.T) {
 	informerFactory.Start(ctx.Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
 
-	queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
+	queue.AddGenericPodGroup(logger, fwk.NewGenericPodGroup(pg))
 	queue.Add(ctx, pod1)
 	queue.Add(ctx, pod2)
 
@@ -5593,7 +5593,7 @@ func TestGetDifferentUIDPreCheck(t *testing.T) {
 	pgWithTarget := st.MakePodGroup().Name("pg-with-target").Obj()
 	pgWithTargetPod := &framework.QueuedPodGroupInfo{
 		PodGroupInfo: &framework.PodGroupInfo{
-			GenericPodGroup: framework.NewGenericPodGroup(pgWithTarget),
+			GenericPodGroup: fwk.NewGenericPodGroup(pgWithTarget),
 		},
 	}
 	pgWithTargetPod.AddPod(otherPodInfo1)
@@ -5602,7 +5602,7 @@ func TestGetDifferentUIDPreCheck(t *testing.T) {
 	pgWithoutTarget := st.MakePodGroup().Name("pg-without-target").Obj()
 	pgWithoutTargetPod := &framework.QueuedPodGroupInfo{
 		PodGroupInfo: &framework.PodGroupInfo{
-			GenericPodGroup: framework.NewGenericPodGroup(pgWithoutTarget),
+			GenericPodGroup: fwk.NewGenericPodGroup(pgWithoutTarget),
 		},
 	}
 	pgWithoutTargetPod.AddPod(otherPodInfo2)

--- a/pkg/scheduler/util/utils.go
+++ b/pkg/scheduler/util/utils.go
@@ -25,7 +25,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
-	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -271,27 +270,4 @@ func GetHostPorts(pod *v1.Pod) []v1.ContainerPort {
 		}
 	}
 	return ports
-}
-
-// PodGroupPriority returns priority of a given pod group.
-func PodGroupPriority(pg *schedulingv1beta1.PodGroup) int32 {
-	if pg.Spec.Priority != nil {
-		return *pg.Spec.Priority
-	}
-	// When priority of a pod group is nil, it means it was created at a time
-	// that there was no global default priority class and the priority class
-	// name of the pod group was empty. So, we resolve to the static default priority.
-	return 0
-}
-
-// CompositePodGroupPriority returns priority of a given composite pod group.
-func CompositePodGroupPriority(cpg *schedulingv1alpha3.CompositePodGroup) int32 {
-	if cpg.Spec.Priority != nil {
-		return *cpg.Spec.Priority
-	}
-	// When priority of a composite pod group is nil, it means it was created
-	// at a time that there was no global default priority class and the priority
-	// class name of the composite pod group was empty. So, we resolve to the
-	// static default priority.
-	return 0
 }

--- a/staging/src/k8s.io/kube-scheduler/framework/types.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/types.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	ndf "k8s.io/component-helpers/nodedeclaredfeatures"
 	"k8s.io/klog/v2"
+	"k8s.io/kube-scheduler/util"
 )
 
 // ActionType is an integer to represent one type of resource change.
@@ -788,4 +789,107 @@ func PodGroupKey(namespace, name string) EntityKey {
 // CompositePodGroupKey returns the key for a composite pod group.
 func CompositePodGroupKey(namespace, name string) EntityKey {
 	return EntityKey{Type: CompositePodGroupKeyType, Namespace: namespace, Name: name}
+}
+
+// GenericPodGroup is a wrapper around either a PodGroup or a CompositePodGroup API object,
+// providing a unified interface for operations on PodGroup objects.
+type GenericPodGroup struct {
+	// PodGroup is a PodGroup API object.
+	PodGroup *schedulingv1beta1.PodGroup
+	// CompositePodGroup is a CompositePodGroup API object.
+	// It can be set only when CompositePodGroup feature is enabled.
+	CompositePodGroup *schedulingv1alpha3.CompositePodGroup
+}
+
+// NewGenericPodGroup returns a GenericPodGroup for a PodGroup.
+func NewGenericPodGroup(pg *schedulingv1beta1.PodGroup) *GenericPodGroup {
+	return &GenericPodGroup{PodGroup: pg}
+}
+
+// NewGenericCompositePodGroup returns a GenericPodGroup for a CompositePodGroup.
+func NewGenericCompositePodGroup(cpg *schedulingv1alpha3.CompositePodGroup) *GenericPodGroup {
+	return &GenericPodGroup{CompositePodGroup: cpg}
+}
+
+// GetPodGroup unwraps the underlying PodGroup object. Returns nil if this wraps a CompositePodGroup.
+func (gpg *GenericPodGroup) GetPodGroup() *schedulingv1beta1.PodGroup {
+	return gpg.PodGroup
+}
+
+// GetCompositePodGroup unwraps the underlying CompositePodGroup object. Returns nil if this wraps a PodGroup.
+func (gpg *GenericPodGroup) GetCompositePodGroup() *schedulingv1alpha3.CompositePodGroup {
+	return gpg.CompositePodGroup
+}
+
+// GetName returns a name of the wrapped object.
+func (gpg *GenericPodGroup) GetName() string {
+	if gpg.PodGroup != nil {
+		return gpg.PodGroup.Name
+	}
+	return gpg.CompositePodGroup.Name
+}
+
+// GetNamespace returns a namespace of the wrapped object.
+func (gpg *GenericPodGroup) GetNamespace() string {
+	if gpg.PodGroup != nil {
+		return gpg.PodGroup.Namespace
+	}
+	return gpg.CompositePodGroup.Namespace
+}
+
+// GetType returns the type of the wrapped object.
+func (gpg *GenericPodGroup) GetType() EntityKeyType {
+	if gpg.PodGroup != nil {
+		return PodGroupKeyType
+	}
+	return CompositePodGroupKeyType
+}
+
+// GetKey returns a key of the wrapped object.
+func (gpg *GenericPodGroup) GetKey() EntityKey {
+	if gpg.PodGroup != nil {
+		return PodGroupKey(gpg.PodGroup.Namespace, gpg.PodGroup.Name)
+	}
+	return CompositePodGroupKey(gpg.CompositePodGroup.Namespace, gpg.CompositePodGroup.Name)
+}
+
+// GetParentCompositePodGroupName returns the parent composite pod group name of the GenericPodGroup.
+// This should be used only when the feature feature gate CompositePodGroup is enabled.
+func (gpg *GenericPodGroup) GetParentCompositePodGroupName() *string {
+	if gpg.PodGroup != nil {
+		return gpg.PodGroup.Spec.ParentCompositePodGroupName
+	}
+	return gpg.CompositePodGroup.Spec.ParentCompositePodGroupName
+}
+
+// HasParent returns true if the GenericPodGroup has a parent.
+// This should be used only when the feature feature gate CompositePodGroup is enabled.
+func (gpg *GenericPodGroup) HasParent() bool {
+	return gpg.GetParentCompositePodGroupName() != nil
+}
+
+// GetParentKey returns the parent key of the GenericPodGroup.
+// This should be used only when the feature CompositePodGroup feature gate is enabled.
+func (gpg *GenericPodGroup) GetParentKey() (EntityKey, bool) {
+	parentName := gpg.GetParentCompositePodGroupName()
+	if parentName == nil {
+		return EntityKey{}, false
+	}
+	return CompositePodGroupKey(gpg.GetNamespace(), *parentName), true
+}
+
+// GetPriority returns the priority of the wrapped object.
+func (gpg *GenericPodGroup) GetPriority() int32 {
+	if gpg.PodGroup != nil {
+		return util.PodGroupPriority(gpg.PodGroup)
+	}
+	return util.CompositePodGroupPriority(gpg.CompositePodGroup)
+}
+
+// GetCreationTimestamp returns the creation timestamp of the wrapped object.
+func (gpg *GenericPodGroup) GetCreationTimestamp() time.Time {
+	if gpg.PodGroup != nil {
+		return gpg.PodGroup.CreationTimestamp.Time
+	}
+	return gpg.CompositePodGroup.CreationTimestamp.Time
 }

--- a/staging/src/k8s.io/kube-scheduler/util/podgroup.go
+++ b/staging/src/k8s.io/kube-scheduler/util/podgroup.go
@@ -1,0 +1,45 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
+	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
+)
+
+// PodGroupPriority returns priority of a given pod group.
+func PodGroupPriority(pg *schedulingv1beta1.PodGroup) int32 {
+	if pg.Spec.Priority != nil {
+		return *pg.Spec.Priority
+	}
+	// When priority of a pod group is nil, it means it was created at a time
+	// that there was no global default priority class and the priority class
+	// name of the pod group was empty. So, we resolve to the static default priority.
+	return 0
+}
+
+// CompositePodGroupPriority returns priority of a given composite pod group.
+func CompositePodGroupPriority(cpg *schedulingv1alpha3.CompositePodGroup) int32 {
+	if cpg.Spec.Priority != nil {
+		return *cpg.Spec.Priority
+	}
+	// When priority of a composite pod group is nil, it means it was created
+	// at a time that there was no global default priority class and the priority
+	// class name of the composite pod group was empty. So, we resolve to the
+	// static default priority.
+	return 0
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR moves the GenericPodGroup definition to staging, allowing for using this unified object in scheduler plugins. It's required to properly refactor the preemption code TBD in a later PR.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
