### PR TITLE
scheduler: reuse NodeInfo after HTTP extender filter

### DIFF
--- a/pkg/scheduler/extender.go
+++ b/pkg/scheduler/extender.go
@@ -32,7 +32,6 @@ import (
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 	fwk "k8s.io/kube-scheduler/framework"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
-	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
 const (
@@ -306,8 +305,15 @@ func (h *HTTPExtender) Filter(
 	} else if result.Nodes != nil {
 		nodeResult = make([]fwk.NodeInfo, len(result.Nodes.Items))
 		for i := range result.Nodes.Items {
-			nodeResult[i] = framework.NewNodeInfo()
-			nodeResult[i].SetNode(&result.Nodes.Items[i])
+			nodeName := result.Nodes.Items[i].Name
+			if n, ok := fromNodeName[nodeName]; ok {
+				// Keep the snapshot NodeInfo (pods, requested resources).
+				nodeResult[i] = n
+			} else {
+				return nil, nil, nil, fmt.Errorf(
+					"extender %q claims a filtered node %q which is not found in the input node list",
+					h.extenderURL, nodeName)
+			}
 		}
 	}
 

--- a/pkg/scheduler/extender_test.go
+++ b/pkg/scheduler/extender_test.go
@@ -18,6 +18,9 @@ package scheduler
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -576,4 +579,102 @@ func TestConvertToVictims(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHTTPExtenderFilterReusesNodeInfo(t *testing.T) {
+	busyNode := createNode("busy")
+	idleNode := createNode("idle")
+
+	busyInfo := framework.NewNodeInfo(st.MakePod().Name("filler").UID("filler").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Obj())
+	busyInfo.SetNode(busyNode)
+	idleInfo := framework.NewNodeInfo()
+	idleInfo.SetNode(idleNode)
+
+	if busyInfo.GetRequested().GetMilliCPU() == 0 {
+		t.Fatal("precondition: busy node should have requested CPU")
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/filter", func(w http.ResponseWriter, r *http.Request) {
+		var args extenderv1.ExtenderArgs
+		if err := json.NewDecoder(r.Body).Decode(&args); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		result := extenderv1.ExtenderFilterResult{}
+		if args.NodeNames != nil {
+			result.NodeNames = args.NodeNames
+		} else {
+			result.Nodes = args.Nodes
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(result)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	pod := st.MakePod().Name("incoming").UID("incoming").Obj()
+	nodes := []fwk.NodeInfo{busyInfo, idleInfo}
+
+	t.Run("nodeCacheCapable=false", func(t *testing.T) {
+		ext := &HTTPExtender{
+			extenderURL:      srv.URL,
+			filterVerb:       "filter",
+			client:           srv.Client(),
+			nodeCacheCapable: false,
+		}
+		got, _, _, err := ext.Filter(pod, nodes)
+		if err != nil {
+			t.Fatalf("Filter() unexpected error: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("Filter() returned %d nodes, want 2", len(got))
+		}
+		if got[0] != busyInfo {
+			t.Fatalf("Filter() did not reuse the original busy NodeInfo")
+		}
+		if got[0].GetRequested().GetMilliCPU() == 0 {
+			t.Fatalf("busy node requested CPU was 0 after Filter")
+		}
+		if got[1] != idleInfo {
+			t.Fatalf("Filter() did not reuse the original idle NodeInfo")
+		}
+	})
+
+	t.Run("nodeCacheCapable=true", func(t *testing.T) {
+		ext := &HTTPExtender{
+			extenderURL:      srv.URL,
+			filterVerb:       "filter",
+			client:           srv.Client(),
+			nodeCacheCapable: true,
+		}
+		got, _, _, err := ext.Filter(pod, nodes)
+		if err != nil {
+			t.Fatalf("Filter() unexpected error: %v", err)
+		}
+		if len(got) != 2 || got[0] != busyInfo || got[1] != idleInfo {
+			t.Fatalf("Filter() did not reuse original NodeInfos: %#v", got)
+		}
+	})
+
+	t.Run("unknown node", func(t *testing.T) {
+		unknown := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			result := extenderv1.ExtenderFilterResult{
+				Nodes: &v1.NodeList{Items: []v1.Node{*createNode("missing")}},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(result)
+		}))
+		t.Cleanup(unknown.Close)
+		ext := &HTTPExtender{
+			extenderURL:      unknown.URL,
+			filterVerb:       "filter",
+			client:           unknown.Client(),
+			nodeCacheCapable: false,
+		}
+		_, _, _, err := ext.Filter(pod, nodes)
+		if err == nil {
+			t.Fatal("Filter() expected error for unknown node")
+		}
+	})
 }


### PR DESCRIPTION
HTTP extender Filter with `nodeCacheCapable=false` was wrapping the returned `v1.Node` in a new empty NodeInfo. After #130537, Score plugins use that NodeInfo directly, so NodeResourcesFit / NodeResourcesBalancedAllocation saw zero requested CPU/memory on every node.

Look the node up in the input list instead, same as the `nodeCacheCapable=true` path.

Fixes #141781

/kind bug
/sig scheduling

```release-note
Fixed scheduler scoring when an HTTP extender is configured with nodeCacheCapable=false. Nodes no longer look empty to resource scoring plugins after extender filter.
```