### PR TITLE
Automated cherry pick of #141035: Avoid reconcile panic on error

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/reconcile.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/reconcile.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
@@ -271,6 +272,9 @@ func (o *ReconcileOptions) RunReconcile() error {
 				result, err = reconcileOptions.Run()
 				return err
 			})
+			if err != nil {
+				return err
+			}
 			o.printResults(result.RoleBinding.GetObject(), result.MissingSubjects, result.ExtraSubjects, nil, nil, result.Operation, result.Protected)
 
 		case *rbacv1.ClusterRoleBinding:
@@ -290,6 +294,9 @@ func (o *ReconcileOptions) RunReconcile() error {
 				result, err = reconcileOptions.Run()
 				return err
 			})
+			if err != nil {
+				return err
+			}
 			o.printResults(result.RoleBinding.GetObject(), result.MissingSubjects, result.ExtraSubjects, nil, nil, result.Operation, result.Protected)
 
 		case *rbacv1beta1.Role,


### PR DESCRIPTION
Cherry pick of #141035 on release-1.35.

#141035: Avoid reconcile panic on error

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

**Motivation for the backport:** downstream controllers that vendor `k8s.io/kubectl` and call `auth reconcile` in-process (Argo CD's application-controller does this for Role/RoleBinding resources) crash with this panic whenever the target cluster's API request fails, taking every application on that controller shard down with it. A patched 1.36/1.35 kubectl lets those projects pick up the fix without moving to a new minor.

#### What type of PR is this?
/kind bug

```release-note
Fixes a panic in `kubectl auth reconcile` if an error was encountered reconciling a rolebinding or clusterrolebinding
```


#### AI usage disclosure:
YES. An AI coding agent I operate drafted this cherry-pick and its description; I reviewed the diff and ran the tests myself before opening it. I point the agent only at problems I have actually hit in my own work — here, Argo CD's application-controller panicking in-process on `auth reconcile` — not at producing contributions.
