### PR TITLE
nominate pacoxu as SIG Scheduling reviewer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -183,18 +183,19 @@ aliases:
   # - wojtek-t
   sig-scheduling:
     - ania-borowiec
+    - Argh4k
     - AxeZhan
     - brejman
     - damemi
     - denkensk
     - dom4ha
+    - kerthcet
     - macsko
     - mm4tt
+    - pacoxu
     - sanposhiho
     - tosi3k
     - utam0k
-    - kerthcet
-    - Argh4k
   # emeritus:
   # - adtac
   # - liu-cong


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:

I would like to self-nominate as a SIG Scheduling reviewer.

I have been a member of the Kubernetes organization since September 2020:
https://github.com/kubernetes/org/issues/2158

I have also served as a SIG Node reviewer since 2021:
https://github.com/kubernetes/kubernetes/pull/104186

Primary or active reviewer for at least 5 SIG Scheduling PRs:

- https://github.com/kubernetes/kubernetes/pull/141021
- https://github.com/kubernetes/kubernetes/pull/141568
- https://github.com/kubernetes/kubernetes/pull/140289
- https://github.com/kubernetes/kubernetes/pull/138849
- https://github.com/kubernetes/kubernetes/pull/138951
- https://github.com/kubernetes/kubernetes/pull/139572
- https://github.com/kubernetes/kubernetes/pull/139472

Reviewed or merged at least 20 PRs related to SIG Scheduling:

- [Recent SIG Scheduling PRs reviewed by me](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+-author%3Apacoxu+reviewed-by%3Apacoxu+label%3Asig%2Fscheduling+updated%3A%3E%3D2026-03-01)
- [Recent SIG Scheduling PRs authored and merged by me](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+is%3Amerged+author%3Apacoxu+label%3Asig%2Fscheduling+merged%3A%3E%3D2026-03-01)

Some representative reviews of larger topics include:

- Multi-level topology-aware scheduling:
  https://github.com/kubernetes/kubernetes/pull/140638
- CompositePodGroup APIs and workload builder:
  https://github.com/kubernetes/kubernetes/pull/140717
- NominatedNodeName support in TAS placement selection:
  https://github.com/kubernetes/kubernetes/pull/139472
- CompositePodGroup protection and garbage collection:
  https://github.com/kubernetes/kubernetes/pull/141021
- Opportunistic batching rescoring:
  https://github.com/kubernetes/kubernetes/pull/140289
- Scheduler framework scored-node handling:
  https://github.com/kubernetes/kubernetes/pull/138849
- Taint eviction retry correctness:
  https://github.com/kubernetes/kubernetes/pull/141568

I plan to continue contributing to scheduler correctness and performance,
particularly around queueing, nomination, asynchronous preemption,
workload-aware scheduling, PodGroups, and topology-aware scheduling. I also
plan to continue taking ownership of reviews and following scheduler
regressions through investigation and resolution.

Some current authored work includes:

- https://github.com/kubernetes/kubernetes/pull/141708
- https://github.com/kubernetes/kubernetes/pull/140071
- https://github.com/kubernetes/kubernetes/pull/140307

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
/sig scheduling

Other scheduling related works
- https://github.com/kubernetes-sigs/lws/pull/979/
- https://github.com/kubernetes/website/pull/57242
- https://github.com/kubernetes/website/pull/55364

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```

```

AI disclosure: AI was used to help summarize my public contribution history and draft this description. I verified the linked PRs and the final text.