### PR TITLE
kube-api-linter: mark core/v1 Pod/Container/Env/Probe fields optional…

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -7278,9 +7278,6 @@
           "description": "Time at which previous execution of the container started"
         }
       },
-      "required": [
-        "exitCode"
-      ],
       "type": "object"
     },
     "io.k8s.api.core.v1.ContainerStateWaiting": {
@@ -7383,13 +7380,6 @@
           "x-kubernetes-patch-strategy": "merge"
         }
       },
-      "required": [
-        "name",
-        "ready",
-        "restartCount",
-        "image",
-        "imageID"
-      ],
       "type": "object"
     },
     "io.k8s.api.core.v1.ContainerUser": {
@@ -7886,7 +7876,8 @@
         }
       },
       "required": [
-        "name"
+        "name",
+        "image"
       ],
       "type": "object"
     },
@@ -8392,8 +8383,7 @@
         }
       },
       "required": [
-        "name",
-        "value"
+        "name"
       ],
       "type": "object"
     },
@@ -8815,10 +8805,6 @@
           "type": "integer"
         }
       },
-      "required": [
-        "uid",
-        "gid"
-      ],
       "type": "object"
     },
     "io.k8s.api.core.v1.LoadBalancerIngress": {
@@ -10251,6 +10237,9 @@
           "description": "Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
+      "required": [
+        "spec"
+      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -10430,8 +10419,7 @@
         }
       },
       "required": [
-        "type",
-        "status"
+        "type"
       ],
       "type": "object"
     },
@@ -10477,6 +10465,9 @@
           "type": "string"
         }
       },
+      "required": [
+        "name"
+      ],
       "type": "object"
     },
     "io.k8s.api.core.v1.PodExtendedResourceClaimStatus": {
@@ -11182,6 +11173,9 @@
           "description": "Template defines the pods that will be created from this pod template. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
+      "required": [
+        "template"
+      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -11238,6 +11232,9 @@
           "description": "Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
+      "required": [
+        "spec"
+      ],
       "type": "object"
     },
     "io.k8s.api.core.v1.PodVolumeHealth": {
@@ -11329,8 +11326,7 @@
         }
       },
       "required": [
-        "weight",
-        "preference"
+        "weight"
       ],
       "type": "object"
     },
@@ -11765,7 +11761,7 @@
         }
       },
       "required": [
-        "resourceID"
+        "health"
       ],
       "type": "object"
     },
@@ -12745,9 +12741,6 @@
           "type": "integer"
         }
       },
-      "required": [
-        "seconds"
-      ],
       "type": "object"
     },
     "io.k8s.api.core.v1.StorageOSPersistentVolumeSource": {
@@ -12815,8 +12808,7 @@
         }
       },
       "required": [
-        "name",
-        "value"
+        "name"
       ],
       "type": "object"
     },

--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -1518,9 +1518,6 @@
             "description": "Time at which previous execution of the container started"
           }
         },
-        "required": [
-          "exitCode"
-        ],
         "type": "object"
       },
       "io.k8s.api.core.v1.ContainerStateWaiting": {
@@ -1646,13 +1643,6 @@
             "x-kubernetes-patch-strategy": "merge"
           }
         },
-        "required": [
-          "name",
-          "ready",
-          "restartCount",
-          "image",
-          "imageID"
-        ],
         "type": "object"
       },
       "io.k8s.api.core.v1.ContainerUser": {
@@ -2242,7 +2232,8 @@
           }
         },
         "required": [
-          "name"
+          "name",
+          "image"
         ],
         "type": "object"
       },
@@ -2827,8 +2818,7 @@
           }
         },
         "required": [
-          "name",
-          "value"
+          "name"
         ],
         "type": "object"
       },
@@ -3313,10 +3303,6 @@
             "type": "integer"
           }
         },
-        "required": [
-          "uid",
-          "gid"
-        ],
         "type": "object"
       },
       "io.k8s.api.core.v1.LoadBalancerIngress": {
@@ -5102,6 +5088,9 @@
             "description": "Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
           }
         },
+        "required": [
+          "spec"
+        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {
@@ -5300,8 +5289,7 @@
           }
         },
         "required": [
-          "type",
-          "status"
+          "type"
         ],
         "type": "object"
       },
@@ -5347,6 +5335,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "io.k8s.api.core.v1.PodExtendedResourceClaimStatus": {
@@ -6126,6 +6117,9 @@
             "description": "Template defines the pods that will be created from this pod template. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
           }
         },
+        "required": [
+          "template"
+        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {
@@ -6197,6 +6191,9 @@
             "description": "Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
           }
         },
+        "required": [
+          "spec"
+        ],
         "type": "object"
       },
       "io.k8s.api.core.v1.PodVolumeHealth": {
@@ -6302,8 +6299,7 @@
           }
         },
         "required": [
-          "weight",
-          "preference"
+          "weight"
         ],
         "type": "object"
       },
@@ -6812,7 +6808,7 @@
           }
         },
         "required": [
-          "resourceID"
+          "health"
         ],
         "type": "object"
       },
@@ -7921,9 +7917,6 @@
             "type": "integer"
           }
         },
-        "required": [
-          "seconds"
-        ],
         "type": "object"
       },
       "io.k8s.api.core.v1.StorageOSPersistentVolumeSource": {
@@ -8001,8 +7994,7 @@
           }
         },
         "required": [
-          "name",
-          "value"
+          "name"
         ],
         "type": "object"
       },

--- a/api/openapi-spec/v3/apis__apps__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apps__v1_openapi.json
@@ -2380,7 +2380,8 @@
           }
         },
         "required": [
-          "name"
+          "name",
+          "image"
         ],
         "type": "object"
       },
@@ -2704,8 +2705,7 @@
           }
         },
         "required": [
-          "name",
-          "value"
+          "name"
         ],
         "type": "object"
       },
@@ -3567,6 +3567,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "io.k8s.api.core.v1.PodOS": {
@@ -4072,6 +4075,9 @@
             "description": "Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
           }
         },
+        "required": [
+          "spec"
+        ],
         "type": "object"
       },
       "io.k8s.api.core.v1.PortworxVolumeSource": {
@@ -4116,8 +4122,7 @@
           }
         },
         "required": [
-          "weight",
-          "preference"
+          "weight"
         ],
         "type": "object"
       },
@@ -4694,9 +4699,6 @@
             "type": "integer"
           }
         },
-        "required": [
-          "seconds"
-        ],
         "type": "object"
       },
       "io.k8s.api.core.v1.StorageOSVolumeSource": {
@@ -4744,8 +4746,7 @@
           }
         },
         "required": [
-          "name",
-          "value"
+          "name"
         ],
         "type": "object"
       },

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -1787,7 +1787,8 @@
           }
         },
         "required": [
-          "name"
+          "name",
+          "image"
         ],
         "type": "object"
       },
@@ -2111,8 +2112,7 @@
           }
         },
         "required": [
-          "name",
-          "value"
+          "name"
         ],
         "type": "object"
       },
@@ -2826,6 +2826,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "io.k8s.api.core.v1.PodOS": {
@@ -3331,6 +3334,9 @@
             "description": "Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
           }
         },
+        "required": [
+          "spec"
+        ],
         "type": "object"
       },
       "io.k8s.api.core.v1.PortworxVolumeSource": {
@@ -3375,8 +3381,7 @@
           }
         },
         "required": [
-          "weight",
-          "preference"
+          "weight"
         ],
         "type": "object"
       },
@@ -3953,9 +3958,6 @@
             "type": "integer"
           }
         },
-        "required": [
-          "seconds"
-        ],
         "type": "object"
       },
       "io.k8s.api.core.v1.StorageOSVolumeSource": {
@@ -4003,8 +4005,7 @@
           }
         },
         "required": [
-          "name",
-          "value"
+          "name"
         ],
         "type": "object"
       },

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -21849,7 +21849,6 @@ func schema_k8sio_api_core_v1_ContainerStateTerminated(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"exitCode"},
 			},
 		},
 		Dependencies: []string{
@@ -22040,7 +22039,6 @@ func schema_k8sio_api_core_v1_ContainerStatus(ref common.ReferenceCallback) comm
 						},
 					},
 				},
-				Required: []string{"name", "ready", "restartCount", "image", "imageID"},
 			},
 		},
 		Dependencies: []string{
@@ -22953,7 +22951,7 @@ func schema_k8sio_api_core_v1_EphemeralContainer(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				Required: []string{"name"},
+				Required: []string{"name", "image"},
 			},
 		},
 		Dependencies: []string{
@@ -23264,7 +23262,7 @@ func schema_k8sio_api_core_v1_EphemeralContainerCommon(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"name"},
+				Required: []string{"name", "image"},
 			},
 		},
 		Dependencies: []string{
@@ -24156,7 +24154,7 @@ func schema_k8sio_api_core_v1_HTTPHeader(ref common.ReferenceCallback) common.Op
 						},
 					},
 				},
-				Required: []string{"name", "value"},
+				Required: []string{"name"},
 			},
 		},
 	}
@@ -24902,7 +24900,6 @@ func schema_k8sio_api_core_v1_LinuxContainerUser(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				Required: []string{"uid", "gid"},
 			},
 		},
 	}
@@ -27736,6 +27733,7 @@ func schema_k8sio_api_core_v1_Pod(ref common.ReferenceCallback) common.OpenAPIDe
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -28135,7 +28133,7 @@ func schema_k8sio_api_core_v1_PodCondition(ref common.ReferenceCallback) common.
 						},
 					},
 				},
-				Required: []string{"type", "status"},
+				Required: []string{"type"},
 			},
 		},
 		Dependencies: []string{
@@ -28236,6 +28234,7 @@ func schema_k8sio_api_core_v1_PodDNSConfigOption(ref common.ReferenceCallback) c
 						},
 					},
 				},
+				Required: []string{"name"},
 			},
 		},
 	}
@@ -29777,6 +29776,7 @@ func schema_k8sio_api_core_v1_PodTemplate(ref common.ReferenceCallback) common.O
 						},
 					},
 				},
+				Required: []string{"template"},
 			},
 		},
 		Dependencies: []string{
@@ -29856,6 +29856,7 @@ func schema_k8sio_api_core_v1_PodTemplateSpec(ref common.ReferenceCallback) comm
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -30057,7 +30058,7 @@ func schema_k8sio_api_core_v1_PreferredSchedulingTerm(ref common.ReferenceCallba
 						},
 					},
 				},
-				Required: []string{"weight", "preference"},
+				Required: []string{"weight"},
 			},
 		},
 		Dependencies: []string{
@@ -30901,7 +30902,7 @@ func schema_k8sio_api_core_v1_ResourceHealth(ref common.ReferenceCallback) commo
 						},
 					},
 				},
-				Required: []string{"resourceID"},
+				Required: []string{"health"},
 			},
 		},
 	}
@@ -32727,7 +32728,6 @@ func schema_k8sio_api_core_v1_SleepAction(ref common.ReferenceCallback) common.O
 						},
 					},
 				},
-				Required: []string{"seconds"},
 			},
 		},
 	}
@@ -32855,7 +32855,7 @@ func schema_k8sio_api_core_v1_Sysctl(ref common.ReferenceCallback) common.OpenAP
 						},
 					},
 				},
-				Required: []string{"name", "value"},
+				Required: []string{"name"},
 			},
 		},
 	}

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -86,6 +86,7 @@ message AppArmorProfile {
   //   RuntimeDefault - the container runtime's default profile.
   //   Unconfined - no AppArmor enforcement.
   // +unionDiscriminator
+  // +required
   optional string type = 1;
 
   // localhostProfile indicates a profile loaded on the node that should be used.
@@ -585,6 +586,7 @@ message ConfigMapKeySelector {
 
   // The key to select from the ConfigMap's Data field.
   // Keys in the BinaryData field are not currently propagated to container env vars.
+  // +required
   optional string key = 2;
 
   // Specify whether the ConfigMap or its key must be defined
@@ -701,6 +703,7 @@ message Container {
   // Name of the container specified as a DNS_LABEL.
   // Each container in a pod must have a unique name (DNS_LABEL).
   // Cannot be updated.
+  // +required
   optional string name = 1;
 
   // Container image name.
@@ -928,12 +931,15 @@ message Container {
 // extended resource name to the device request name.
 message ContainerExtendedResourceRequest {
   // The name of the container requesting resources.
+  // +required
   optional string containerName = 1;
 
   // The name of the extended resource in that container which gets backed by DRA.
+  // +required
   optional string resourceName = 2;
 
   // The name of the request in the special ResourceClaim which corresponds to the extended resource.
+  // +required
   optional string requestName = 3;
 }
 
@@ -967,6 +973,7 @@ message ContainerPort {
 
   // Number of port to expose on the pod's IP address.
   // This must be a valid port number, 0 < x < 65536.
+  // +required
   optional int32 containerPort = 3;
 
   // Protocol for port. Must be UDP, TCP, or SCTP.
@@ -984,10 +991,12 @@ message ContainerPort {
 message ContainerResizePolicy {
   // Name of the resource to which this resource resize policy applies.
   // Supported values: cpu, memory.
+  // +required
   optional string resourceName = 1;
 
   // Restart policy to apply when specified resource is resized.
   // If not specified, it defaults to NotRequired.
+  // +required
   optional string restartPolicy = 2;
 }
 
@@ -1051,6 +1060,7 @@ message ContainerStateRunning {
 // ContainerStateTerminated is a terminated state of a container.
 message ContainerStateTerminated {
   // Exit status from the last termination of the container
+  // +optional
   optional int32 exitCode = 1;
 
   // Signal from the last termination of the container
@@ -1094,6 +1104,7 @@ message ContainerStatus {
   // Name is a DNS_LABEL representing the unique name of the container.
   // Each container in a pod must have a unique name across all container types.
   // Cannot be updated.
+  // +optional
   optional string name = 1;
 
   // State holds details about the container's current condition.
@@ -1113,23 +1124,27 @@ message ContainerStatus {
   //
   // The value is typically used to determine whether a container is ready to
   // accept traffic.
+  // +optional
   optional bool ready = 4;
 
   // RestartCount holds the number of times the container has been restarted.
   // Kubelet makes an effort to always increment the value, but there
   // are cases when the state may be lost due to node restarts and then the value
   // may be reset to 0. The value is never negative.
+  // +optional
   optional int32 restartCount = 5;
 
   // Image is the name of container image that the container is running.
   // The container image may not match the image used in the PodSpec,
   // as it may have been resolved by the runtime.
   // More info: https://kubernetes.io/docs/concepts/containers/images.
+  // +optional
   optional string image = 6;
 
   // ImageID is the image ID of the container's image. The image ID may not
   // match the image ID of the image used in the PodSpec, as it may have been
   // resolved by the runtime.
+  // +optional
   optional string imageID = 7;
 
   // ContainerID is the ID of the container in the format '<type>://<container_id>'.
@@ -1468,6 +1483,7 @@ message EnvFromSource {
 message EnvVar {
   // Name of the environment variable.
   // May consist of any printable ASCII characters except '='.
+  // +required
   optional string name = 1;
 
   // Variable references $(VAR_NAME) are expanded
@@ -1547,10 +1563,12 @@ message EphemeralContainer {
 message EphemeralContainerCommon {
   // Name of the ephemeral container specified as a DNS_LABEL.
   // This name must be unique among all containers, init containers and ephemeral containers.
+  // +required
   optional string name = 1;
 
   // Container image name.
   // More info: https://kubernetes.io/docs/concepts/containers/images
+  // +required
   optional string image = 2;
 
   // Entrypoint array. Not executed within a shell.
@@ -2075,6 +2093,7 @@ message GCEPersistentDiskVolumeSource {
 // GRPCAction specifies an action involving a GRPC service.
 message GRPCAction {
   // Port number of the gRPC service. Number must be in the range 1 to 65535.
+  // +required
   optional int32 port = 1;
 
   // Service is the name of the service to place in the gRPC HealthCheckRequest
@@ -2167,6 +2186,7 @@ message HTTPGetAction {
   // Name or number of the port to access on the container.
   // Number must be in the range 1 to 65535.
   // Name must be an IANA_SVC_NAME.
+  // +required
   optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString port = 2;
 
   // Host name to connect to, defaults to the pod IP. You probably want to set
@@ -2195,9 +2215,11 @@ message HTTPGetAction {
 message HTTPHeader {
   // The header field name.
   // This will be canonicalized upon output, so case-variant names will be understood as the same header.
+  // +required
   optional string name = 1;
 
   // The header field value
+  // +optional
   optional string value = 2;
 }
 
@@ -2210,6 +2232,7 @@ message HostAlias {
 
   // Hostnames for the above IP address.
   // +listType=atomic
+  // +optional
   repeated string hostnames = 2;
 }
 
@@ -2522,9 +2545,11 @@ message LimitRangeSpec {
 // LinuxContainerUser represents user identity information in Linux containers
 message LinuxContainerUser {
   // UID is the primary uid initially attached to the first process in the container
+  // +optional
   optional int64 uid = 1;
 
   // GID is the primary gid initially attached to the first process in the container
+  // +optional
   optional int64 gid = 2;
 
   // SupplementalGroups are the supplemental groups initially attached to the first process in the container
@@ -3037,6 +3062,7 @@ message NodeRuntimeHandlerFeatures {
 message NodeSelector {
   // Required. A list of node selector terms. The terms are ORed.
   // +listType=atomic
+  // +required
   repeated NodeSelectorTerm nodeSelectorTerms = 1;
 }
 
@@ -3044,10 +3070,12 @@ message NodeSelector {
 // that relates the key and values.
 message NodeSelectorRequirement {
   // The label key that the selector applies to.
+  // +required
   optional string key = 1;
 
   // Represents a key's relationship to a set of values.
   // Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+  // +required
   optional string operator = 2;
 
   // An array of string values. If the operator is In or NotIn,
@@ -3274,6 +3302,7 @@ message ObjectFieldSelector {
   optional string apiVersion = 1;
 
   // Path of the field to select in the specified API version.
+  // +required
   optional string fieldPath = 2;
 }
 
@@ -3902,7 +3931,7 @@ message Pod {
 
   // Specification of the desired behavior of the pod.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional PodSpec spec = 2;
 
   // Most recently observed status of the pod.
@@ -3966,6 +3995,7 @@ message PodAffinityTerm {
   // whose value of the label with key topologyKey matches that of any node on which any of the
   // selected pods is running.
   // Empty topologyKey is not allowed.
+  // +required
   optional string topologyKey = 3;
 
   // A label query over the set of namespaces that the term applies to.
@@ -4162,6 +4192,7 @@ message PodCertificateProjection {
 message PodCondition {
   // Type is the type of the condition.
   // More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
+  // +required
   optional string type = 1;
 
   // If set, this represents the .metadata.generation that the pod condition was set based upon.
@@ -4171,6 +4202,7 @@ message PodCondition {
   // Status is the status of the condition.
   // Can be True, False, Unknown.
   // More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
+  // +optional
   optional string status = 2;
 
   // Last time we probed the condition.
@@ -4220,6 +4252,7 @@ message PodDNSConfig {
 message PodDNSConfigOption {
   // Name is this DNS resolver option's name.
   // Required.
+  // +required
   optional string name = 1;
 
   // Value is this DNS resolver option's value.
@@ -4267,10 +4300,12 @@ message PodExtendedResourceClaimStatus {
   // RequestMappings identifies the mapping of <container, extended resource backed by DRA> to  device request
   // in the generated ResourceClaim.
   // +listType=atomic
+  // +required
   repeated ContainerExtendedResourceRequest requestMappings = 1;
 
   // ResourceClaimName is the name of the ResourceClaim that was
   // generated for the Pod in the namespace of the Pod.
+  // +required
   optional string resourceClaimName = 2;
 }
 
@@ -4362,6 +4397,7 @@ message PodOS {
   // Additional value may be defined in future and can be one of:
   // https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
   // Clients should expect to handle additional values and treat unrecognized values in this field as os: null
+  // +required
   optional string name = 1;
 }
 
@@ -4389,6 +4425,7 @@ message PodProxyOptions {
 // PodReadinessGate contains the reference to a pod condition
 message PodReadinessGate {
   // ConditionType refers to a condition in the pod's condition list with matching type.
+  // +required
   optional string conditionType = 1;
 }
 
@@ -4409,6 +4446,7 @@ message PodReadinessGate {
 message PodResourceClaim {
   // Name uniquely identifies this resource claim inside the pod.
   // This must be a DNS_LABEL.
+  // +required
   optional string name = 1;
 
   // ResourceClaimName is the name of a ResourceClaim object in the same
@@ -4416,6 +4454,7 @@ message PodResourceClaim {
   //
   // Exactly one of ResourceClaimName and ResourceClaimTemplateName must
   // be set.
+  // +optional
   optional string resourceClaimName = 3;
 
   // ResourceClaimTemplateName is the name of a ResourceClaimTemplate
@@ -4443,6 +4482,7 @@ message PodResourceClaim {
   //
   // Exactly one of ResourceClaimName and ResourceClaimTemplateName must
   // be set.
+  // +optional
   optional string resourceClaimTemplateName = 4;
 }
 
@@ -4453,6 +4493,7 @@ message PodResourceClaimStatus {
   // Name uniquely identifies this resource claim inside the pod.
   // This must match the name of an entry in pod.spec.resourceClaims,
   // which implies that the string must be a DNS_LABEL.
+  // +required
   optional string name = 1;
 
   // ResourceClaimName is the name of the ResourceClaim that was
@@ -4475,6 +4516,7 @@ message PodResourceClaimStatus {
 message PodSchedulingGate {
   // Name of the scheduling gate.
   // Each scheduling gate must have a unique name field.
+  // +required
   optional string name = 1;
 }
 
@@ -4663,6 +4705,7 @@ message PodSpec {
   // +patchStrategy=merge
   // +listType=map
   // +listMapKey=name
+  // +optional
   repeated Container initContainers = 20;
 
   // List of containers belonging to the pod.
@@ -4673,6 +4716,7 @@ message PodSpec {
   // +patchStrategy=merge
   // +listType=map
   // +listMapKey=name
+  // +required
   repeated Container containers = 2;
 
   // List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
@@ -5162,6 +5206,7 @@ message PodStatus {
   // ignored.
   // More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-and-container-status
   // +listType=atomic
+  // +optional
   repeated ContainerStatus initContainerStatuses = 10;
 
   // Statuses of containers in this pod.
@@ -5269,7 +5314,7 @@ message PodTemplate {
 
   // Template defines the pods that will be created from this pod template.
   // https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional PodTemplateSpec template = 2;
 }
 
@@ -5294,7 +5339,7 @@ message PodTemplateSpec {
 
   // Specification of the desired behavior of the pod.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional PodSpec spec = 2;
 }
 
@@ -5397,9 +5442,11 @@ message PreferAvoidPodsEntry {
 // (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
 message PreferredSchedulingTerm {
   // Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+  // +required
   optional int32 weight = 1;
 
   // A node selector term, associated with the corresponding weight.
+  // +optional
   optional NodeSelectorTerm preference = 2;
 }
 
@@ -5784,6 +5831,7 @@ message ResourceClaim {
   // Name must match the name of one entry in pod.spec.resourceClaims of
   // the Pod where this field is used. It makes that resource available
   // inside a container.
+  // +required
   optional string name = 1;
 
   // Request is the name chosen for a request in the referenced claim.
@@ -5802,6 +5850,7 @@ message ResourceFieldSelector {
   optional string containerName = 1;
 
   // Required: resource to select
+  // +required
   optional string resource = 2;
 
   // Specifies the output format of the exposed resources, defaults to "1"
@@ -5813,6 +5862,7 @@ message ResourceFieldSelector {
 // This is a part of KEP https://kep.k8s.io/4680.
 message ResourceHealth {
   // ResourceID is the unique identifier of the resource. See the ResourceID type for more information.
+  // +optional
   optional string resourceID = 1;
 
   // Health of the resource.
@@ -5825,6 +5875,7 @@ message ResourceHealth {
   //             For example, Device Plugin got unregistered and hasn't been re-registered since.
   //
   // In future we may want to introduce the PermanentlyUnhealthy Status.
+  // +required
   optional string health = 2;
 
   // Message provides human-readable context for Health (e.g. "ECC error count exceeded threshold").
@@ -5945,6 +5996,7 @@ message ResourceStatus {
   // See ResourceID type definition for a specific format it has in various use cases.
   // +listType=map
   // +listMapKey=resourceID
+  // +optional
   repeated ResourceHealth resources = 2;
 }
 
@@ -6103,6 +6155,7 @@ message SeccompProfile {
   // RuntimeDefault - the container runtime default profile should be used.
   // Unconfined - no profile should be applied.
   // +unionDiscriminator
+  // +required
   optional string type = 1;
 
   // localhostProfile indicates a profile defined in a file on the node should be used.
@@ -6172,6 +6225,7 @@ message SecretKeySelector {
   optional LocalObjectReference localObjectReference = 1;
 
   // The key of the secret to select from.  Must be a valid secret key.
+  // +required
   optional string key = 2;
 
   // Specify whether the Secret or its key must be defined
@@ -6835,6 +6889,7 @@ message SessionAffinityConfig {
 // SleepAction describes a "sleep" action.
 message SleepAction {
   // Seconds is the number of seconds to sleep.
+  // +optional
   optional int64 seconds = 1;
 }
 
@@ -6905,9 +6960,11 @@ message StorageOSVolumeSource {
 // Sysctl defines a kernel parameter to be set
 message Sysctl {
   // Name of a property to set
+  // +required
   optional string name = 1;
 
   // Value of a property to set
+  // +optional
   optional string value = 2;
 }
 
@@ -6916,6 +6973,7 @@ message TCPSocketAction {
   // Number or name of the port to access on the container.
   // Number must be in the range 1 to 65535.
   // Name must be an IANA_SVC_NAME.
+  // +required
   optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString port = 1;
 
   // Optional: Host name to connect to, defaults to the pod IP.
@@ -6927,6 +6985,7 @@ message TCPSocketAction {
 // any pod that does not tolerate the Taint.
 message Taint {
   // Required. The taint key to be applied to a node.
+  // +required
   optional string key = 1;
 
   // The taint value corresponding to the taint key.
@@ -6936,6 +6995,7 @@ message Taint {
   // Required. The effect of the taint on pods
   // that do not tolerate the taint.
   // Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+  // +required
   optional string effect = 3;
 
   // TimeAdded represents the time at which the taint was added.
@@ -6983,11 +7043,13 @@ message Toleration {
 // This is an alpha feature and may change in the future.
 message TopologySelectorLabelRequirement {
   // The label key that the selector applies to.
+  // +required
   optional string key = 1;
 
   // An array of string values. One value must match the label to be selected.
   // Each entry in Values is ORed.
   // +listType=atomic
+  // +required
   repeated string values = 2;
 }
 
@@ -7026,6 +7088,7 @@ message TopologySpreadConstraint {
   // When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
   // to topologies that satisfy it.
   // It's a required field. Default value is 1 and 0 is not allowed.
+  // +required
   optional int32 maxSkew = 1;
 
   // TopologyKey is the key of node labels. Nodes that have a label with this key
@@ -7038,6 +7101,7 @@ message TopologySpreadConstraint {
   // e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
   // And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
   // It's a required field.
+  // +required
   optional string topologyKey = 2;
 
   // WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
@@ -7061,6 +7125,7 @@ message TopologySpreadConstraint {
   // MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
   // won't make it *more* imbalanced.
   // It's a required field.
+  // +required
   optional string whenUnsatisfiable = 3;
 
   // LabelSelector is used to find matching pods.
@@ -7679,9 +7744,11 @@ message VsphereVirtualDiskVolumeSource {
 message WeightedPodAffinityTerm {
   // weight associated with matching the corresponding podAffinityTerm,
   // in the range 1-100.
+  // +required
   optional int32 weight = 1;
 
   // Required. A pod affinity term, associated with the corresponding weight.
+  // +required
   optional PodAffinityTerm podAffinityTerm = 2;
 }
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2515,6 +2515,7 @@ type ContainerPort struct {
 	HostPort int32 `json:"hostPort,omitempty" protobuf:"varint,2,opt,name=hostPort"`
 	// Number of port to expose on the pod's IP address.
 	// This must be a valid port number, 0 < x < 65536.
+	// +required
 	ContainerPort int32 `json:"containerPort" protobuf:"varint,3,opt,name=containerPort"`
 	// Protocol for port. Must be UDP, TCP, or SCTP.
 	// Defaults to "TCP".
@@ -2646,6 +2647,7 @@ type VolumeDevice struct {
 type EnvVar struct {
 	// Name of the environment variable.
 	// May consist of any printable ASCII characters except '='.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 
 	// Optional: no more than one of the following may be specified.
@@ -2724,6 +2726,7 @@ type ObjectFieldSelector struct {
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,1,opt,name=apiVersion"`
 	// Path of the field to select in the specified API version.
+	// +required
 	FieldPath string `json:"fieldPath" protobuf:"bytes,2,opt,name=fieldPath"`
 }
 
@@ -2734,6 +2737,7 @@ type ResourceFieldSelector struct {
 	// +optional
 	ContainerName string `json:"containerName,omitempty" protobuf:"bytes,1,opt,name=containerName"`
 	// Required: resource to select
+	// +required
 	Resource string `json:"resource" protobuf:"bytes,2,opt,name=resource"`
 	// Specifies the output format of the exposed resources, defaults to "1"
 	// +optional
@@ -2747,6 +2751,7 @@ type ConfigMapKeySelector struct {
 	LocalObjectReference `json:"" protobuf:"bytes,1,opt,name=localObjectReference"`
 	// The key to select from the ConfigMap's Data field.
 	// Keys in the BinaryData field are not currently propagated to container env vars.
+	// +required
 	Key string `json:"key" protobuf:"bytes,2,opt,name=key"`
 	// Specify whether the ConfigMap or its key must be defined
 	// +optional
@@ -2759,6 +2764,7 @@ type SecretKeySelector struct {
 	// The name of the secret in the pod's namespace to select from.
 	LocalObjectReference `json:"" protobuf:"bytes,1,opt,name=localObjectReference"`
 	// The key of the secret to select from.  Must be a valid secret key.
+	// +required
 	Key string `json:"key" protobuf:"bytes,2,opt,name=key"`
 	// Specify whether the Secret or its key must be defined
 	// +optional
@@ -2810,8 +2816,10 @@ type SecretEnvSource struct {
 type HTTPHeader struct {
 	// The header field name.
 	// This will be canonicalized upon output, so case-variant names will be understood as the same header.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 	// The header field value
+	// +optional
 	Value string `json:"value" protobuf:"bytes,2,opt,name=value"`
 }
 
@@ -2836,6 +2844,7 @@ type HTTPGetAction struct {
 	// Name or number of the port to access on the container.
 	// Number must be in the range 1 to 65535.
 	// Name must be an IANA_SVC_NAME.
+	// +required
 	Port intstr.IntOrString `json:"port" protobuf:"bytes,2,opt,name=port"`
 	// Host name to connect to, defaults to the pod IP. You probably want to set
 	// "Host" in httpHeaders instead.
@@ -2872,6 +2881,7 @@ type TCPSocketAction struct {
 	// Number or name of the port to access on the container.
 	// Number must be in the range 1 to 65535.
 	// Name must be an IANA_SVC_NAME.
+	// +required
 	Port intstr.IntOrString `json:"port" protobuf:"bytes,1,opt,name=port"`
 	// Optional: Host name to connect to, defaults to the pod IP.
 	// +optional
@@ -2881,6 +2891,7 @@ type TCPSocketAction struct {
 // GRPCAction specifies an action involving a GRPC service.
 type GRPCAction struct {
 	// Port number of the gRPC service. Number must be in the range 1 to 65535.
+	// +required
 	Port int32 `json:"port" protobuf:"bytes,1,opt,name=port"`
 
 	// Service is the name of the service to place in the gRPC HealthCheckRequest
@@ -2928,6 +2939,7 @@ type ExecAction struct {
 // SleepAction describes a "sleep" action.
 type SleepAction struct {
 	// Seconds is the number of seconds to sleep.
+	// +optional
 	Seconds int64 `json:"seconds" protobuf:"bytes,1,opt,name=seconds"`
 }
 
@@ -3005,9 +3017,11 @@ const (
 type ContainerResizePolicy struct {
 	// Name of the resource to which this resource resize policy applies.
 	// Supported values: cpu, memory.
+	// +required
 	ResourceName ResourceName `json:"resourceName" protobuf:"bytes,1,opt,name=resourceName,casttype=ResourceName"`
 	// Restart policy to apply when specified resource is resized.
 	// If not specified, it defaults to NotRequired.
+	// +required
 	RestartPolicy ResourceResizeRestartPolicy `json:"restartPolicy" protobuf:"bytes,2,opt,name=restartPolicy,casttype=ResourceResizeRestartPolicy"`
 }
 
@@ -3104,6 +3118,7 @@ type ResourceClaim struct {
 	// Name must match the name of one entry in pod.spec.resourceClaims of
 	// the Pod where this field is used. It makes that resource available
 	// inside a container.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 
 	// Request is the name chosen for a request in the referenced claim.
@@ -3124,6 +3139,7 @@ type Container struct {
 	// Name of the container specified as a DNS_LABEL.
 	// Each container in a pod must have a unique name (DNS_LABEL).
 	// Cannot be updated.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 	// Container image name.
 	// More info: https://kubernetes.io/docs/concepts/containers/images
@@ -3495,6 +3511,7 @@ type ContainerStateRunning struct {
 // ContainerStateTerminated is a terminated state of a container.
 type ContainerStateTerminated struct {
 	// Exit status from the last termination of the container
+	// +optional
 	ExitCode int32 `json:"exitCode" protobuf:"varint,1,opt,name=exitCode"`
 	// Signal from the last termination of the container
 	// +optional
@@ -3536,6 +3553,7 @@ type ContainerStatus struct {
 	// Name is a DNS_LABEL representing the unique name of the container.
 	// Each container in a pod must have a unique name across all container types.
 	// Cannot be updated.
+	// +optional
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 	// State holds details about the container's current condition.
 	// +optional
@@ -3552,20 +3570,24 @@ type ContainerStatus struct {
 	//
 	// The value is typically used to determine whether a container is ready to
 	// accept traffic.
+	// +optional
 	Ready bool `json:"ready" protobuf:"varint,4,opt,name=ready"`
 	// RestartCount holds the number of times the container has been restarted.
 	// Kubelet makes an effort to always increment the value, but there
 	// are cases when the state may be lost due to node restarts and then the value
 	// may be reset to 0. The value is never negative.
+	// +optional
 	RestartCount int32 `json:"restartCount" protobuf:"varint,5,opt,name=restartCount"`
 	// Image is the name of container image that the container is running.
 	// The container image may not match the image used in the PodSpec,
 	// as it may have been resolved by the runtime.
 	// More info: https://kubernetes.io/docs/concepts/containers/images.
+	// +optional
 	Image string `json:"image" protobuf:"bytes,6,opt,name=image"`
 	// ImageID is the image ID of the container's image. The image ID may not
 	// match the image ID of the image used in the PodSpec, as it may have been
 	// resolved by the runtime.
+	// +optional
 	ImageID string `json:"imageID" protobuf:"bytes,7,opt,name=imageID"`
 	// ContainerID is the ID of the container in the format '<type>://<container_id>'.
 	// Where type is a container runtime identifier, returned from Version call of CRI API
@@ -3636,6 +3658,7 @@ type ResourceStatus struct {
 	// See ResourceID type definition for a specific format it has in various use cases.
 	// +listType=map
 	// +listMapKey=resourceID
+	// +optional
 	Resources []ResourceHealth `json:"resources,omitempty" protobuf:"bytes,2,rep,name=resources"`
 }
 
@@ -3666,6 +3689,7 @@ type ResourceID string
 // This is a part of KEP https://kep.k8s.io/4680.
 type ResourceHealth struct {
 	// ResourceID is the unique identifier of the resource. See the ResourceID type for more information.
+	// +optional
 	ResourceID ResourceID `json:"resourceID" protobuf:"bytes,1,opt,name=resourceID"`
 	// Health of the resource.
 	// can be one of:
@@ -3677,6 +3701,7 @@ type ResourceHealth struct {
 	//             For example, Device Plugin got unregistered and hasn't been re-registered since.
 	//
 	// In future we may want to introduce the PermanentlyUnhealthy Status.
+	// +required
 	Health ResourceHealthStatus `json:"health,omitempty" protobuf:"bytes,2,name=health"`
 	// Message provides human-readable context for Health (e.g. "ECC error count exceeded threshold").
 	// This field is populated by the kubelet when ResourceHealthStatusMessage is enabled if the DRA plugin returns a message, and is null otherwise.
@@ -3700,8 +3725,10 @@ type ContainerUser struct {
 // LinuxContainerUser represents user identity information in Linux containers
 type LinuxContainerUser struct {
 	// UID is the primary uid initially attached to the first process in the container
+	// +optional
 	UID int64 `json:"uid" protobuf:"varint,1,name=uid"`
 	// GID is the primary gid initially attached to the first process in the container
+	// +optional
 	GID int64 `json:"gid" protobuf:"varint,2,name=gid"`
 	// SupplementalGroups are the supplemental groups initially attached to the first process in the container
 	// +optional
@@ -3808,6 +3835,7 @@ const (
 type PodCondition struct {
 	// Type is the type of the condition.
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
+	// +required
 	Type PodConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=PodConditionType"`
 	// If set, this represents the .metadata.generation that the pod condition was set based upon.
 	// +optional
@@ -3815,6 +3843,7 @@ type PodCondition struct {
 	// Status is the status of the condition.
 	// Can be True, False, Unknown.
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
+	// +optional
 	Status ConditionStatus `json:"status" protobuf:"bytes,2,opt,name=status,casttype=ConditionStatus"`
 	// Last time we probed the condition.
 	// +optional
@@ -3994,6 +4023,7 @@ const (
 type NodeSelector struct {
 	// Required. A list of node selector terms. The terms are ORed.
 	// +listType=atomic
+	// +required
 	NodeSelectorTerms []NodeSelectorTerm `json:"nodeSelectorTerms" protobuf:"bytes,1,rep,name=nodeSelectorTerms"`
 }
 
@@ -4016,9 +4046,11 @@ type NodeSelectorTerm struct {
 // that relates the key and values.
 type NodeSelectorRequirement struct {
 	// The label key that the selector applies to.
+	// +required
 	Key string `json:"key" protobuf:"bytes,1,opt,name=key"`
 	// Represents a key's relationship to a set of values.
 	// Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+	// +required
 	Operator NodeSelectorOperator `json:"operator" protobuf:"bytes,2,opt,name=operator,casttype=NodeSelectorOperator"`
 	// An array of string values. If the operator is In or NotIn,
 	// the values array must be non-empty. If the operator is Exists or DoesNotExist,
@@ -4063,10 +4095,12 @@ type TopologySelectorTerm struct {
 // This is an alpha feature and may change in the future.
 type TopologySelectorLabelRequirement struct {
 	// The label key that the selector applies to.
+	// +required
 	Key string `json:"key" protobuf:"bytes,1,opt,name=key"`
 	// An array of string values. One value must match the label to be selected.
 	// Each entry in Values is ORed.
 	// +listType=atomic
+	// +required
 	Values []string `json:"values" protobuf:"bytes,2,rep,name=values"`
 }
 
@@ -4161,8 +4195,10 @@ type PodAntiAffinity struct {
 type WeightedPodAffinityTerm struct {
 	// weight associated with matching the corresponding podAffinityTerm,
 	// in the range 1-100.
+	// +required
 	Weight int32 `json:"weight" protobuf:"varint,1,opt,name=weight"`
 	// Required. A pod affinity term, associated with the corresponding weight.
+	// +required
 	PodAffinityTerm PodAffinityTerm `json:"podAffinityTerm" protobuf:"bytes,2,opt,name=podAffinityTerm"`
 }
 
@@ -4189,6 +4225,7 @@ type PodAffinityTerm struct {
 	// whose value of the label with key topologyKey matches that of any node on which any of the
 	// selected pods is running.
 	// Empty topologyKey is not allowed.
+	// +required
 	TopologyKey string `json:"topologyKey" protobuf:"bytes,3,opt,name=topologyKey"`
 	// A label query over the set of namespaces that the term applies to.
 	// The term is applied to the union of the namespaces selected by this field
@@ -4259,8 +4296,10 @@ type NodeAffinity struct {
 // (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
 type PreferredSchedulingTerm struct {
 	// Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+	// +required
 	Weight int32 `json:"weight" protobuf:"varint,1,opt,name=weight"`
 	// A node selector term, associated with the corresponding weight.
+	// +optional
 	Preference NodeSelectorTerm `json:"preference" protobuf:"bytes,2,opt,name=preference"`
 }
 
@@ -4268,6 +4307,7 @@ type PreferredSchedulingTerm struct {
 // any pod that does not tolerate the Taint.
 type Taint struct {
 	// Required. The taint key to be applied to a node.
+	// +required
 	Key string `json:"key" protobuf:"bytes,1,opt,name=key"`
 	// The taint value corresponding to the taint key.
 	// +optional
@@ -4275,6 +4315,7 @@ type Taint struct {
 	// Required. The effect of the taint on pods
 	// that do not tolerate the taint.
 	// Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+	// +required
 	Effect TaintEffect `json:"effect" protobuf:"bytes,3,opt,name=effect,casttype=TaintEffect"`
 	// TimeAdded represents the time at which the taint was added.
 	// +optional
@@ -4351,6 +4392,7 @@ const (
 // PodReadinessGate contains the reference to a pod condition
 type PodReadinessGate struct {
 	// ConditionType refers to a condition in the pod's condition list with matching type.
+	// +required
 	ConditionType PodConditionType `json:"conditionType" protobuf:"bytes,1,opt,name=conditionType,casttype=PodConditionType"`
 }
 
@@ -4381,6 +4423,7 @@ type PodSpec struct {
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=name
+	// +optional
 	InitContainers []Container `json:"initContainers,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,20,rep,name=initContainers"`
 	// List of containers belonging to the pod.
 	// Containers cannot currently be added or removed.
@@ -4390,6 +4433,7 @@ type PodSpec struct {
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=name
+	// +required
 	Containers []Container `json:"containers" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,2,rep,name=containers"`
 	// List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
 	// pod to perform user-initiated actions such as debugging. This list cannot be specified when
@@ -4761,6 +4805,7 @@ type PodSpec struct {
 type PodResourceClaim struct {
 	// Name uniquely identifies this resource claim inside the pod.
 	// This must be a DNS_LABEL.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,name=name"`
 
 	// Source is tombstoned since Kubernetes 1.31 where it got replaced with
@@ -4773,6 +4818,7 @@ type PodResourceClaim struct {
 	//
 	// Exactly one of ResourceClaimName and ResourceClaimTemplateName must
 	// be set.
+	// +optional
 	ResourceClaimName *string `json:"resourceClaimName,omitempty" protobuf:"bytes,3,opt,name=resourceClaimName"`
 
 	// ResourceClaimTemplateName is the name of a ResourceClaimTemplate
@@ -4800,6 +4846,7 @@ type PodResourceClaim struct {
 	//
 	// Exactly one of ResourceClaimName and ResourceClaimTemplateName must
 	// be set.
+	// +optional
 	ResourceClaimTemplateName *string `json:"resourceClaimTemplateName,omitempty" protobuf:"bytes,4,opt,name=resourceClaimTemplateName"`
 }
 
@@ -4810,6 +4857,7 @@ type PodResourceClaimStatus struct {
 	// Name uniquely identifies this resource claim inside the pod.
 	// This must match the name of an entry in pod.spec.resourceClaims,
 	// which implies that the string must be a DNS_LABEL.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,name=name"`
 
 	// ResourceClaimName is the name of the ResourceClaim that was
@@ -4835,10 +4883,12 @@ type PodExtendedResourceClaimStatus struct {
 	// RequestMappings identifies the mapping of <container, extended resource backed by DRA> to  device request
 	// in the generated ResourceClaim.
 	// +listType=atomic
+	// +required
 	RequestMappings []ContainerExtendedResourceRequest `json:"requestMappings" protobuf:"bytes,1,rep,name=requestMappings"`
 
 	// ResourceClaimName is the name of the ResourceClaim that was
 	// generated for the Pod in the namespace of the Pod.
+	// +required
 	ResourceClaimName string `json:"resourceClaimName" protobuf:"bytes,2,name=resourceClaimName"`
 }
 
@@ -4846,10 +4896,13 @@ type PodExtendedResourceClaimStatus struct {
 // extended resource name to the device request name.
 type ContainerExtendedResourceRequest struct {
 	// The name of the container requesting resources.
+	// +required
 	ContainerName string `json:"containerName" protobuf:"bytes,1,name=containerName"`
 	// The name of the extended resource in that container which gets backed by DRA.
+	// +required
 	ResourceName string `json:"resourceName" protobuf:"bytes,2,name=resourceName"`
 	// The name of the request in the special ResourceClaim which corresponds to the extended resource.
+	// +required
 	RequestName string `json:"requestName" protobuf:"bytes,3,name=requestName"`
 }
 
@@ -4868,6 +4921,7 @@ type PodOS struct {
 	// Additional value may be defined in future and can be one of:
 	// https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
 	// Clients should expect to handle additional values and treat unrecognized values in this field as os: null
+	// +required
 	Name OSName `json:"name" protobuf:"bytes,1,opt,name=name"`
 }
 
@@ -4875,6 +4929,7 @@ type PodOS struct {
 type PodSchedulingGate struct {
 	// Name of the scheduling gate.
 	// Each scheduling gate must have a unique name field.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 }
 
@@ -4937,6 +4992,7 @@ type TopologySpreadConstraint struct {
 	// When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
 	// to topologies that satisfy it.
 	// It's a required field. Default value is 1 and 0 is not allowed.
+	// +required
 	MaxSkew int32 `json:"maxSkew" protobuf:"varint,1,opt,name=maxSkew"`
 	// TopologyKey is the key of node labels. Nodes that have a label with this key
 	// and identical values are considered to be in the same topology.
@@ -4948,6 +5004,7 @@ type TopologySpreadConstraint struct {
 	// e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
 	// And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
 	// It's a required field.
+	// +required
 	TopologyKey string `json:"topologyKey" protobuf:"bytes,2,opt,name=topologyKey"`
 	// WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
 	// the spread constraint.
@@ -4970,6 +5027,7 @@ type TopologySpreadConstraint struct {
 	// MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
 	// won't make it *more* imbalanced.
 	// It's a required field.
+	// +required
 	WhenUnsatisfiable UnsatisfiableConstraintAction `json:"whenUnsatisfiable" protobuf:"bytes,3,opt,name=whenUnsatisfiable,casttype=UnsatisfiableConstraintAction"`
 	// LabelSelector is used to find matching pods.
 	// Pods that match this label selector are counted to determine the number of pods
@@ -5045,6 +5103,7 @@ type HostAlias struct {
 	IP string `json:"ip" protobuf:"bytes,1,opt,name=ip"`
 	// Hostnames for the above IP address.
 	// +listType=atomic
+	// +optional
 	Hostnames []string `json:"hostnames,omitempty" protobuf:"bytes,2,rep,name=hostnames"`
 }
 
@@ -5232,6 +5291,7 @@ type SeccompProfile struct {
 	// RuntimeDefault - the container runtime default profile should be used.
 	// Unconfined - no profile should be applied.
 	// +unionDiscriminator
+	// +required
 	Type SeccompProfileType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=SeccompProfileType"`
 	// localhostProfile indicates a profile defined in a file on the node should be used.
 	// The profile must be preconfigured on the node to work.
@@ -5264,6 +5324,7 @@ type AppArmorProfile struct {
 	//   RuntimeDefault - the container runtime's default profile.
 	//   Unconfined - no AppArmor enforcement.
 	// +unionDiscriminator
+	// +required
 	Type AppArmorProfileType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=AppArmorProfileType"`
 
 	// localhostProfile indicates a profile loaded on the node that should be used.
@@ -5328,6 +5389,7 @@ type PodDNSConfig struct {
 type PodDNSConfigOption struct {
 	// Name is this DNS resolver option's name.
 	// Required.
+	// +required
 	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
 	// Value is this DNS resolver option's value.
 	// +optional
@@ -5355,9 +5417,11 @@ type HostIP struct {
 type EphemeralContainerCommon struct {
 	// Name of the ephemeral container specified as a DNS_LABEL.
 	// This name must be unique among all containers, init containers and ephemeral containers.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 	// Container image name.
 	// More info: https://kubernetes.io/docs/concepts/containers/images
+	// +required
 	Image string `json:"image,omitempty" protobuf:"bytes,2,opt,name=image"`
 	// Entrypoint array. Not executed within a shell.
 	// The image's ENTRYPOINT is used if this is not provided.
@@ -5679,6 +5743,7 @@ type PodStatus struct {
 	// ignored.
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-and-container-status
 	// +listType=atomic
+	// +optional
 	InitContainerStatuses []ContainerStatus `json:"initContainerStatuses,omitempty" protobuf:"bytes,10,rep,name=initContainerStatuses"`
 
 	// Statuses of containers in this pod.
@@ -5797,7 +5862,7 @@ type Pod struct {
 
 	// Specification of the desired behavior of the pod.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec PodSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 
 	// Most recently observed status of the pod.
@@ -5835,7 +5900,7 @@ type PodTemplateSpec struct {
 
 	// Specification of the desired behavior of the pod.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec PodSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 
@@ -5853,7 +5918,7 @@ type PodTemplate struct {
 
 	// Template defines the pods that will be created from this pod template.
 	// https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Template PodTemplateSpec `json:"template,omitempty" protobuf:"bytes,2,opt,name=template"`
 }
 
@@ -8786,8 +8851,10 @@ const (
 // Sysctl defines a kernel parameter to be set
 type Sysctl struct {
 	// Name of a property to set
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 	// Value of a property to set
+	// +optional
 	Value string `json:"value" protobuf:"bytes,2,opt,name=value"`
 }
 


### PR DESCRIPTION
Continues the per-chunk rollout of the `optionalorrequired` lint rule for the `core` API group (part of #136865, follow-up to #140587). This chunk covers the Pod, Container, EnvVar, Probe/Handler, PodSpec/PodStatus, scheduling (affinity/taints/topology spread), and DNS/sysctl types in `staging/src/k8s.io/api/core/v1/types.go`.

65 `+optional`/`+required` markers added.

