### PR TITLE
kubectl: Refactor flags and options in `kubectl exec` cmd

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
@@ -78,14 +78,27 @@ const (
 	defaultPodExecTimeout = 60 * time.Second
 )
 
-func NewCmdExec(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
-	options := &ExecOptions{
-		StreamOptions: StreamOptions{
-			IOStreams: streams,
-		},
+// ExecFlags directly reflect the information that CLI is gathering via flags.
+type ExecFlags struct {
+	resource.FilenameOptions
 
-		Executor: &DefaultRemoteExecutor{},
+	ContainerName string
+	Stdin         bool
+	TTY           bool
+	Quiet         bool
+
+	genericiooptions.IOStreams
+}
+
+// NewExecFlags returns a default ExecFlags
+func NewExecFlags(streams genericiooptions.IOStreams) *ExecFlags {
+	return &ExecFlags{
+		IOStreams: streams,
 	}
+}
+
+func NewCmdExec(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+	flags := NewExecFlags(streams)
 	cmd := &cobra.Command{
 		Use:                   "exec (POD | TYPE/NAME) [-c CONTAINER] [flags] -- COMMAND [args...]",
 		DisableFlagsInUseLine: true,
@@ -95,21 +108,27 @@ func NewCmdExec(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Co
 		ValidArgsFunction:     completion.PodResourceNameCompletionFunc(f),
 		Run: func(cmd *cobra.Command, args []string) {
 			argsLenAtDash := cmd.ArgsLenAtDash()
-			cmdutil.CheckErr(options.Complete(f, cmd, args, argsLenAtDash))
-			cmdutil.CheckErr(options.Validate())
-			cmdutil.CheckErr(options.Run())
+			o, err := flags.ToOptions(f, cmd, args, argsLenAtDash)
+			cmdutil.CheckErr(err)
+			cmdutil.CheckErr(o.Validate())
+			cmdutil.CheckErr(o.Run())
 		},
 	}
-	cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodExecTimeout)
-	cmdutil.AddJsonFilenameFlag(cmd.Flags(), &options.FilenameOptions.Filenames, "to use to exec into the resource")
-	// TODO support UID
-	cmdutil.AddContainerVarFlags(cmd, &options.ContainerName, options.ContainerName)
+	flags.AddFlags(cmd)
 	cmdutil.CheckErr(cmd.RegisterFlagCompletionFunc("container", completion.ContainerCompletionFunc(f)))
-
-	cmd.Flags().BoolVarP(&options.Stdin, "stdin", "i", options.Stdin, "Pass stdin to the container")
-	cmd.Flags().BoolVarP(&options.TTY, "tty", "t", options.TTY, "Stdin is a TTY")
-	cmd.Flags().BoolVarP(&options.Quiet, "quiet", "q", options.Quiet, "Only print output from the remote session")
 	return cmd
+}
+
+// AddFlags registers flags for a cli
+func (flags *ExecFlags) AddFlags(cmd *cobra.Command) {
+	cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodExecTimeout)
+	cmdutil.AddJsonFilenameFlag(cmd.Flags(), &flags.FilenameOptions.Filenames, "to use to exec into the resource")
+	// TODO support UID
+	cmdutil.AddContainerVarFlags(cmd, &flags.ContainerName, flags.ContainerName)
+
+	cmd.Flags().BoolVarP(&flags.Stdin, "stdin", "i", flags.Stdin, "Pass stdin to the container")
+	cmd.Flags().BoolVarP(&flags.TTY, "tty", "t", flags.TTY, "Stdin is a TTY")
+	cmd.Flags().BoolVarP(&flags.Quiet, "quiet", "q", flags.Quiet, "Only print output from the remote session")
 }
 
 // RemoteExecutor defines the interface accepted by the Exec command - provided for test stubbing
@@ -203,47 +222,60 @@ type ExecOptions struct {
 	Config        *restclient.Config
 }
 
-// Complete verifies command line arguments and loads data from the command environment
-func (p *ExecOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, argsIn []string, argsLenAtDash int) error {
+// ToOptions converts from CLI inputs to runtime inputs
+func (flags *ExecFlags) ToOptions(f cmdutil.Factory, cmd *cobra.Command, argsIn []string, argsLenAtDash int) (*ExecOptions, error) {
+	o := &ExecOptions{
+		StreamOptions: StreamOptions{
+			ContainerName: flags.ContainerName,
+			Stdin:         flags.Stdin,
+			TTY:           flags.TTY,
+			Quiet:         flags.Quiet,
+			IOStreams:     flags.IOStreams,
+		},
+		FilenameOptions: flags.FilenameOptions,
+
+		Executor: &DefaultRemoteExecutor{},
+	}
+
 	if len(argsIn) > 0 && argsLenAtDash != 0 {
-		p.ResourceName = argsIn[0]
+		o.ResourceName = argsIn[0]
 	}
 	// we expect exactly one arg (the pod/resource name) before the dash separator.
 	// pflag guarantees `argsLenAtDash <= len(args)`.
 	if argsLenAtDash == 0 || argsLenAtDash == 1 {
-		p.Command = argsIn[argsLenAtDash:]
-	} else if len(argsIn) > 1 || (len(argsIn) > 0 && len(p.FilenameOptions.Filenames) != 0) {
-		return cmdutil.UsageErrorf(cmd, "exec [POD] [COMMAND] is not supported anymore. Use exec [POD] -- [COMMAND] instead")
+		o.Command = argsIn[argsLenAtDash:]
+	} else if len(argsIn) > 1 || (len(argsIn) > 0 && len(flags.FilenameOptions.Filenames) != 0) {
+		return nil, fmt.Errorf("exec [POD] [COMMAND] is not supported anymore. Use exec [POD] -- [COMMAND] instead")
 	}
 
 	var err error
-	p.Namespace, p.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
+	o.Namespace, o.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	p.ExecutablePodFn = polymorphichelpers.AttachablePodForObjectFn
+	o.ExecutablePodFn = polymorphichelpers.AttachablePodForObjectFn
 
-	p.GetPodTimeout, err = cmdutil.GetPodRunningTimeoutFlag(cmd)
+	o.GetPodTimeout, err = cmdutil.GetPodRunningTimeoutFlag(cmd)
 	if err != nil {
-		return cmdutil.UsageErrorf(cmd, "%s", err.Error())
+		return nil, err
 	}
 
-	p.Builder = f.NewBuilder
-	p.restClientGetter = f
+	o.Builder = f.NewBuilder
+	o.restClientGetter = f
 
-	p.Config, err = f.ToRESTConfig()
+	o.Config, err = f.ToRESTConfig()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	clientset, err := f.KubernetesClientSet()
 	if err != nil {
-		return err
+		return nil, err
 	}
-	p.PodClient = clientset.CoreV1()
+	o.PodClient = clientset.CoreV1()
 
-	return nil
+	return o, nil
 }
 
 // Validate checks that the provided exec options are specified.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec_test.go
@@ -58,7 +58,7 @@ func TestPodAndContainer(t *testing.T) {
 	tests := []struct {
 		args              []string
 		argsLenAtDash     int
-		p                 *ExecOptions
+		flags             *ExecFlags
 		name              string
 		expectError       bool
 		expectedPod       string
@@ -67,27 +67,27 @@ func TestPodAndContainer(t *testing.T) {
 		obj               *corev1.Pod
 	}{
 		{
-			p:             &ExecOptions{},
+			flags:         &ExecFlags{},
 			argsLenAtDash: -1,
 			expectError:   true,
 			name:          "empty",
 		},
 		{
-			p:             &ExecOptions{},
+			flags:         &ExecFlags{},
 			argsLenAtDash: -1,
 			expectError:   true,
 			name:          "no cmd",
 			obj:           execPod(),
 		},
 		{
-			p:             &ExecOptions{StreamOptions: StreamOptions{ContainerName: "bar"}},
+			flags:         &ExecFlags{ContainerName: "bar"},
 			argsLenAtDash: -1,
 			expectError:   true,
 			name:          "no cmd, w/ container",
 			obj:           execPod(),
 		},
 		{
-			p:             &ExecOptions{},
+			flags:         &ExecFlags{},
 			args:          []string{"foo", "cmd"},
 			argsLenAtDash: 0,
 			expectError:   true,
@@ -95,7 +95,7 @@ func TestPodAndContainer(t *testing.T) {
 			obj:           execPod(),
 		},
 		{
-			p:             &ExecOptions{},
+			flags:         &ExecFlags{},
 			args:          []string{"foo"},
 			argsLenAtDash: -1,
 			expectError:   true,
@@ -103,7 +103,7 @@ func TestPodAndContainer(t *testing.T) {
 			obj:           execPod(),
 		},
 		{
-			p:             &ExecOptions{},
+			flags:         &ExecFlags{},
 			args:          []string{"foo", "cmd"},
 			argsLenAtDash: 1,
 			expectedPod:   "foo",
@@ -112,7 +112,7 @@ func TestPodAndContainer(t *testing.T) {
 			obj:           execPod(),
 		},
 		{
-			p:             &ExecOptions{},
+			flags:         &ExecFlags{},
 			args:          []string{"foo", "cmd"},
 			argsLenAtDash: -1,
 			expectError:   true,
@@ -120,7 +120,7 @@ func TestPodAndContainer(t *testing.T) {
 			obj:           execPod(),
 		},
 		{
-			p:             &ExecOptions{StreamOptions: StreamOptions{ContainerName: "bar"}},
+			flags:         &ExecFlags{ContainerName: "bar"},
 			args:          []string{"foo", "cmd"},
 			argsLenAtDash: -1,
 			expectError:   true,
@@ -128,7 +128,7 @@ func TestPodAndContainer(t *testing.T) {
 			obj:           execPod(),
 		},
 		{
-			p:             &ExecOptions{},
+			flags:         &ExecFlags{},
 			args:          []string{"foo", "cmd", "bar"},
 			argsLenAtDash: 2,
 			expectError:   true,
@@ -136,7 +136,7 @@ func TestPodAndContainer(t *testing.T) {
 			obj:           execPod(),
 		},
 		{
-			p:             &ExecOptions{},
+			flags:         &ExecFlags{},
 			args:          []string{"foo", "--any-flag", "any-value"},
 			argsLenAtDash: -1,
 			expectError:   true,
@@ -159,14 +159,16 @@ func TestPodAndContainer(t *testing.T) {
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
 			cmd := NewCmdExec(tf, genericiooptions.NewTestIOStreamsDiscard())
-			options := test.p
-			options.ErrOut = bytes.NewBuffer([]byte{})
-			options.Out = bytes.NewBuffer([]byte{})
-			err = options.Complete(tf, cmd, test.args, test.argsLenAtDash)
+			flags := test.flags
+			flags.ErrOut = bytes.NewBuffer([]byte{})
+			flags.Out = bytes.NewBuffer([]byte{})
+			options, err := flags.ToOptions(tf, cmd, test.args, test.argsLenAtDash)
 			if !test.expectError && err != nil {
 				t.Errorf("%s: unexpected error: %v", test.name, err)
 			}
-			err = options.Validate()
+			if err == nil {
+				err = options.Validate()
+			}
 
 			if test.expectError && err == nil {
 				t.Errorf("%s: unexpected non-error", test.name)
@@ -247,20 +249,19 @@ func TestExec(t *testing.T) {
 			if test.execErr {
 				ex.execErr = fmt.Errorf("exec error")
 			}
-			params := &ExecOptions{
-				StreamOptions: StreamOptions{
-					PodName:       "foo",
-					ContainerName: "bar",
-					IOStreams:     genericiooptions.NewTestIOStreamsDiscard(),
-				},
-				Executor: ex,
+			flags := &ExecFlags{
+				ContainerName: "bar",
+				IOStreams:     genericiooptions.NewTestIOStreamsDiscard(),
 			}
 			cmd := NewCmdExec(tf, genericiooptions.NewTestIOStreamsDiscard())
 			args := []string{"pod/foo", "--", "command"}
-			if err := params.Complete(tf, cmd, args, 1); err != nil {
+			params, err := flags.ToOptions(tf, cmd, args, 1)
+			if err != nil {
 				t.Fatal(err)
 			}
-			err := params.Run()
+			params.PodName = "foo"
+			params.Executor = ex
+			err = params.Run()
 			if test.execErr && err != ex.execErr {
 				t.Errorf("%s: Unexpected exec error: %v", test.name, err)
 				return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR decouples the command options from the input flags. The input flags from the command are then translated to options which are further used while running the command.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```


