### PR TITLE
test: remove tCtx.Cancel workarounds

### DIFF
--- a/pkg/controller/devicetainteviction/device_taint_eviction_test.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction_test.go
@@ -2385,11 +2385,10 @@ func testEviction(tCtx ktesting.TContext) {
 			controller := newTestController(tCtx)
 
 			var wg sync.WaitGroup
-			defer func() {
+			tCtx.Cleanup(func() {
 				tCtx.Log("Waiting for goroutine termination...")
-				tCtx.Cancel("time to stop")
 				wg.Wait()
-			}()
+			})
 			wg.Go(func() {
 				tCtx.AssertNoError(controller.Run(tCtx, 10 /* workers */), "eviction controller failed")
 			})
@@ -2483,11 +2482,10 @@ func synctestDeviceTaintRule(tCtx ktesting.TContext, toleration, slowDelete bool
 	controller := newTestController(tCtx)
 
 	var wg sync.WaitGroup
-	defer func() {
+	tCtx.Cleanup(func() {
 		tCtx.Log("Waiting for goroutine termination...")
-		tCtx.Cancel("time to stop")
 		wg.Wait()
-	}()
+	})
 	wg.Go(func() {
 		// Run with 1 worker to ensure sequential execution. Concurrent workers cause
 		// non-deterministic ordering of status updates, leading to flakes in Status assertions.
@@ -2687,11 +2685,10 @@ func doCancelEviction(tCtx ktesting.TContext, deletePod bool) {
 	}
 
 	var wg sync.WaitGroup
-	defer func() {
+	tCtx.Cleanup(func() {
 		tCtx.Log("Waiting for goroutine termination...")
-		tCtx.Cancel("time to stop")
 		wg.Wait()
-	}()
+	})
 	wg.Go(func() {
 		tCtx.AssertNoError(controller.Run(tCtx, 10 /* workers */), "eviction controller failed")
 	})
@@ -2784,11 +2781,10 @@ func synctestParallelPodDeletion(tCtx ktesting.TContext) {
 	controller := newTestController(tCtx)
 
 	var wg sync.WaitGroup
-	defer func() {
+	tCtx.Cleanup(func() {
 		tCtx.Log("Waiting for goroutine termination...")
-		tCtx.Cancel("time to stop")
 		wg.Wait()
-	}()
+	})
 	wg.Go(func() {
 		tCtx.AssertNoError(controller.Run(tCtx, 10 /* workers */), "eviction controller failed")
 	})
@@ -2851,11 +2847,10 @@ func synctestRetry(tCtx ktesting.TContext) {
 	controller := newTestController(tCtx)
 
 	var wg sync.WaitGroup
-	defer func() {
+	tCtx.Cleanup(func() {
 		tCtx.Log("Waiting for goroutine termination...")
-		tCtx.Cancel("time to stop")
 		wg.Wait()
-	}()
+	})
 	wg.Go(func() {
 		tCtx.AssertNoError(controller.Run(tCtx, 10 /* workers */), "eviction controller failed")
 	})

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -1039,10 +1039,9 @@ func TestGarbageCollectorSync(t *testing.T) {
 	sharedInformers := informers.NewSharedInformerFactory(client, 0)
 
 	var wg sync.WaitGroup
-	defer wg.Wait()
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
+	tCtx.Cleanup(wg.Wait)
 	logger := tCtx.Logger()
 
 	alwaysStarted := make(chan struct{})

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -1656,7 +1656,6 @@ func testEventHandlers(tCtx ktesting.TContext) {
 
 			informerFactory.StartWithContext(tCtx)
 			stopInformers := func() {
-				tCtx.Cancel("stopping informers")
 				informerFactory.Shutdown()
 			}
 			tCtx.Cleanup(stopInformers)

--- a/pkg/controller/serviceaccount/serviceaccounts_controller_test.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller_test.go
@@ -166,11 +166,10 @@ func TestServiceAccountCreation(t *testing.T) {
 			nsInformer := informers.Core().V1().Namespaces()
 
 			var wg sync.WaitGroup
-			defer wg.Wait()
 
 			tCtx := ktesting.Init(t)
+			tCtx.Cleanup(wg.Wait)
 			logger := tCtx.Logger()
-			defer tCtx.Cancel("test case terminating")
 
 			controller, err := NewServiceAccountsController(
 				tCtx,

--- a/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
@@ -298,8 +298,7 @@ func attachDetachRecoveryTestCase(t *testing.T, extraPods1 []*v1.Pod, extraPods2
 
 	// Create the controller
 	var wg sync.WaitGroup
-	defer wg.Wait()
-	defer tCtx.Cancel("test case terminating")
+	tCtx.Cleanup(wg.Wait)
 
 	adcObj, err := NewAttachDetachController(
 		tCtx,
@@ -569,8 +568,7 @@ func volumeAttachmentRecoveryTestCase(t *testing.T, tc vaTest) {
 
 	// Create the controller
 	var wg sync.WaitGroup
-	defer wg.Wait()
-	defer tCtx.Cancel("test case terminating")
+	tCtx.Cleanup(wg.Wait)
 
 	adc := createADC(t, tCtx, fakeKubeClient, informerFactory, plugins)
 

--- a/pkg/controlplane/apiserver/samples/generic/server/testing/testserver.go
+++ b/pkg/controlplane/apiserver/samples/generic/server/testing/testserver.go
@@ -93,6 +93,8 @@ func NewDefaultTestServerOptions() *TestServerInstanceOptions {
 // and its backing store.
 func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, customFlags []string, storageConfig *storagebackend.Config) (result TestServer, err error) {
 	tCtx := ktesting.Init(t)
+	var runCtx context.Context = tCtx
+	cancelRun := func(error) {}
 
 	if instanceOptions == nil {
 		instanceOptions = NewDefaultTestServerOptions()
@@ -107,7 +109,7 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 	tearDown := func() {
 		// Cancel is stopping apiserver and cleaning up
 		// after itself, including shutting down its storage layer.
-		tCtx.Cancel("tearing down")
+		cancelRun(fmt.Errorf("tearing down"))
 
 		// If the apiserver was started, let's wait for it to
 		// shutdown clearly.
@@ -194,13 +196,19 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 		return result, fmt.Errorf("failed to create server chain: %w", err)
 	}
 
+	runCtx, cancelRun = context.WithCancelCause(tCtx)
+	defer func() {
+		if result.TearDownFn == nil {
+			cancelRun(fmt.Errorf("startup failed"))
+		}
+	}()
 	errCh = make(chan error)
 	go func() {
 		defer close(errCh)
 		prepared, err := s.PrepareRun()
 		if err != nil {
 			errCh <- err
-		} else if err := prepared.Run(tCtx); err != nil {
+		} else if err := prepared.Run(runCtx); err != nil {
 			errCh <- err
 		}
 	}()

--- a/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager_test.go
+++ b/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager_test.go
@@ -131,7 +131,6 @@ func TestGetTrustAnchorsByName(t *testing.T) {
 }
 
 func testGetTrustAnchorsByName[T clusterTrustBundle](tCtx ktesting.TContext, b testingFunctionBundle[T]) {
-	defer tCtx.Cancel("test completed")
 	t := tCtx.TB()
 
 	ctb1Bundle := mustMakeRoot(t, "root1")
@@ -188,7 +187,6 @@ func TestGetTrustAnchorsByNameCaching(t *testing.T) {
 }
 
 func testGetTrustAnchorsByNameCaching[T clusterTrustBundle](tCtx ktesting.TContext, b testingFunctionBundle[T]) {
-	defer tCtx.Cancel("test completed")
 	t := tCtx.TB()
 
 	ctb1Bundle := mustMakeRoot(t, "root1")
@@ -273,7 +271,6 @@ func TestGetTrustAnchorsBySignerName(t *testing.T) {
 }
 
 func testGetTrustAnchorsBySignerName[T clusterTrustBundle](tCtx ktesting.TContext, b testingFunctionBundle[T]) {
-	defer tCtx.Cancel("test completed")
 	t := tCtx.TB()
 
 	ctb1 := b.ctbConstructor("signer-a-label-a-1", "foo.bar/a", map[string]string{"label": "a"}, mustMakeRoot(t, "0"))
@@ -404,7 +401,6 @@ func TestGetTrustAnchorsBySignerNameCaching(t *testing.T) {
 }
 
 func testGetTrustAnchorsBySignerNameCaching[T clusterTrustBundle](tCtx ktesting.TContext, b testingFunctionBundle[T]) {
-	defer tCtx.Cancel("test completed")
 	t := tCtx.TB()
 
 	ctb1 := b.ctbConstructor("signer-a-label-a-1", "foo.bar/a", map[string]string{"label": "a"}, mustMakeRoot(t, "0"))

--- a/pkg/kubelet/config/mux_test.go
+++ b/pkg/kubelet/config/mux_test.go
@@ -30,7 +30,6 @@ import (
 
 func TestConfigurationChannels(t *testing.T) {
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("TestConfigurationChannels completed")
 
 	mux := newMux(nil)
 	channelOne := mux.ChannelWithContext(tCtx, "one")
@@ -45,7 +44,6 @@ func TestConfigurationChannels(t *testing.T) {
 
 func TestMergeInvoked(t *testing.T) {
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("TestMergeInvoked completed")
 
 	const expectedSource = "one"
 	done := make(chan interface{})
@@ -83,7 +81,6 @@ func (f mergeFunc) Merge(ctx context.Context, source string, update sourceUpdate
 
 func TestSimultaneousMerge(t *testing.T) {
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("TestSimultaneousMerge completed")
 
 	ch := make(chan bool, 2)
 	mux := newMux(mergeFunc(func(ctx context.Context, source string, update sourceUpdate) error {

--- a/pkg/kubelet/images/image_gc_manager_test.go
+++ b/pkg/kubelet/images/image_gc_manager_test.go
@@ -503,7 +503,6 @@ func TestDeleteUnusedImagesLimitByImageLiveTime(t *testing.T) {
 }
 
 func testDeleteUnusedImagesLimitByImageLiveTime(tCtx ktesting.TContext) {
-	defer tCtx.Cancel("test completed")
 	t := tCtx.TB()
 	mockStatsProvider := statstest.NewMockProvider(t)
 

--- a/pkg/kubelet/kubelet_volumes_test.go
+++ b/pkg/kubelet/kubelet_volumes_test.go
@@ -81,7 +81,6 @@ func TestListVolumesForPod(t *testing.T) {
 	})
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 	go kubelet.volumeManager.Run(tCtx, kubelet.sourcesReady)
 
 	kubelet.podManager.SetPods([]*v1.Pod{pod})
@@ -200,7 +199,6 @@ func TestPodVolumesExist(t *testing.T) {
 	}
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 
 	go kubelet.volumeManager.Run(tCtx, kubelet.sourcesReady)
 
@@ -261,7 +259,6 @@ func TestPodVolumeDeadlineAttachAndMount(t *testing.T) {
 	}
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 	go kubelet.volumeManager.Run(tCtx, kubelet.sourcesReady)
 
 	kubelet.podManager.SetPods(pods)
@@ -323,7 +320,6 @@ func TestPodVolumeDeadlineUnmount(t *testing.T) {
 	}
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 	go kubelet.volumeManager.Run(tCtx, kubelet.sourcesReady)
 
 	kubelet.podManager.SetPods(pods)
@@ -377,7 +373,6 @@ func TestVolumeAttachAndMountControllerDisabled(t *testing.T) {
 	})
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 	go kubelet.volumeManager.Run(tCtx, kubelet.sourcesReady)
 
 	kubelet.podManager.SetPods([]*v1.Pod{pod})
@@ -437,7 +432,6 @@ func TestVolumeUnmountAndDetachControllerDisabled(t *testing.T) {
 	})
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 	go kubelet.volumeManager.Run(tCtx, kubelet.sourcesReady)
 
 	// Add pod
@@ -540,7 +534,6 @@ func TestVolumeAttachAndMountControllerEnabled(t *testing.T) {
 	})
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 	go kubelet.volumeManager.Run(tCtx, kubelet.sourcesReady)
 
 	kubelet.podManager.SetPods([]*v1.Pod{pod})
@@ -625,7 +618,6 @@ func TestVolumeUnmountAndDetachControllerEnabled(t *testing.T) {
 	})
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 	go kubelet.volumeManager.Run(tCtx, kubelet.sourcesReady)
 
 	// Add pod

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux_test.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux_test.go
@@ -323,7 +323,6 @@ func TestManager(t *testing.T) {
 
 	for _, tc := range tests {
 		tCtx.SyncTest(tc.desc, func(tCtx ktesting.TContext) {
-			defer tCtx.Cancel("test completed")
 			t := tCtx.TB()
 			logger := tCtx.Logger()
 
@@ -486,7 +485,6 @@ func TestRestart(t *testing.T) {
 }
 
 func testRestart(tCtx ktesting.TContext) {
-	defer tCtx.Cancel("test completed")
 	logger := tCtx.Logger()
 	t := tCtx.TB()
 	systemDbusTmp := systemDbus
@@ -564,7 +562,6 @@ func TestStartDoesNotReconnectAfterContextCancel(t *testing.T) {
 }
 
 func testStartDoesNotReconnectAfterContextCancel(tCtx ktesting.TContext) {
-	defer tCtx.Cancel("test completed")
 	logger := tCtx.Logger()
 	t := tCtx.TB()
 
@@ -865,7 +862,6 @@ func TestRestartClosesOldConnection(t *testing.T) {
 }
 
 func testRestartClosesOldConnection(tCtx ktesting.TContext) {
-	defer tCtx.Cancel("test completed")
 	logger := tCtx.Logger()
 	t := tCtx.TB()
 

--- a/pkg/kubelet/prober/prober_manager_test.go
+++ b/pkg/kubelet/prober/prober_manager_test.go
@@ -146,7 +146,6 @@ func TestAddPodContinuesAfterExistingWorker(t *testing.T) {
 }
 
 func testAddPodContinuesAfterExistingWorker(tCtx ktesting.TContext) {
-	defer tCtx.Cancel("test completed")
 	t := tCtx.TB()
 	ctx := tCtx.Context
 

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -111,7 +111,6 @@ func TestGetMountedVolumesForPodAndGetVolumesInUse(t *testing.T) {
 			manager := newTestVolumeManager(t, tmpDir, podManager, kubeClient, node)
 
 			tCtx := ktesting.Init(t)
-			defer tCtx.Cancel("test has completed")
 			sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
 			go manager.Run(tCtx, sourcesReady)
 
@@ -238,7 +237,6 @@ func TestWaitForAttachAndMountError(t *testing.T) {
 	manager := newTestVolumeManager(t, tmpDir, podManager, kubeClient, nil)
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
 	go manager.Run(tCtx, sourcesReady)
 
@@ -329,7 +327,6 @@ func TestWaitForAttachAndMountVolumeAttachLimitExceededError(t *testing.T) {
 		0)
 
 	tCtx := ktesting.Init(t)
-	t.Cleanup(func() { tCtx.Cancel("test has completed") })
 	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
 	go manager.Run(tCtx, sourcesReady)
 	podManager.SetPods([]*v1.Pod{pod})
@@ -366,7 +363,6 @@ func TestInitialPendingVolumesForPodAndGetVolumesInUse(t *testing.T) {
 
 	manager := newTestVolumeManager(t, tmpDir, podManager, kubeClient, node)
 
-	defer tCtx.Cancel("test has completed")
 	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
 	go manager.Run(tCtx, sourcesReady)
 
@@ -457,7 +453,6 @@ func TestGetExtraSupplementalGroupsForPod(t *testing.T) {
 		manager := newTestVolumeManager(t, tmpDir, podManager, kubeClient, node)
 
 		tCtx := ktesting.Init(t)
-		defer tCtx.Cancel("test has completed")
 		sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
 		go manager.Run(tCtx, sourcesReady)
 

--- a/pkg/kubelet/watchdog/watchdog_linux_test.go
+++ b/pkg/kubelet/watchdog/watchdog_linux_test.go
@@ -156,9 +156,6 @@ func TestHealthCheckerStart(t *testing.T) {
 		tCtx.SyncTest(tt.name, func(tCtx ktesting.TContext) {
 			tCtx = ktesting.Init(tCtx, initoption.BufferLogs(true))
 			logger := tCtx.Logger()
-			defer func() {
-				tCtx.Cancel("test has completed")
-			}()
 
 			// Mock SdWatchdogEnabled to return a valid value
 			mockClient := &mockWatchdogClient{

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -4657,7 +4657,6 @@ func setup(tCtx ktesting.TContext, args *config.DynamicResourcesArgs, nodes []*v
 	fh, err := runtime.NewFramework(tCtx, nil, nil, opts...)
 	tCtx.ExpectNoError(err, "create scheduler framework")
 	tCtx.Cleanup(func() {
-		tCtx.Cancel("test has completed")
 		runtime.WaitForShutdown(fh)
 	})
 
@@ -4685,8 +4684,6 @@ func setup(tCtx ktesting.TContext, args *config.DynamicResourcesArgs, nodes []*v
 
 	tc.informerFactory.Start(tCtx.Done())
 	tCtx.Cleanup(func() {
-		// Need to cancel before waiting for the shutdown.
-		tCtx.Cancel("test is done")
 		// Now we can wait for all goroutines to stop.
 		tc.informerFactory.Shutdown()
 	})

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
@@ -324,10 +324,9 @@ func testNodeResourcesBalancedAllocation(tCtx ktesting.TContext) {
 			featuregatetesting.SetFeatureGateDuringTest(tCtx, utilfeature.DefaultFeatureGate, features.DRAExtendedResource, test.draObjects != nil)
 			snapshot := cache.NewSnapshot(test.existingPods, test.nodes)
 			fh, _ := runtime.NewFramework(tCtx, nil, nil, runtime.WithSnapshotSharedLister(snapshot))
-			defer func() {
-				tCtx.Cancel("test has completed")
+			tCtx.Cleanup(func() {
 				runtime.WaitForShutdown(fh)
-			}()
+			})
 			p, _ := NewBalancedAllocation(tCtx, &test.args, fh, feature.Features{
 				EnableDRAExtendedResource: test.draObjects != nil,
 			})
@@ -445,12 +444,10 @@ func testBalancedAllocationSignPod(tCtx ktesting.TContext) {
 			} else {
 				featuregatetesting.SetFeatureGateEmulationVersionDuringTest(tCtx, utilfeature.DefaultFeatureGate, version.MustParse("1.36"))
 			}
-
 			fh, _ := runtime.NewFramework(tCtx, nil, nil, runOpts...)
-			defer func() {
-				tCtx.Cancel("test has completed")
+			tCtx.Cleanup(func() {
 				runtime.WaitForShutdown(fh)
-			}()
+			})
 
 			p, err := NewBalancedAllocation(tCtx, &config.NodeResourcesBalancedAllocationArgs{}, fh, feature.Features{
 				EnableDRAExtendedResource: !test.disableDRAExtendedResource,

--- a/pkg/scheduler/framework/plugins/noderesources/fit_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit_test.go
@@ -722,10 +722,9 @@ func testEnoughRequests(tCtx ktesting.TContext) {
 				runOpts = append(runOpts, runtime.WithSharedDRAManager(testDRAManager))
 			}
 			fh, _ := runtime.NewFramework(tCtx, nil, nil, runOpts...)
-			defer func() {
-				tCtx.Cancel("test has completed")
+			tCtx.Cleanup(func() {
 				runtime.WaitForShutdown(fh)
-			}()
+			})
 			p, err := NewFit(tCtx, &test.args, fh, plfeature.Features{EnablePodLevelResources: test.podLevelResourcesEnabled, EnableDRAExtendedResource: test.draExtendedResourceEnabled})
 			tCtx.ExpectNoError(err, "create fit plugin")
 			cycleState := framework.NewCycleState()
@@ -1261,10 +1260,9 @@ func testFitScore(tCtx ktesting.TContext) {
 			state := framework.NewCycleState()
 			snapshot := cache.NewSnapshot(test.existingPods, test.nodes)
 			fh, _ := runtime.NewFramework(tCtx, nil, nil, runtime.WithSnapshotSharedLister(snapshot))
-			defer func() {
-				tCtx.Cancel("test has completed")
+			tCtx.Cleanup(func() {
 				runtime.WaitForShutdown(fh)
-			}()
+			})
 			args := test.nodeResourcesFitArgs
 			p, err := NewFit(tCtx, &args, fh, plfeature.Features{
 				EnableDRAExtendedResource: test.draObjects != nil,
@@ -2439,10 +2437,9 @@ func testFitSignPod(tCtx ktesting.TContext) {
 				runOpts = append(runOpts, runtime.WithSharedDRAManager(testDRAManager))
 			}
 			fh, _ := runtime.NewFramework(tCtx, nil, nil, runOpts...)
-			defer func() {
-				tCtx.Cancel("test has completed")
+			tCtx.Cleanup(func() {
 				runtime.WaitForShutdown(fh)
-			}()
+			})
 
 			p, err := NewFit(tCtx, &config.NodeResourcesFitArgs{ScoringStrategy: defaultScoringStrategy}, fh, plfeature.Features{
 				EnableDRAExtendedResource: !test.disableDRAExtendedResource,
@@ -3266,10 +3263,9 @@ func TestDeferredResizeFit(t *testing.T) {
 			nodeInfo.SetNode(&node)
 
 			fh, _ := runtime.NewFramework(tCtx, nil, nil)
-			defer func() {
-				tCtx.Cancel("test has completed")
+			tCtx.Cleanup(func() {
 				runtime.WaitForShutdown(fh)
-			}()
+			})
 
 			p, err := NewFit(tCtx, &config.NodeResourcesFitArgs{ScoringStrategy: defaultScoringStrategy}, fh, plfeature.Features{
 				EnablePodLevelResources:                            true,

--- a/pkg/scheduler/framework/plugins/noderesources/resource_allocation_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_allocation_test.go
@@ -619,7 +619,6 @@ func newTestDRAManager(tCtx ktesting.TContext, objects ...apiruntime.Object) *dy
 
 	informerFactory.Start(tCtx.Done())
 	tCtx.Cleanup(func() {
-		tCtx.Cancel("test has completed")
 		// Now we can wait for all goroutines to stop.
 		informerFactory.Shutdown()
 	})

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -106,7 +106,6 @@ func setupWithResources(t *testing.T, groupVersions []schema.GroupVersion, resou
 	})
 
 	newTeardown := func() {
-		tCtx.Cancel("tearing down apiserver")
 		teardown()
 	}
 

--- a/test/integration/apiserver/flowcontrol/concurrency_test.go
+++ b/test/integration/apiserver/flowcontrol/concurrency_test.go
@@ -60,7 +60,6 @@ func setup(t testing.TB, maxReadonlyRequestsInFlight, maxMutatingRequestsInFligh
 	})
 
 	newTeardown := func() {
-		tCtx.Cancel("tearing down apiserver")
 		tearDownFn()
 	}
 	return tCtx, kubeConfig, newTeardown

--- a/test/integration/cronjob/cronjob_test.go
+++ b/test/integration/cronjob/cronjob_test.go
@@ -151,10 +151,7 @@ func TestCronJobLaunchesPodAndCleansUp(t *testing.T) {
 	tCtx := ktesting.Init(t)
 
 	closeFn, cjc, jc, informerSet, clientSet := setup(tCtx, t)
-	defer closeFn()
-
-	// When shutting down, cancel must be called before closeFn.
-	defer tCtx.Cancel("test has completed")
+	tCtx.Cleanup(closeFn)
 
 	cronJobName := "foo"
 	namespaceName := "simple-cronjob-test"

--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -42,7 +42,6 @@ import (
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
-	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/daemon"
@@ -57,11 +56,11 @@ import (
 
 var zero = int64(0)
 
-func setup(t *testing.T) (context.Context, kubeapiservertesting.TearDownFunc, *daemon.DaemonSetsController, informers.SharedInformerFactory, clientset.Interface) {
+func setup(t *testing.T) (context.Context, *daemon.DaemonSetsController, informers.SharedInformerFactory, clientset.Interface) {
 	return setupWithServerSetup(t, framework.TestServerSetup{})
 }
 
-func setupWithServerSetup(t *testing.T, serverSetup framework.TestServerSetup) (context.Context, kubeapiservertesting.TearDownFunc, *daemon.DaemonSetsController, informers.SharedInformerFactory, clientset.Interface) {
+func setupWithServerSetup(t *testing.T, serverSetup framework.TestServerSetup) (context.Context, *daemon.DaemonSetsController, informers.SharedInformerFactory, clientset.Interface) {
 	tCtx := ktesting.Init(t)
 	modifyServerRunOptions := serverSetup.ModifyServerRunOptions
 	serverSetup.ModifyServerRunOptions = func(opts *options.ServerRunOptions) {
@@ -112,13 +111,16 @@ func setupWithServerSetup(t *testing.T, serverSetup framework.TestServerSetup) (
 	eventBroadcaster.StartRecordingToSink(tCtx.Done())
 	go sched.Run(tCtx)
 
-	tearDownFn := func() {
-		tCtx.Cancel("tearing down apiserver")
+	// The scheduler above (and the DaemonSets controller started by the
+	// caller) run with tCtx, so tCtx must get canceled before the server
+	// shuts down, to avoid them logging errors while (or after) the test
+	// binary considers the test done.
+	tCtx.Cleanup(func() {
 		closeFn()
 		eventBroadcaster.Shutdown()
-	}
+	})
 
-	return tCtx, tearDownFn, dc, informers, clientSet
+	return tCtx, dc, informers, clientSet
 }
 
 func testLabels() map[string]string {
@@ -532,8 +534,7 @@ func forEachStrategy(t *testing.T, tf func(t *testing.T, strategy *apps.DaemonSe
 
 func TestOneNodeDaemonLaunchesPod(t *testing.T) {
 	forEachStrategy(t, func(t *testing.T, strategy *apps.DaemonSetUpdateStrategy) {
-		ctx, closeFn, dc, informers, clientset := setup(t)
-		defer closeFn()
+		ctx, dc, informers, clientset := setup(t)
 		ns := framework.CreateNamespaceOrDie(clientset, "one-node-daemonset-test", t)
 		defer framework.DeleteNamespaceOrDie(clientset, ns, t)
 
@@ -565,8 +566,7 @@ func TestOneNodeDaemonLaunchesPod(t *testing.T) {
 
 func TestSimpleDaemonSetLaunchesPods(t *testing.T) {
 	forEachStrategy(t, func(t *testing.T, strategy *apps.DaemonSetUpdateStrategy) {
-		ctx, closeFn, dc, informers, clientset := setup(t)
-		defer closeFn()
+		ctx, dc, informers, clientset := setup(t)
 		ns := framework.CreateNamespaceOrDie(clientset, "simple-daemonset-test", t)
 		defer framework.DeleteNamespaceOrDie(clientset, ns, t)
 
@@ -612,8 +612,7 @@ func TestSimpleDaemonSetRestartsPodsOnTerminalPhase(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			forEachStrategy(t, func(t *testing.T, strategy *apps.DaemonSetUpdateStrategy) {
-				ctx, closeFn, dc, informers, clientset := setup(t)
-				defer closeFn()
+				ctx, dc, informers, clientset := setup(t)
 				ns := framework.CreateNamespaceOrDie(clientset, "daemonset-restart-terminal-pod-test", t)
 				defer framework.DeleteNamespaceOrDie(clientset, ns, t)
 
@@ -657,8 +656,7 @@ func TestSimpleDaemonSetRestartsPodsOnTerminalPhase(t *testing.T) {
 
 func TestDaemonSetWithNodeSelectorLaunchesPods(t *testing.T) {
 	forEachStrategy(t, func(t *testing.T, strategy *apps.DaemonSetUpdateStrategy) {
-		ctx, closeFn, dc, informers, clientset := setup(t)
-		defer closeFn()
+		ctx, dc, informers, clientset := setup(t)
 		ns := framework.CreateNamespaceOrDie(clientset, "simple-daemonset-test", t)
 		defer framework.DeleteNamespaceOrDie(clientset, ns, t)
 
@@ -720,8 +718,7 @@ func TestDaemonSetWithNodeSelectorLaunchesPods(t *testing.T) {
 
 func TestNotReadyNodeDaemonDoesLaunchPod(t *testing.T) {
 	forEachStrategy(t, func(t *testing.T, strategy *apps.DaemonSetUpdateStrategy) {
-		ctx, closeFn, dc, informers, clientset := setup(t)
-		defer closeFn()
+		ctx, dc, informers, clientset := setup(t)
 		ns := framework.CreateNamespaceOrDie(clientset, "simple-daemonset-test", t)
 		defer framework.DeleteNamespaceOrDie(clientset, ns, t)
 
@@ -761,8 +758,7 @@ func TestNotReadyNodeDaemonDoesLaunchPod(t *testing.T) {
 // not schedule Pods onto the nodes with insufficient resource.
 func TestInsufficientCapacityNode(t *testing.T) {
 	forEachStrategy(t, func(t *testing.T, strategy *apps.DaemonSetUpdateStrategy) {
-		ctx, closeFn, dc, informers, clientset := setup(t)
-		defer closeFn()
+		ctx, dc, informers, clientset := setup(t)
 		ns := framework.CreateNamespaceOrDie(clientset, "insufficient-capacity", t)
 		defer framework.DeleteNamespaceOrDie(clientset, ns, t)
 
@@ -819,8 +815,7 @@ func TestInsufficientCapacityNode(t *testing.T) {
 // TestLaunchWithHashCollision tests that a DaemonSet can be updated even if there is a
 // hash collision with an existing ControllerRevision
 func TestLaunchWithHashCollision(t *testing.T) {
-	ctx, closeFn, dc, informers, clientset := setup(t)
-	defer closeFn()
+	ctx, dc, informers, clientset := setup(t)
 	ns := framework.CreateNamespaceOrDie(clientset, "one-node-daemonset-test", t)
 	defer framework.DeleteNamespaceOrDie(clientset, ns, t)
 
@@ -924,8 +919,7 @@ func TestLaunchWithHashCollision(t *testing.T) {
 // 2. Add a node to ensure the controller sync
 // 3. The dsc is expected to "PATCH" the existing pod label with new hash and deletes the old controllerrevision once finishes the update
 func TestDSCUpdatesPodLabelAfterDedupCurHistories(t *testing.T) {
-	ctx, closeFn, dc, informers, clientset := setup(t)
-	defer closeFn()
+	ctx, dc, informers, clientset := setup(t)
 	ns := framework.CreateNamespaceOrDie(clientset, "one-node-daemonset-test", t)
 	defer framework.DeleteNamespaceOrDie(clientset, ns, t)
 
@@ -1053,8 +1047,7 @@ func TestDSCUpdatesPodLabelAfterDedupCurHistories(t *testing.T) {
 // TestTaintedNode tests tainted node isn't expected to have pod scheduled
 func TestTaintedNode(t *testing.T) {
 	forEachStrategy(t, func(t *testing.T, strategy *apps.DaemonSetUpdateStrategy) {
-		ctx, closeFn, dc, informers, clientset := setup(t)
-		defer closeFn()
+		ctx, dc, informers, clientset := setup(t)
 		ns := framework.CreateNamespaceOrDie(clientset, "tainted-node", t)
 		defer framework.DeleteNamespaceOrDie(clientset, ns, t)
 
@@ -1112,8 +1105,7 @@ func TestTaintedNode(t *testing.T) {
 // to the Unschedulable nodes.
 func TestUnschedulableNodeDaemonDoesLaunchPod(t *testing.T) {
 	forEachStrategy(t, func(t *testing.T, strategy *apps.DaemonSetUpdateStrategy) {
-		ctx, closeFn, dc, informers, clientset := setup(t)
-		defer closeFn()
+		ctx, dc, informers, clientset := setup(t)
 		ns := framework.CreateNamespaceOrDie(clientset, "daemonset-unschedulable-test", t)
 		defer framework.DeleteNamespaceOrDie(clientset, ns, t)
 
@@ -1176,14 +1168,13 @@ func TestUnschedulableNodeDaemonDoesLaunchPod(t *testing.T) {
 func TestUpdateStatusDespitePodCreationFailure(t *testing.T) {
 	forEachStrategy(t, func(t *testing.T, strategy *apps.DaemonSetUpdateStrategy) {
 		limitedPodNumber := 2
-		ctx, closeFn, dc, informers, clientset := setupWithServerSetup(t, framework.TestServerSetup{
+		ctx, dc, informers, clientset := setupWithServerSetup(t, framework.TestServerSetup{
 			ModifyServerConfig: func(config *controlplane.Config) {
 				config.ControlPlane.Generic.AdmissionControl = &fakePodFailAdmission{
 					limitedPodNumber: limitedPodNumber,
 				}
 			},
 		})
-		defer closeFn()
 		ns := framework.CreateNamespaceOrDie(clientset, "update-status-despite-pod-failure", t)
 		defer framework.DeleteNamespaceOrDie(clientset, ns, t)
 
@@ -1214,8 +1205,7 @@ func TestDaemonSetRollingUpdateWithTolerations(t *testing.T) {
 	var taints []v1.Taint
 	var node *v1.Node
 	var tolerations []v1.Toleration
-	ctx, closeFn, dc, informers, clientset := setup(t)
-	defer closeFn()
+	ctx, dc, informers, clientset := setup(t)
 	ns := framework.CreateNamespaceOrDie(clientset, "daemonset-rollingupdate-with-tolerations-test", t)
 	defer framework.DeleteNamespaceOrDie(clientset, ns, t)
 

--- a/test/integration/disruption/disruption_test.go
+++ b/test/integration/disruption/disruption_test.go
@@ -116,8 +116,7 @@ func setup(ctx context.Context, t *testing.T) (*kubeapiservertesting.TestServer,
 func TestPDBWithScaleSubresource(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	s, pdbc, informers, clientSet, apiExtensionClient, dynamicClient := setup(tCtx, t)
-	defer s.TearDownFn()
-	defer tCtx.Cancel("test has completed")
+	tCtx.Cleanup(s.TearDownFn)
 
 	nsName := "pdb-scale-subresource"
 	createNs(tCtx, t, nsName, clientSet)
@@ -248,8 +247,7 @@ func TestEmptySelector(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tCtx := ktesting.Init(t)
 			s, pdbc, informers, clientSet, _, _ := setup(tCtx, t)
-			defer s.TearDownFn()
-			defer tCtx.Cancel("test has completed")
+			tCtx.Cleanup(s.TearDownFn)
 
 			nsName := fmt.Sprintf("pdb-empty-selector-%d", i)
 			createNs(tCtx, t, nsName, clientSet)
@@ -362,8 +360,7 @@ func TestSelectorsForPodsWithoutLabels(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tCtx := ktesting.Init(t)
 			s, pdbc, informers, clientSet, _, _ := setup(tCtx, t)
-			defer s.TearDownFn()
-			defer tCtx.Cancel("test has completed")
+			tCtx.Cleanup(s.TearDownFn)
 
 			nsName := fmt.Sprintf("pdb-selectors-%d", i)
 			createNs(tCtx, t, nsName, clientSet)
@@ -535,12 +532,9 @@ func createPDBUsingRemovedAPI(ctx context.Context, etcdClient *clientv3.Client, 
 func TestPatchCompatibility(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	s, pdbc, _, clientSet, _, _ := setup(tCtx, t)
-	defer s.TearDownFn()
-	// Even though pdbc isn't used in this test, its creation is already
-	// spawning some goroutines. So we need to run it to ensure they won't leak.
-	// We can't cancel immediately but later, because when the context is canceled,
-	// the event broadcaster will be shut down .
-	defer tCtx.Cancel("cleaning up")
+	tCtx.Cleanup(s.TearDownFn)
+	// Even though pdbc isn't used in this test, its creation already spawns
+	// goroutines, so run it and let test cleanup stop it with tCtx cancellation.
 	go pdbc.Run(tCtx, 1)
 
 	testcases := []struct {
@@ -638,8 +632,7 @@ func TestPatchCompatibility(t *testing.T) {
 func TestStalePodDisruption(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	s, pdbc, informers, clientSet, _, _ := setup(tCtx, t)
-	defer s.TearDownFn()
-	defer tCtx.Cancel("test has completed")
+	tCtx.Cleanup(s.TearDownFn)
 
 	nsName := "pdb-stale-pod-disruption"
 	createNs(tCtx, t, nsName, clientSet)

--- a/test/integration/dra/core.go
+++ b/test/integration/dra/core.go
@@ -755,7 +755,6 @@ func testControllerManagerMetrics(tCtx ktesting.TContext) {
 	// Start the controller (this will run in background and stop when tCtx is cancelled)
 	var wg sync.WaitGroup
 	tCtx.Cleanup(func() {
-		tCtx.Cancel("test is done")
 		wg.Wait()
 	})
 	wg.Go(runResourceClaimController)

--- a/test/integration/dra/device_taints.go
+++ b/test/integration/dra/device_taints.go
@@ -59,10 +59,9 @@ func testEvictCluster(tCtx ktesting.TContext, useRule useRuleMode) {
 	// Not parallel because it creates a controller.
 
 	var wg sync.WaitGroup
-	defer func() {
-		tCtx.Cancel("time to shut down")
+	tCtx.Cleanup(func() {
 		wg.Wait()
-	}()
+	})
 
 	numPods := 1000
 	devicesPerSlice := 50

--- a/test/integration/dra/dra.go
+++ b/test/integration/dra/dra.go
@@ -421,7 +421,6 @@ func run(tCtx ktesting.TContext, whatRE string) {
 			tCtx.ExpectNoError(err, "add claim event handler")
 			informerFactory.StartWithContext(tCtx)
 			tCtx.Cleanup(func() {
-				tCtx.Cancel("test is done")
 				_ = informerFactory.Resource().V1().ResourceClaims().Informer().RemoveEventHandler(claimHandle)
 				informerFactory.Shutdown()
 			})

--- a/test/integration/etcd/crd_overlap_storage_test.go
+++ b/test/integration/etcd/crd_overlap_storage_test.go
@@ -70,7 +70,6 @@ func TestOverlappingBuiltInResources(t *testing.T) {
 // TestOverlappingCustomResourceAPIService ensures creating and deleting a custom resource overlapping with APIServices does not destroy APIService data
 func TestOverlappingCustomResourceAPIService(t *testing.T) {
 	apiServer := StartRealAPIServerOrDie(t)
-	defer apiServer.Cleanup()
 
 	apiServiceClient, err := apiregistrationclient.NewForConfig(apiServer.Config)
 	if err != nil {
@@ -232,7 +231,6 @@ func TestOverlappingCustomResourceAPIService(t *testing.T) {
 // TestOverlappingCustomResourceCustomResourceDefinition ensures creating and deleting a custom resource overlapping with CustomResourceDefinition does not destroy CustomResourceDefinition data
 func TestOverlappingCustomResourceCustomResourceDefinition(t *testing.T) {
 	apiServer := StartRealAPIServerOrDie(t)
-	defer apiServer.Cleanup()
 
 	crdClient, err := crdclient.NewForConfig(apiServer.Config)
 	if err != nil {

--- a/test/integration/etcd/etcd_cross_group_test.go
+++ b/test/integration/etcd/etcd_cross_group_test.go
@@ -36,7 +36,6 @@ import (
 // TestCrossGroupStorage tests to make sure that all objects stored in an expected location in etcd can be converted/read.
 func TestCrossGroupStorage(t *testing.T) {
 	apiServer := StartRealAPIServerOrDie(t)
-	defer apiServer.Cleanup()
 
 	etcdStorageData := GetEtcdStorageData()
 

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -106,7 +106,6 @@ func testEtcdStoragePathWithVersion(t *testing.T, v string) {
 		}
 	})
 
-	defer apiServer.Cleanup()
 	defer dumpEtcdKVOnFailure(t, apiServer.KV)
 
 	client := &allClient{dynamicClient: apiServer.Dynamic}

--- a/test/integration/etcd/server.go
+++ b/test/integration/etcd/server.go
@@ -249,13 +249,8 @@ func StartRealAPIServerOrDie(t *testing.T, configFuncs ...func(*options.ServerRu
 		t.Fatal(err)
 	}
 
-	cleanup := func() {
-		// Cancel stopping apiserver and cleaning up
-		// after itself, including shutting down its storage layer.
-		tCtx.Cancel("cleaning up")
-
-		// If the apiserver was started, let's wait for it to
-		// shutdown clearly.
+	tCtx.Cleanup(func() {
+		// Wait for the apiserver to shut down after the test context gets canceled.
 		err, ok := <-errCh
 		if ok && err != nil {
 			t.Error(err)
@@ -264,7 +259,7 @@ func StartRealAPIServerOrDie(t *testing.T, configFuncs ...func(*options.ServerRu
 		if err := os.RemoveAll(certDir); err != nil {
 			t.Log(err)
 		}
-	}
+	})
 
 	return &APIServer{
 		Client:    kubeClient,
@@ -273,12 +268,10 @@ func StartRealAPIServerOrDie(t *testing.T, configFuncs ...func(*options.ServerRu
 		KV:        kvClient,
 		Mapper:    restMapper,
 		Resources: GetResources(t, serverResources),
-		Cleanup:   cleanup,
 	}
 }
 
-// APIServer represents a running API server that is ready for use
-// The Cleanup func must be deferred to prevent resource leaks
+// APIServer represents a running API server that is ready for use.
 type APIServer struct {
 	Client    clientset.Interface
 	Dynamic   dynamic.Interface
@@ -286,7 +279,6 @@ type APIServer struct {
 	KV        clientv3.KV
 	Mapper    meta.RESTMapper
 	Resources []Resource
-	Cleanup   func()
 }
 
 // Resource contains REST mapping information for a specific resource and extra metadata such as delete collection support

--- a/test/integration/evictions/evictions_test.go
+++ b/test/integration/evictions/evictions_test.go
@@ -68,11 +68,10 @@ func TestConcurrentEvictionRequests(t *testing.T) {
 
 	tCtx := ktesting.Init(t)
 	closeFn, rm, informers, _, clientSet := rmSetup(tCtx, t)
-	defer closeFn()
+	tCtx.Cleanup(closeFn)
 
 	ns := framework.CreateNamespaceOrDie(clientSet, "concurrent-eviction-requests", t)
 	defer framework.DeleteNamespaceOrDie(clientSet, ns, t)
-	defer tCtx.Cancel("test has completed")
 
 	informers.Start(tCtx.Done())
 	go rm.Run(tCtx, 1)
@@ -181,11 +180,10 @@ func TestConcurrentEvictionRequests(t *testing.T) {
 func TestTerminalPodEviction(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	closeFn, rm, informers, _, clientSet := rmSetup(tCtx, t)
-	defer closeFn()
+	tCtx.Cleanup(closeFn)
 
 	ns := framework.CreateNamespaceOrDie(clientSet, "terminalpod-eviction", t)
 	defer framework.DeleteNamespaceOrDie(clientSet, ns, t)
-	defer tCtx.Cancel("test has completed")
 
 	informers.Start(tCtx.Done())
 	go rm.Run(tCtx, 1)
@@ -255,8 +253,7 @@ func TestTerminalPodEviction(t *testing.T) {
 func TestEvictionVersions(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	closeFn, rm, informers, config, clientSet := rmSetup(tCtx, t)
-	defer closeFn()
-	defer tCtx.Cancel("test has completed")
+	tCtx.Cleanup(closeFn)
 
 	informers.Start(tCtx.Done())
 	go rm.Run(tCtx, 1)
@@ -365,11 +362,10 @@ func TestEvictionWithFinalizers(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			tCtx := ktesting.Init(t)
 			closeFn, rm, informers, _, clientSet := rmSetup(tCtx, t)
-			defer closeFn()
+			tCtx.Cleanup(closeFn)
 
 			ns := framework.CreateNamespaceOrDie(clientSet, "eviction-with-finalizers", t)
 			defer framework.DeleteNamespaceOrDie(clientSet, ns, t)
-			defer tCtx.Cancel("test has completed")
 
 			informers.Start(tCtx.Done())
 			go rm.Run(tCtx, 1)
@@ -440,11 +436,10 @@ func TestEvictionWithUnhealthyPodEvictionPolicy(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			tCtx := ktesting.Init(t)
 			closeFn, rm, informers, _, clientSet := rmSetup(tCtx, t)
-			defer closeFn()
+			tCtx.Cleanup(closeFn)
 
 			ns := framework.CreateNamespaceOrDie(clientSet, "eviction-with-pdb-pod-healthy-policy", t)
 			defer framework.DeleteNamespaceOrDie(clientSet, ns, t)
-			defer tCtx.Cancel("test has completed")
 
 			informers.Start(tCtx.Done())
 			go rm.Run(tCtx, 1)
@@ -533,12 +528,11 @@ func TestEvictionWithPrecondition(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			tCtx := ktesting.Init(t)
 			closeFn, rm, informers, _, clientSet := rmSetup(tCtx, t)
-			defer closeFn()
+			tCtx.Cleanup(closeFn)
 
 			ns := framework.CreateNamespaceOrDie(clientSet, "eviction-with-preconditions", t)
 			defer framework.DeleteNamespaceOrDie(clientSet, ns, t)
 
-			defer tCtx.Cancel("test has completed")
 			informers.Start(tCtx.Done())
 			go rm.Run(tCtx, 1)
 

--- a/test/integration/garbagecollector/cluster_scoped_owner_test.go
+++ b/test/integration/garbagecollector/cluster_scoped_owner_test.go
@@ -67,7 +67,6 @@ func TestClusterScopedOwners(t *testing.T) {
 		})
 	}
 	ctx := setupWithServer(t, server, 5)
-	defer ctx.tearDown()
 
 	_, clientSet := ctx.gc, ctx.clientSet
 

--- a/test/integration/garbagecollector/garbage_collector_test.go
+++ b/test/integration/garbagecollector/garbage_collector_test.go
@@ -225,7 +225,6 @@ func createRandomCustomResourceDefinition(
 
 type testContext struct {
 	logger             klog.Logger
-	tearDown           func()
 	gc                 *garbagecollector.GarbageCollector
 	clientSet          clientset.Interface
 	apiExtensionClient apiextensionsclientset.Interface
@@ -289,10 +288,10 @@ func setupWithServer(t *testing.T, result *kubeapiservertesting.TestServer, work
 		t.Fatalf("failed to create garbage collector: %v", err)
 	}
 
-	tearDown := func() {
-		tCtx.Cancel("tearing down")
-		result.TearDownFn()
-	}
+	// The garbage collector runs with tCtx, so tCtx must get canceled
+	// before the server shuts down, to avoid it logging errors while (or
+	// after) the test binary considers the test done.
+	tCtx.Cleanup(result.TearDownFn)
 	syncPeriod := 5 * time.Second
 	startGC := func(workers int) {
 		go wait.Until(func() {
@@ -311,7 +310,6 @@ func setupWithServer(t *testing.T, result *kubeapiservertesting.TestServer, work
 
 	return &testContext{
 		logger:             logger,
-		tearDown:           tearDown,
 		gc:                 gc,
 		clientSet:          clientSet,
 		apiExtensionClient: apiExtensionClient,
@@ -420,7 +418,6 @@ func testCrossNamespaceReferences(t *testing.T, watchCache bool) {
 
 	// start GC with existing objects in place to simulate controller-manager restart
 	ctx := setupWithServer(t, testServer, workers)
-	defer ctx.tearDown()
 	testServer = nil
 
 	// Wait for the invalid children to be garbage collected
@@ -485,7 +482,6 @@ func testCrossNamespaceReferences(t *testing.T, watchCache bool) {
 // This test simulates the cascading deletion.
 func TestCascadingDeletion(t *testing.T) {
 	ctx := setup(t, 5)
-	defer ctx.tearDown()
 
 	gc, clientSet := ctx.gc, ctx.clientSet
 
@@ -572,7 +568,6 @@ func TestCascadingDeletion(t *testing.T) {
 // doesn't exist. It verifies the GC will delete such an object.
 func TestCreateWithNonExistentOwner(t *testing.T) {
 	ctx := setup(t, 5)
-	defer ctx.tearDown()
 
 	clientSet := ctx.clientSet
 
@@ -694,7 +689,6 @@ func verifyRemainingObjects(t *testing.T, clientSet clientset.Interface, namespa
 // e2e tests that put more stress.
 func TestStressingCascadingDeletion(t *testing.T) {
 	ctx := setup(t, 5)
-	defer ctx.tearDown()
 
 	gc, clientSet := ctx.gc, ctx.clientSet
 
@@ -758,7 +752,6 @@ func TestStressingCascadingDeletion(t *testing.T) {
 
 func TestOrphaning(t *testing.T) {
 	ctx := setup(t, 5)
-	defer ctx.tearDown()
 
 	gc, clientSet := ctx.gc, ctx.clientSet
 
@@ -838,7 +831,6 @@ func TestOrphaning(t *testing.T) {
 
 func TestSolidOwnerDoesNotBlockWaitingOwner(t *testing.T) {
 	ctx := setup(t, 5)
-	defer ctx.tearDown()
 
 	clientSet := ctx.clientSet
 
@@ -898,7 +890,6 @@ func TestSolidOwnerDoesNotBlockWaitingOwner(t *testing.T) {
 
 func TestNonBlockingOwnerRefDoesNotBlock(t *testing.T) {
 	ctx := setup(t, 5)
-	defer ctx.tearDown()
 
 	clientSet := ctx.clientSet
 
@@ -965,7 +956,6 @@ func TestNonBlockingOwnerRefDoesNotBlock(t *testing.T) {
 func TestDoubleDeletionWithFinalizer(t *testing.T) {
 	// test setup
 	ctx := setup(t, 5)
-	defer ctx.tearDown()
 	clientSet := ctx.clientSet
 	ns := createNamespaceOrDie("gc-double-foreground", clientSet, t)
 	defer deleteNamespaceOrDie(ns.Name, clientSet, t)
@@ -1027,7 +1017,6 @@ func TestDoubleDeletionWithFinalizer(t *testing.T) {
 
 func TestBlockingOwnerRefDoesBlock(t *testing.T) {
 	ctx := setup(t, 0)
-	defer ctx.tearDown()
 	gc, clientSet := ctx.gc, ctx.clientSet
 
 	ns := createNamespaceOrDie("foo", clientSet, t)
@@ -1087,7 +1076,6 @@ func TestBlockingOwnerRefDoesBlock(t *testing.T) {
 // behavior supports custom resources.
 func TestCustomResourceCascadingDeletion(t *testing.T) {
 	ctx := setup(t, 5)
-	defer ctx.tearDown()
 
 	clientSet, apiExtensionClient, dynamicClient := ctx.clientSet, ctx.apiExtensionClient, ctx.dynamicClient
 
@@ -1147,7 +1135,6 @@ func TestCustomResourceCascadingDeletion(t *testing.T) {
 // specific node in the before graph with certain delete options).
 func TestMixedRelationships(t *testing.T) {
 	ctx := setup(t, 5)
-	defer ctx.tearDown()
 
 	clientSet, apiExtensionClient, dynamicClient := ctx.clientSet, ctx.apiExtensionClient, ctx.dynamicClient
 
@@ -1245,7 +1232,6 @@ func TestMixedRelationships(t *testing.T) {
 // definition with an instance that owns a core resource.
 func TestCRDDeletionCascading(t *testing.T) {
 	ctx := setup(t, 5)
-	defer ctx.tearDown()
 
 	clientSet, apiExtensionClient, dynamicClient := ctx.clientSet, ctx.apiExtensionClient, ctx.dynamicClient
 
@@ -1315,7 +1301,6 @@ func testCRDDeletion(t *testing.T, ctx *testContext, ns *v1.Namespace, definitio
 // a CRD, updates the storage version with a bad conversion webhook and then runs a simple cascading delete test.
 func TestCascadingDeleteOnCRDConversionFailure(t *testing.T) {
 	ctx := setup(t, 0)
-	defer ctx.tearDown()
 	gc, apiExtensionClient, dynamicClient, clientSet := ctx.gc, ctx.apiExtensionClient, ctx.dynamicClient, ctx.clientSet
 
 	ns := createNamespaceOrDie("gc-cache-sync-fail", clientSet, t)

--- a/test/integration/replicaset/replicaset_test.go
+++ b/test/integration/replicaset/replicaset_test.go
@@ -118,7 +118,7 @@ func newMatchingPod(podName, namespace string) *v1.Pod {
 	}
 }
 
-func rmSetup(t *testing.T) (context.Context, kubeapiservertesting.TearDownFunc, *replicaset.ReplicaSetController, informers.SharedInformerFactory, clientset.Interface) {
+func setup(t *testing.T) (context.Context, *replicaset.ReplicaSetController, informers.SharedInformerFactory, clientset.Interface) {
 	tCtx := ktesting.Init(t)
 	// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
@@ -139,12 +139,12 @@ func rmSetup(t *testing.T) (context.Context, kubeapiservertesting.TearDownFunc, 
 		replicaset.BurstReplicas,
 	)
 
-	newTeardown := func() {
-		tCtx.Cancel("tearing down controller")
-		server.TearDownFn()
-	}
+	// The replicaset controller runs with tCtx, so tCtx must get canceled
+	// before the server shuts down, to avoid the controller logging errors
+	// while (or after) the test binary considers the test done.
+	tCtx.Cleanup(server.TearDownFn)
 
-	return tCtx, newTeardown, rm, informers, clientSet
+	return tCtx, rm, informers, clientSet
 }
 
 func rmSimpleSetup(t *testing.T) (kubeapiservertesting.TearDownFunc, clientset.Interface) {
@@ -444,8 +444,7 @@ func TestAdoption(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tCtx, closeFn, rm, informers, clientSet := rmSetup(t)
-			defer closeFn()
+			tCtx, rm, informers, clientSet := setup(t)
 
 			ns := framework.CreateNamespaceOrDie(clientSet, fmt.Sprintf("rs-adoption-%d", i), t)
 			defer framework.DeleteNamespaceOrDie(clientSet, ns, t)
@@ -516,8 +515,7 @@ func TestRSSelectorImmutability(t *testing.T) {
 }
 
 func TestSpecReplicasChange(t *testing.T) {
-	tCtx, closeFn, rm, informers, c := rmSetup(t)
-	defer closeFn()
+	tCtx, rm, informers, c := setup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-spec-replicas-change", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	stopControllers := runControllerAndInformers(t, rm, informers, 0)
@@ -558,8 +556,7 @@ func TestSpecReplicasChange(t *testing.T) {
 }
 
 func TestDeletingAndFailedPods(t *testing.T) {
-	tCtx, closeFn, rm, informers, c := rmSetup(t)
-	defer closeFn()
+	tCtx, rm, informers, c := setup(t)
 
 	ns := framework.CreateNamespaceOrDie(c, "test-deleting-and-failed-pods", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
@@ -662,8 +659,7 @@ func TestPodDeletionCost(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodDeletionCost, tc.enabled)
-			_, closeFn, rm, informers, c := rmSetup(t)
-			defer closeFn()
+			_, rm, informers, c := setup(t)
 			ns := framework.CreateNamespaceOrDie(c, tc.name, t)
 			defer framework.DeleteNamespaceOrDie(c, ns, t)
 			stopControllers := runControllerAndInformers(t, rm, informers, 0)
@@ -721,8 +717,7 @@ func TestPodDeletionCost(t *testing.T) {
 }
 
 func TestOverlappingRSs(t *testing.T) {
-	tCtx, closeFn, rm, informers, c := rmSetup(t)
-	defer closeFn()
+	tCtx, rm, informers, c := setup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-overlapping-rss", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	stopControllers := runControllerAndInformers(t, rm, informers, 0)
@@ -756,8 +751,7 @@ func TestOverlappingRSs(t *testing.T) {
 }
 
 func TestPodOrphaningAndAdoptionWhenLabelsChange(t *testing.T) {
-	tCtx, closeFn, rm, informers, c := rmSetup(t)
-	defer closeFn()
+	tCtx, rm, informers, c := setup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-pod-orphaning-and-adoption-when-labels-change", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	stopControllers := runControllerAndInformers(t, rm, informers, 0)
@@ -834,8 +828,7 @@ func TestPodOrphaningAndAdoptionWhenLabelsChange(t *testing.T) {
 }
 
 func TestGeneralPodAdoption(t *testing.T) {
-	_, closeFn, rm, informers, c := rmSetup(t)
-	defer closeFn()
+	_, rm, informers, c := setup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-general-pod-adoption", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	stopControllers := runControllerAndInformers(t, rm, informers, 0)
@@ -866,8 +859,7 @@ func TestGeneralPodAdoption(t *testing.T) {
 }
 
 func TestReadyAndAvailableReplicas(t *testing.T) {
-	tCtx, closeFn, rm, informers, c := rmSetup(t)
-	defer closeFn()
+	tCtx, rm, informers, c := setup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-ready-and-available-replicas", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	stopControllers := runControllerAndInformers(t, rm, informers, 0)
@@ -918,8 +910,7 @@ func TestReadyAndAvailableReplicas(t *testing.T) {
 }
 
 func TestRSScaleSubresource(t *testing.T) {
-	_, closeFn, rm, informers, c := rmSetup(t)
-	defer closeFn()
+	_, rm, informers, c := setup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-rs-scale-subresource", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	stopControllers := runControllerAndInformers(t, rm, informers, 0)
@@ -937,8 +928,7 @@ func TestRSScaleSubresource(t *testing.T) {
 }
 
 func TestExtraPodsAdoptionAndDeletion(t *testing.T) {
-	_, closeFn, rm, informers, c := rmSetup(t)
-	defer closeFn()
+	_, rm, informers, c := setup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-extra-pods-adoption-and-deletion", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 
@@ -969,8 +959,7 @@ func TestExtraPodsAdoptionAndDeletion(t *testing.T) {
 }
 
 func TestFullyLabeledReplicas(t *testing.T) {
-	tCtx, closeFn, rm, informers, c := rmSetup(t)
-	defer closeFn()
+	tCtx, rm, informers, c := setup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-fully-labeled-replicas", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	stopControllers := runControllerAndInformers(t, rm, informers, 0)
@@ -1012,8 +1001,7 @@ func TestFullyLabeledReplicas(t *testing.T) {
 }
 
 func TestReplicaSetsAppsV1DefaultGCPolicy(t *testing.T) {
-	tCtx, closeFn, rm, informers, c := rmSetup(t)
-	defer closeFn()
+	tCtx, rm, informers, c := setup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-default-gc-v1", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	stopControllers := runControllerAndInformers(t, rm, informers, 0)
@@ -1073,8 +1061,7 @@ func TestReplicaSetsAppsV1DefaultGCPolicy(t *testing.T) {
 func TestTerminatingReplicas(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DeploymentReplicaSetTerminatingReplicas, false)
 
-	tCtx, closeFn, rm, informers, c := rmSetup(t)
-	defer closeFn()
+	tCtx, rm, informers, c := setup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-terminating-replicas", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	stopControllers := runControllerAndInformers(t, rm, informers, 0)

--- a/test/integration/replicationcontroller/replicationcontroller_test.go
+++ b/test/integration/replicationcontroller/replicationcontroller_test.go
@@ -109,7 +109,7 @@ func newMatchingPod(podName, namespace string) *v1.Pod {
 	}
 }
 
-func rmSetup(t *testing.T) (context.Context, kubeapiservertesting.TearDownFunc, *replication.ReplicationManager, informers.SharedInformerFactory, clientset.Interface) {
+func setup(t *testing.T) (context.Context, *replication.ReplicationManager, informers.SharedInformerFactory, clientset.Interface) {
 	tCtx := ktesting.Init(t)
 	// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
@@ -129,12 +129,12 @@ func rmSetup(t *testing.T) (context.Context, kubeapiservertesting.TearDownFunc, 
 		clientset.NewForConfigOrDie(restclient.AddUserAgent(config, "replication-controller")),
 		replication.BurstReplicas,
 	)
-	newTeardown := func() {
-		tCtx.Cancel("tearing down controller")
-		server.TearDownFn()
-	}
+	// The replication controller runs with tCtx, so tCtx must get canceled
+	// before the server shuts down, to avoid the controller logging errors
+	// while (or after) the test binary considers the test done.
+	tCtx.Cleanup(server.TearDownFn)
 
-	return tCtx, newTeardown, rm, informers, clientSet
+	return tCtx, rm, informers, clientSet
 }
 
 // Run RC controller and informers
@@ -415,8 +415,7 @@ func TestAdoption(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tCtx, closeFn, rm, informers, clientSet := rmSetup(t)
-			defer closeFn()
+			tCtx, rm, informers, clientSet := setup(t)
 			ns := framework.CreateNamespaceOrDie(clientSet, fmt.Sprintf("rc-adoption-%d", i), t)
 			defer framework.DeleteNamespaceOrDie(clientSet, ns, t)
 
@@ -458,8 +457,7 @@ func TestAdoption(t *testing.T) {
 }
 
 func TestSpecReplicasChange(t *testing.T) {
-	tCtx, closeFn, rm, informers, c := rmSetup(t)
-	defer closeFn()
+	tCtx, rm, informers, c := setup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-spec-replicas-change", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	stopControllers := runControllerAndInformers(t, rm, informers, 0)
@@ -500,8 +498,7 @@ func TestSpecReplicasChange(t *testing.T) {
 }
 
 func TestLogarithmicScaleDown(t *testing.T) {
-	tCtx, closeFn, rm, informers, c := rmSetup(t)
-	defer closeFn()
+	tCtx, rm, informers, c := setup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-spec-replicas-change", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	stopControllers := runControllerAndInformers(t, rm, informers, 0)
@@ -537,8 +534,7 @@ func TestLogarithmicScaleDown(t *testing.T) {
 }
 
 func TestDeletingAndFailedPods(t *testing.T) {
-	tCtx, closeFn, rm, informers, c := rmSetup(t)
-	defer closeFn()
+	tCtx, rm, informers, c := setup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-deleting-and-failed-pods", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	stopControllers := runControllerAndInformers(t, rm, informers, 0)
@@ -602,8 +598,7 @@ func TestDeletingAndFailedPods(t *testing.T) {
 }
 
 func TestOverlappingRCs(t *testing.T) {
-	tCtx, closeFn, rm, informers, c := rmSetup(t)
-	defer closeFn()
+	tCtx, rm, informers, c := setup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-overlapping-rcs", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	stopControllers := runControllerAndInformers(t, rm, informers, 0)
@@ -637,8 +632,7 @@ func TestOverlappingRCs(t *testing.T) {
 }
 
 func TestPodOrphaningAndAdoptionWhenLabelsChange(t *testing.T) {
-	tCtx, closeFn, rm, informers, c := rmSetup(t)
-	defer closeFn()
+	tCtx, rm, informers, c := setup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-pod-orphaning-and-adoption-when-labels-change", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	stopControllers := runControllerAndInformers(t, rm, informers, 0)
@@ -715,8 +709,7 @@ func TestPodOrphaningAndAdoptionWhenLabelsChange(t *testing.T) {
 }
 
 func TestGeneralPodAdoption(t *testing.T) {
-	_, closeFn, rm, informers, c := rmSetup(t)
-	defer closeFn()
+	_, rm, informers, c := setup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-general-pod-adoption", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	stopControllers := runControllerAndInformers(t, rm, informers, 0)
@@ -747,8 +740,7 @@ func TestGeneralPodAdoption(t *testing.T) {
 }
 
 func TestReadyAndAvailableReplicas(t *testing.T) {
-	tCtx, closeFn, rm, informers, c := rmSetup(t)
-	defer closeFn()
+	tCtx, rm, informers, c := setup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-ready-and-available-replicas", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	stopControllers := runControllerAndInformers(t, rm, informers, 0)
@@ -799,8 +791,7 @@ func TestReadyAndAvailableReplicas(t *testing.T) {
 }
 
 func TestRCScaleSubresource(t *testing.T) {
-	_, closeFn, rm, informers, c := rmSetup(t)
-	defer closeFn()
+	_, rm, informers, c := setup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-rc-scale-subresource", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	stopControllers := runControllerAndInformers(t, rm, informers, 0)
@@ -818,8 +809,7 @@ func TestRCScaleSubresource(t *testing.T) {
 }
 
 func TestExtraPodsAdoptionAndDeletion(t *testing.T) {
-	_, closeFn, rm, informers, c := rmSetup(t)
-	defer closeFn()
+	_, rm, informers, c := setup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-extra-pods-adoption-and-deletion", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 
@@ -850,8 +840,7 @@ func TestExtraPodsAdoptionAndDeletion(t *testing.T) {
 }
 
 func TestFullyLabeledReplicas(t *testing.T) {
-	tCtx, closeFn, rm, informers, c := rmSetup(t)
-	defer closeFn()
+	tCtx, rm, informers, c := setup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-fully-labeled-replicas", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	stopControllers := runControllerAndInformers(t, rm, informers, 0)

--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -818,7 +818,6 @@ func RunBenchmarkPerfScheduling(b *testing.B, configFile string, topicName strin
 					featureGates := featureGatesMerge(tc.FeatureGates, w.FeatureGates)
 					scheduler, informerFactory, schedulerDone, tCtx := setupTestCase(b, tc, featureGates, w, opts)
 					tCtx.TB().Cleanup(func() {
-						tCtx.Cancel("workload is done")
 						<-schedulerDone
 						// Reset metrics to prevent metrics generated in current workload gets
 						// carried over to the next workload.
@@ -946,7 +945,6 @@ func RunIntegrationPerfScheduling(t *testing.T, configFile string, options ...Sc
 					featureGates := featureGatesMerge(tc.FeatureGates, w.FeatureGates)
 					scheduler, informerFactory, schedulerDone, tCtx := setupTestCase(t, tc, featureGates, w, opts)
 					tCtx.TB().Cleanup(func() {
-						tCtx.Cancel("workload is done")
 						<-schedulerDone
 						// Reset metrics to prevent metrics generated in current workload gets
 						// carried over to the next workload.
@@ -1138,7 +1136,6 @@ func runWorkload(tCtx ktesting.TContext, tc *testCase, w *Workload, topicName st
 	}
 
 	tCtx.TB().Cleanup(func() {
-		tCtx.Cancel("workload is done")
 		executor.wait()
 	})
 

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -123,9 +123,6 @@ func mustSetupCluster(tCtx ktesting.TContext, config *config.KubeSchedulerConfig
 	// child context, then the server.
 	tCtx.Cleanup(server.TearDownFn)
 	tCtx = tCtx.WithCancel()
-	tCtx.Cleanup(func() {
-		tCtx.Cancel("test is done")
-	})
 
 	// TODO: client connection configuration, such as QPS or Burst is configurable in theory, this could be derived from the `config`, need to
 	// support this when there is any testcase that depends on such configuration.

--- a/test/integration/servicecidr/migration_test.go
+++ b/test/integration/servicecidr/migration_test.go
@@ -197,7 +197,7 @@ func TestMigrateServiceCIDR(t *testing.T) {
 			"--disable-admission-plugins=ServiceAccount",
 		},
 		etcdOptions)
-	defer s2.TearDownFn()
+	t.Cleanup(s2.TearDownFn)
 
 	client2, err := clientset.NewForConfig(s2.ClientConfig)
 	if err != nil {
@@ -211,7 +211,6 @@ func TestMigrateServiceCIDR(t *testing.T) {
 
 	// ServiceCIDR controller
 	tCtx2 := ktesting.Init(t)
-	defer tCtx2.Cancel("tearing down ServiceCIDR controller 2")
 	informers2 := informers.NewSharedInformerFactory(client2, resyncPeriod)
 	go servicecidrs.NewController(
 		tCtx2,

--- a/test/integration/statefulset/statefulset_test.go
+++ b/test/integration/statefulset/statefulset_test.go
@@ -127,8 +127,7 @@ func TestVolumeTemplateNoopUpdate(t *testing.T) {
 }
 
 func TestSpecReplicasChange(t *testing.T) {
-	tCtx, closeFn, rm, informers, c := scSetup(t)
-	defer closeFn()
+	tCtx, rm, informers, c := scSetup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-spec-replicas-change", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	cancel := runControllerAndInformers(tCtx, rm, informers)
@@ -170,8 +169,7 @@ func TestSpecReplicasChange(t *testing.T) {
 }
 
 func TestDeletingAndTerminatingPods(t *testing.T) {
-	tCtx, closeFn, rm, informers, c := scSetup(t)
-	defer closeFn()
+	tCtx, rm, informers, c := scSetup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-deleting-and-failed-pods", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	cancel := runControllerAndInformers(tCtx, rm, informers)
@@ -288,8 +286,7 @@ func TestStatefulSetAvailable(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tCtx, closeFn, rm, informers, c := scSetup(t)
-			defer closeFn()
+			tCtx, rm, informers, c := scSetup(t)
 			ns := framework.CreateNamespaceOrDie(c, "test-available-pods", t)
 			defer framework.DeleteNamespaceOrDie(c, ns, t)
 			cancel := runControllerAndInformers(tCtx, rm, informers)
@@ -387,8 +384,7 @@ func TestStatefulSetStatusWithPodFail(t *testing.T) {
 			}
 		},
 	})
-	defer closeFn()
-	defer tCtx.Cancel("test has completed")
+	tCtx.Cleanup(closeFn)
 	resyncPeriod := 12 * time.Hour
 	informers := informers.NewSharedInformerFactory(clientset.NewForConfigOrDie(restclient.AddUserAgent(config, "statefulset-informers")), resyncPeriod)
 	ssc := statefulset.NewStatefulSetController(
@@ -471,8 +467,7 @@ func TestAutodeleteOwnerRefs(t *testing.T) {
 		},
 	}
 
-	tCtx, closeFn, rm, informers, c := scSetup(t)
-	defer closeFn()
+	tCtx, rm, informers, c := scSetup(t)
 	cancel := runControllerAndInformers(tCtx, rm, informers)
 	defer cancel()
 
@@ -514,8 +509,7 @@ func TestAutodeleteOwnerRefs(t *testing.T) {
 }
 
 func TestDeletingPodForRollingUpdatePartition(t *testing.T) {
-	tCtx, closeFn, rm, informers, c := scSetup(t)
-	defer closeFn()
+	tCtx, rm, informers, c := scSetup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-deleting-pod-for-rolling-update-partition", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	cancel := runControllerAndInformers(tCtx, rm, informers)
@@ -693,8 +687,7 @@ func TestStatefulSetStartOrdinal(t *testing.T) {
 		},
 	}
 
-	tCtx, closeFn, rm, informers, c := scSetup(t)
-	defer closeFn()
+	tCtx, rm, informers, c := scSetup(t)
 	cancel := runControllerAndInformers(tCtx, rm, informers)
 	defer cancel()
 
@@ -767,8 +760,7 @@ func TestStatefulSetStartOrdinal(t *testing.T) {
 	}
 }
 func TestStatefulSetPodSubdomain(t *testing.T) {
-	tCtx, closeFn, rm, informers, c := scSetup(t)
-	defer closeFn()
+	tCtx, rm, informers, c := scSetup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-pod-subdomain", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	cancel := runControllerAndInformers(tCtx, rm, informers)
@@ -801,8 +793,7 @@ func TestStatefulSetPodSubdomain(t *testing.T) {
 
 func TestRecreateStatefulSetUpdate(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StatefulSetRecreateStrategy, true)
-	tCtx, closeFn, rm, informers, c := scSetup(t)
-	defer closeFn()
+	tCtx, rm, informers, c := scSetup(t)
 	ns := framework.CreateNamespaceOrDie(c, "test-recreate-update", t)
 	defer framework.DeleteNamespaceOrDie(c, ns, t)
 	cancel := runControllerAndInformers(tCtx, rm, informers)

--- a/test/integration/statefulset/util.go
+++ b/test/integration/statefulset/util.go
@@ -163,7 +163,7 @@ func newStatefulSetPVC(name string) v1.PersistentVolumeClaim {
 }
 
 // scSetup sets up necessities for Statefulset integration test, including control plane, apiserver, informers, and clientset
-func scSetup(t *testing.T) (context.Context, kubeapiservertesting.TearDownFunc, *statefulset.StatefulSetController, informers.SharedInformerFactory, clientset.Interface) {
+func scSetup(t *testing.T) (context.Context, *statefulset.StatefulSetController, informers.SharedInformerFactory, clientset.Interface) {
 	tCtx := ktesting.Init(t)
 	// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
@@ -185,11 +185,11 @@ func scSetup(t *testing.T) (context.Context, kubeapiservertesting.TearDownFunc, 
 		clientset.NewForConfigOrDie(restclient.AddUserAgent(config, "statefulset-controller")),
 	)
 
-	teardown := func() {
-		tCtx.Cancel("tearing down controller")
-		server.TearDownFn()
-	}
-	return tCtx, teardown, sc, informers, clientSet
+	// The statefulset controller runs with tCtx, so tCtx must get canceled
+	// before the server shuts down, to avoid it logging errors while (or
+	// after) the test binary considers the test done.
+	tCtx.Cleanup(server.TearDownFn)
+	return tCtx, sc, informers, clientSet
 }
 
 // Run STS controller and informers

--- a/test/integration/volume/attach_detach_test.go
+++ b/test/integration/volume/attach_detach_test.go
@@ -148,10 +148,9 @@ var defaultTimerConfig = attachdetach.TimerConfig{
 func TestPodTerminationWithNodeOOSDetach(t *testing.T) {
 	// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
-	defer server.TearDownFn()
+	t.Cleanup(server.TearDownFn)
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 	testClient, ctrl, pvCtrl, podgcCtrl, informers := createAdClients(tCtx, t, server, defaultSyncPeriod, attachdetach.TimerConfig{
 		ReconcilerLoopPeriod:                        100 * time.Millisecond,
 		ReconcilerMaxWaitForUnmountDuration:         6 * time.Second,
@@ -240,7 +239,7 @@ func TestPodTerminationWithNodeOOSDetach(t *testing.T) {
 func TestPodDeletionWithDswp(t *testing.T) {
 	// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
-	defer server.TearDownFn()
+	t.Cleanup(server.TearDownFn)
 
 	namespaceName := "test-pod-deletion"
 	node := &v1.Node{
@@ -253,7 +252,6 @@ func TestPodDeletionWithDswp(t *testing.T) {
 	}
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 	testClient, ctrl, pvCtrl, podgcCtrl, informers := createAdClients(tCtx, t, server, defaultSyncPeriod, defaultTimerConfig)
 
 	ns := framework.CreateNamespaceOrDie(testClient, namespaceName, t)
@@ -315,7 +313,7 @@ func initCSIObjects(stopCh <-chan struct{}, informers clientgoinformers.SharedIn
 func TestPodUpdateWithADC(t *testing.T) {
 	// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
-	defer server.TearDownFn()
+	t.Cleanup(server.TearDownFn)
 	namespaceName := "test-pod-update"
 
 	node := &v1.Node{
@@ -328,7 +326,6 @@ func TestPodUpdateWithADC(t *testing.T) {
 	}
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 	testClient, ctrl, pvCtrl, podgcCtrl, informers := createAdClients(tCtx, t, server, defaultSyncPeriod, defaultTimerConfig)
 
 	ns := framework.CreateNamespaceOrDie(testClient, namespaceName, t)
@@ -504,7 +501,7 @@ func createAdClients(ctx context.Context, t *testing.T, server *kubeapiservertes
 func TestPodAddedByDswp(t *testing.T) {
 	// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
-	defer server.TearDownFn()
+	t.Cleanup(server.TearDownFn)
 	namespaceName := "test-pod-deletion"
 
 	node := &v1.Node{
@@ -517,7 +514,6 @@ func TestPodAddedByDswp(t *testing.T) {
 	}
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 	testClient, ctrl, pvCtrl, podgcCtrl, informers := createAdClients(tCtx, t, server, defaultSyncPeriod, defaultTimerConfig)
 
 	ns := framework.CreateNamespaceOrDie(testClient, namespaceName, t)
@@ -582,10 +578,9 @@ func TestPodAddedByDswp(t *testing.T) {
 func TestPVCBoundWithADC(t *testing.T) {
 	// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
-	defer server.TearDownFn()
+	t.Cleanup(server.TearDownFn)
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 
 	namespaceName := "test-pod-deletion"
 

--- a/test/integration/volume/persistent_volumes_test.go
+++ b/test/integration/volume/persistent_volumes_test.go
@@ -116,11 +116,10 @@ func testSleep() {
 func TestPersistentVolumeRecycler(t *testing.T) {
 	klog.V(2).Infof("TestPersistentVolumeRecycler started")
 	s := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins=ServiceAccount,StorageObjectInUseProtection"}, framework.SharedEtcd())
-	defer s.TearDownFn()
+	t.Cleanup(s.TearDownFn)
 	namespaceName := "pv-recycler"
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 
 	testClient, ctrl, informers, watchPV, watchPVC := createClients(tCtx, namespaceName, t, s, defaultSyncPeriod)
 	defer watchPV.Stop()
@@ -173,11 +172,10 @@ func TestPersistentVolumeRecycler(t *testing.T) {
 func TestPersistentVolumeDeleter(t *testing.T) {
 	klog.V(2).Infof("TestPersistentVolumeDeleter started")
 	s := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins=ServiceAccount,StorageObjectInUseProtection"}, framework.SharedEtcd())
-	defer s.TearDownFn()
+	t.Cleanup(s.TearDownFn)
 	namespaceName := "pv-deleter"
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 	testClient, ctrl, informers, watchPV, watchPVC := createClients(tCtx, namespaceName, t, s, defaultSyncPeriod)
 	defer watchPV.Stop()
 	defer watchPVC.Stop()
@@ -234,11 +232,10 @@ func TestPersistentVolumeBindRace(t *testing.T) {
 	// PVC. Only this specific PVC should get bound.
 	klog.V(2).Infof("TestPersistentVolumeBindRace started")
 	s := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins=ServiceAccount,StorageObjectInUseProtection"}, framework.SharedEtcd())
-	defer s.TearDownFn()
+	t.Cleanup(s.TearDownFn)
 	namespaceName := "pv-bind-race"
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 	testClient, ctrl, informers, watchPV, watchPVC := createClients(tCtx, namespaceName, t, s, defaultSyncPeriod)
 	defer watchPV.Stop()
 	defer watchPVC.Stop()
@@ -307,11 +304,10 @@ func TestPersistentVolumeBindRace(t *testing.T) {
 // TestPersistentVolumeClaimLabelSelector test binding using label selectors
 func TestPersistentVolumeClaimLabelSelector(t *testing.T) {
 	s := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins=ServiceAccount,StorageObjectInUseProtection"}, framework.SharedEtcd())
-	defer s.TearDownFn()
+	t.Cleanup(s.TearDownFn)
 	namespaceName := "pvc-label-selector"
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 	testClient, controller, informers, watchPV, watchPVC := createClients(tCtx, namespaceName, t, s, defaultSyncPeriod)
 	defer watchPV.Stop()
 	defer watchPVC.Stop()
@@ -389,11 +385,10 @@ func TestPersistentVolumeClaimLabelSelector(t *testing.T) {
 // MatchExpressions label selectors
 func TestPersistentVolumeClaimLabelSelectorMatchExpressions(t *testing.T) {
 	s := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins=ServiceAccount,StorageObjectInUseProtection"}, framework.SharedEtcd())
-	defer s.TearDownFn()
+	t.Cleanup(s.TearDownFn)
 	namespaceName := "pvc-match-expressions"
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 	testClient, controller, informers, watchPV, watchPVC := createClients(tCtx, namespaceName, t, s, defaultSyncPeriod)
 	defer watchPV.Stop()
 	defer watchPVC.Stop()
@@ -490,11 +485,10 @@ func TestPersistentVolumeClaimLabelSelectorMatchExpressions(t *testing.T) {
 // different size.
 func TestPersistentVolumeMultiPVs(t *testing.T) {
 	s := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins=ServiceAccount,StorageObjectInUseProtection"}, framework.SharedEtcd())
-	defer s.TearDownFn()
+	t.Cleanup(s.TearDownFn)
 	namespaceName := "multi-pvs"
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 	testClient, controller, informers, watchPV, watchPVC := createClients(tCtx, namespaceName, t, s, defaultSyncPeriod)
 	defer watchPV.Stop()
 	defer watchPVC.Stop()
@@ -679,10 +673,9 @@ func TestPersistentVolumeClaimVolumeAttirbutesClassName(t *testing.T) {
 			}
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, tc.featureEnabled)
 			s := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins=ServiceAccount,StorageObjectInUseProtection"}, framework.SharedEtcd())
-			defer s.TearDownFn()
+			t.Cleanup(s.TearDownFn)
 
 			tCtx := ktesting.Init(t)
-			defer tCtx.Cancel("test has completed")
 			testClient, controller, informers, watchPV, watchPVC := createClients(tCtx, namespaceName, t, s, defaultSyncPeriod)
 			defer watchPV.Stop()
 			defer watchPVC.Stop()
@@ -758,11 +751,10 @@ func TestPersistentVolumeClaimVolumeAttirbutesClassName(t *testing.T) {
 // This test is configurable by KUBE_INTEGRATION_PV_* variables.
 func TestPersistentVolumeMultiPVsPVCs(t *testing.T) {
 	s := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins=ServiceAccount,StorageObjectInUseProtection"}, framework.SharedEtcd())
-	defer s.TearDownFn()
+	t.Cleanup(s.TearDownFn)
 	namespaceName := "multi-pvs-pvcs"
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 	testClient, binder, informers, watchPV, watchPVC := createClients(tCtx, namespaceName, t, s, defaultSyncPeriod)
 	defer watchPV.Stop()
 	defer watchPVC.Stop()
@@ -920,7 +912,7 @@ func TestPersistentVolumeMultiPVsPVCs(t *testing.T) {
 // The controller should not unbind any volumes when it starts.
 func TestPersistentVolumeControllerStartup(t *testing.T) {
 	s := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins=ServiceAccount,StorageObjectInUseProtection"}, framework.SharedEtcd())
-	defer s.TearDownFn()
+	t.Cleanup(s.TearDownFn)
 	namespaceName := "controller-startup"
 
 	objCount := getObjectCount()
@@ -929,7 +921,6 @@ func TestPersistentVolumeControllerStartup(t *testing.T) {
 	syncPeriod := getSyncPeriod(shortSyncPeriod)
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 	testClient, binder, informers, watchPV, watchPVC := createClients(tCtx, namespaceName, t, s, shortSyncPeriod)
 	defer watchPV.Stop()
 	defer watchPVC.Stop()
@@ -1052,11 +1043,10 @@ func TestPersistentVolumeControllerStartup(t *testing.T) {
 // This test is configurable by KUBE_INTEGRATION_PV_* variables.
 func TestPersistentVolumeProvisionMultiPVCs(t *testing.T) {
 	s := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins=ServiceAccount,StorageObjectInUseProtection"}, framework.SharedEtcd())
-	defer s.TearDownFn()
+	t.Cleanup(s.TearDownFn)
 	namespaceName := "provision-multi-pvs"
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 	testClient, binder, informers, watchPV, watchPVC := createClients(tCtx, namespaceName, t, s, defaultSyncPeriod)
 	defer watchPV.Stop()
 	defer watchPVC.Stop()
@@ -1148,11 +1138,10 @@ func TestPersistentVolumeProvisionMultiPVCs(t *testing.T) {
 // PVs with different access modes.
 func TestPersistentVolumeMultiPVsDiffAccessModes(t *testing.T) {
 	s := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins=ServiceAccount,StorageObjectInUseProtection"}, framework.SharedEtcd())
-	defer s.TearDownFn()
+	t.Cleanup(s.TearDownFn)
 	namespaceName := "multi-pvs-diff-access"
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 	testClient, controller, informers, watchPV, watchPVC := createClients(tCtx, namespaceName, t, s, defaultSyncPeriod)
 	defer watchPV.Stop()
 	defer watchPVC.Stop()
@@ -1231,13 +1220,12 @@ func TestPersistentVolumeMultiPVsDiffAccessModes(t *testing.T) {
 // and without presence of a default SC.
 func TestRetroactiveStorageClassAssignment(t *testing.T) {
 	s := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins=DefaultStorageClass"}, framework.SharedEtcd())
-	defer s.TearDownFn()
+	t.Cleanup(s.TearDownFn)
 	namespaceName := "retro-pvc-sc"
 	defaultStorageClassName := "gold"
 	storageClassName := "silver"
 
 	tCtx := ktesting.Init(t)
-	defer tCtx.Cancel("test has completed")
 	testClient, binder, informers, watchPV, watchPVC := createClients(tCtx, namespaceName, t, s, defaultSyncPeriod)
 	defer watchPV.Stop()
 	defer watchPVC.Stop()


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Since https://github.com/kubernetes/kubernetes/pull/141545, a TContext created by ktesting.Init is automatically canceled as soon as the test binary considers the test done, before any t.Cleanup callback runs. Previously, many tests had to explicitly call tCtx.Cancel(...) at the end of the test (typically via defer) to stop tCtx-driven background goroutines (controllers, informers, schedulers) because automatic cancellation only happened during Cleanup, i.e. too late. That workaround is now redundant and is removed throughout the codebase.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

Three different patterns had to be handled, depending on what the removed Cancel call was ordering:

 - Bare "defer tCtx.Cancel(...)" with nothing else depending on it: simply deleted. This wasn't necessary in the first place.

 - "tCtx.Cancel(...)" followed by dependent code in the same defer/closure (e.g. wg.Wait(), informerFactory.Shutdown(), runtime.WaitForShutdown()): kept the dependent code but moved it (without the Cancel call) into tCtx.Cleanup(...), since Cleanup callbacks now reliably run only after the automatic cancellation.

 - "tCtx.Cancel(...)" was ordering a *separate* deferred teardown function (e.g. "defer closeFn()" or "defer server.TearDownFn()") registered *earlier* in the same function. Because Go defers run LIFO, the old code relied on Cancel (registered later) running before that teardown (registered earlier), guaranteeing tCtx-driven goroutines stopped before the apiserver they talk to was torn down. Simply deleting the Cancel call would break this ordering: the deferred teardown would now run immediately when the test function returns, while the goroutine keeps running unconstrained until the (now later) automatic cancellation during Cleanup - risking connection errors or a "Log in goroutine after Test has completed" panic. These sites were fixed by converting the deferred teardown into a t.Cleanup/tCtx.Cleanup registration.

   In some cases the teardown can be removed entirely by directly registering the corresponding operation inside the setup function.

Left untouched: Cancel calls used for legitimate mid-test, explicit timing (e.g. servicecidr's migration test cancels the first controller before switching to a second apiserver), and self-contained helpers that synchronously call Cancel as their own first action regardless of ktesting's automatic timing (e.g. resourceclaim's stopInformers, invoked both via defer and explicitly mid-test).


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### AI usage disclosure:

YES. I explained how to remove explicit cancel calls and an agent did the work. I reviewed.