### PR TITLE
Automated cherry pick of #141307: DRA: avoid integer overflow in per-claim device-limit checks

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math"
 	"slices"
 	"testing"
 	"time"
@@ -2310,6 +2311,60 @@ func TestAllocator(t *testing.T,
 
 			expectError: gomega.MatchError(gomega.ContainSubstring("exceeds the claim limit")),
 		},
+		// Two counts that are each representable but together overflow the native
+		// int accumulator to a negative value, rejected before the sum is formed.
+		// The value comes from math.MaxInt so it also triggers on 32-bit builds.
+		"exact-count-total-overflows-claim-limit": {
+			claimsToAllocate: objects(claim(claim0).withRequests(
+				deviceRequest(req0, classA, int64(math.MaxInt/2+1)),
+				deviceRequest(req1, classA, int64(math.MaxInt/2+1)),
+			)),
+			classes:     objects(class(classA, driverA)),
+			expectError: gomega.MatchError(gomega.ContainSubstring("exceeds the claim limit")),
+		},
+		// Four counts that would wrap a naive int accumulator back to zero rather
+		// than negative; each is rejected against remaining capacity before summing.
+		"exact-count-total-would-wrap-to-zero": {
+			claimsToAllocate: objects(claim(claim0).withRequests(
+				deviceRequest(req0, classA, int64(math.MaxInt/2+1)),
+				deviceRequest(req1, classA, int64(math.MaxInt/2+1)),
+				deviceRequest(req2, classA, int64(math.MaxInt/2+1)),
+				deviceRequest(req3, classA, int64(math.MaxInt/2+1)),
+			)),
+			classes:     objects(class(classA, driverA)),
+			expectError: gomega.MatchError(gomega.ContainSubstring("exceeds the claim limit")),
+		},
+		// req0 fits on its own, so the rejection has to name req1 as the one
+		// that pushes the claim over.
+		"exact-count-sum-exceeds-claim-limit": {
+			claimsToAllocate: objects(claim(claim0).withRequests(
+				deviceRequest(req0, classA, 20),
+				deviceRequest(req1, classA, 20),
+			)),
+			classes: objects(class(classA, driverA)),
+			expectError: gomega.MatchError(gomega.And(
+				gomega.ContainSubstring("request "+req1),
+				gomega.ContainSubstring("exceeds the claim limit"),
+			)),
+		},
+		// Two counts whose sum exactly fills the per-claim limit both allocate;
+		// this pins the pre-flight comparison as > and not >=.
+		"exact-count-sum-exactly-fills-claim-limit": {
+			claimsToAllocate: objects(claim(claim0).withRequests(
+				deviceRequest(req0, classA, resourceapi.AllocationResultsMaxSize/2),
+				deviceRequest(req1, classA, resourceapi.AllocationResultsMaxSize/2),
+			)),
+			classes: objects(class(classA, driverA)),
+			slices:  unwrapResourceSlices(sliceWithMultipleDevices(slice1, node1, pool1, driverA, resourceapi.AllocationResultsMaxSize)),
+			node:    node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				slices.Concat(
+					multipleDeviceAllocationResults(req0, driverA, pool1, resourceapi.AllocationResultsMaxSize/2, 0),
+					multipleDeviceAllocationResults(req1, driverA, pool1, resourceapi.AllocationResultsMaxSize/2, resourceapi.AllocationResultsMaxSize/2),
+				)...,
+			)},
+		},
 		"all-devices-invalid-CEL": {
 			claimsToAllocate: objects(claimWithRequests(claim0, nil, request(req0, classA, 500))),
 			classes:          objects(class(classA, driverA)),
@@ -2815,6 +2870,49 @@ func TestAllocator(t *testing.T,
 				localNodeSelector(node1),
 				deviceAllocationResult(req0SubReq1, driverA, pool1, device1, false),
 			)},
+		},
+		// A prioritized list is worth at least its smallest alternative, so the
+		// pre-flight check reads that. min(20, 24) leaves the claim over the
+		// limit before any device is looked at.
+		"prioritized-list-minimum-sum-exceeds-claim-limit": {
+			features: Features{PrioritizedList: true},
+			claimsToAllocate: objects(claim(claim0).withRequests(
+				deviceRequest(req0, classA, 20),
+				requestWithPrioritizedList(req1,
+					subRequest(subReq0, classA, 20),
+					subRequest(subReq1, classA, 24),
+				),
+			)),
+			classes: objects(class(classA, driverA)),
+			expectError: gomega.MatchError(gomega.And(
+				gomega.ContainSubstring("request "+req1),
+				gomega.ContainSubstring("exceeds the claim limit"),
+			)),
+		},
+		// The oversized alternative sits behind a device already allocated for the
+		// claim, which is what overflowed the per-request check. Only the pinned
+		// invocation count separates pruning it from descending into it.
+		"prioritized-list-overflowing-first-subrequest-is-pruned": {
+			features: Features{PrioritizedList: true},
+			claimsToAllocate: objects(claim(claim0).withRequests(
+				deviceRequest(req0, classA, 1),
+				requestWithPrioritizedList(req1,
+					subRequest(subReq0, classA, int64(math.MaxInt)),
+					subRequest(subReq1, classA, 1),
+				),
+			)),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
+				device(device1, nil, nil),
+				device(device2, nil, nil),
+			)),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device1, false),
+				deviceAllocationResult(req1SubReq1, driverA, pool1, device2, false),
+			)},
+			expectNumAllocateOneInvocations: 8,
 		},
 		"partitionable-devices-single-device": {
 			features: Features{

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -220,11 +220,10 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 				}
 			}
 
+			var minDevicesPerRequest int
 			if hasSubRequests {
-				// We need to find the minimum number of devices that can be allocated
-				// for the request, so setting this to a high number so we can do the
-				// easy comparison in the loop.
-				minDevicesPerRequest := math.MaxInt
+				// Seeded high so the loop below can take the minimum.
+				minDevicesPerRequest = math.MaxInt
 				// A request with subrequests gets one entry per subrequest in alloc.requestData.
 				// We can only predict a lower number of devices because it depends on which
 				// subrequest gets chosen.
@@ -236,30 +235,25 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 					}
 					requestKey.subRequestIndex = i
 					alloc.requestData[requestKey] = reqData
-					if reqData.numDevices < minDevicesPerRequest {
-						minDevicesPerRequest = reqData.numDevices
-					}
+					minDevicesPerRequest = min(minDevicesPerRequest, reqData.numDevices)
 				}
-				minDevicesPerClaim += minDevicesPerRequest
 			} else {
 				reqData, err := alloc.validateDeviceRequest(&exactDeviceRequestAccessor{request: request}, nil, requestKey, pools)
 				if err != nil {
 					return nil, err
 				}
 				alloc.requestData[requestKey] = reqData
-				minDevicesPerClaim += reqData.numDevices
+				minDevicesPerRequest = reqData.numDevices
 			}
+			// Compare against the remaining capacity before adding, so a large count cannot overflow the total.
+			if minDevicesPerRequest > resourceapi.AllocationResultsMaxSize-minDevicesPerClaim {
+				return nil, fmt.Errorf("claim %s, request %s: adding %d devices exceeds the claim limit of %d, with %d already accounted for", klog.KObj(claim), request.Name, minDevicesPerRequest, resourceapi.AllocationResultsMaxSize, minDevicesPerClaim)
+			}
+			minDevicesPerClaim += minDevicesPerRequest
 		}
 		alloc.logger.V(6).Info("Checked claim", "claim", klog.KObj(claim), "minDevices", minDevicesPerClaim)
-		// Check that we don't end up with too many results.
-		// This isn't perfectly reliable because numDevicesPerClaim is
-		// only a lower bound, so allocation also has to check this.
-		if minDevicesPerClaim > resourceapi.AllocationResultsMaxSize {
-			return nil, fmt.Errorf("claim %s: number of requested devices %d exceeds the claim limit of %d", klog.KObj(claim), minDevicesPerClaim, resourceapi.AllocationResultsMaxSize)
-		}
 
-		// If we don't, then we can pre-allocate the result slices for
-		// appending the actual results later.
+		// Only a lower bound: a subrequest may pick more, so allocateOne checks the limit again.
 		alloc.result[claimIndex].devices = make([]internalDeviceResult, 0, minDevicesPerClaim)
 
 		// Constraints are assumed to be monotonic: once a constraint returns
@@ -979,13 +973,11 @@ func (alloc *allocator) allocateOne(r deviceIndices, allocateSubRequest bool) (b
 		return success, err
 	}
 
-	// Before trying to allocate devices, check if allocating the devices
-	// in the current request will put us over the threshold.
-	// We can calculate this by adding the number of already allocated devices with the number
-	// of devices in the current request, and then finally subtract the deviceIndex since we
-	// don't want to double count any devices already allocated for the current request.
-	numDevicesAfterAlloc := len(alloc.result[r.claimIndex].devices) + requestData.numDevices - r.deviceIndex
-	if numDevicesAfterAlloc > resourceapi.AllocationResultsMaxSize {
+	// Compare rather than add, so a large count cannot wrap the sum. deviceIndex
+	// is below numDevices here, checked above, so remaining stays positive.
+	remaining := requestData.numDevices - r.deviceIndex
+	available := resourceapi.AllocationResultsMaxSize - len(alloc.result[r.claimIndex].devices)
+	if remaining > available {
 		// Return a special error so we can identify this situation in the
 		// callers and do more aggressive backtracking.
 		return false, errAllocationResultMaxSizeExceeded

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
@@ -174,12 +174,10 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 				return nil, fmt.Errorf("claim %s, request %s: has subrequests, but the DRAPrioritizedList feature is disabled", klog.KObj(claim), request.Name)
 			}
 
+			var minDevicesPerRequest int
 			if hasSubRequests {
-				// We need to find the minimum number of devices that can be allocated
-				// for the request, so setting this to a high number so we can do the
-				// easy comparison in the loop.
-				minDevicesPerRequest := math.MaxInt
-
+				// Seeded high so the loop below can take the minimum.
+				minDevicesPerRequest = math.MaxInt
 				// A request with subrequests gets one entry per subrequest in alloc.requestData.
 				// We can only predict a lower number of devices because it depends on which
 				// subrequest gets chosen.
@@ -191,30 +189,25 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 					}
 					requestKey.subRequestIndex = i
 					alloc.requestData[requestKey] = reqData
-					if reqData.numDevices < minDevicesPerRequest {
-						minDevicesPerRequest = reqData.numDevices
-					}
+					minDevicesPerRequest = min(minDevicesPerRequest, reqData.numDevices)
 				}
-				minDevicesPerClaim += minDevicesPerRequest
 			} else {
 				reqData, err := alloc.validateDeviceRequest(&exactDeviceRequestAccessor{request: request}, nil, requestKey, pools)
 				if err != nil {
 					return nil, err
 				}
 				alloc.requestData[requestKey] = reqData
-				minDevicesPerClaim += reqData.numDevices
+				minDevicesPerRequest = reqData.numDevices
 			}
+			// Compare against the remaining capacity before adding, so a large count cannot overflow the total.
+			if minDevicesPerRequest > resourceapi.AllocationResultsMaxSize-minDevicesPerClaim {
+				return nil, fmt.Errorf("claim %s, request %s: adding %d devices exceeds the claim limit of %d, with %d already accounted for", klog.KObj(claim), request.Name, minDevicesPerRequest, resourceapi.AllocationResultsMaxSize, minDevicesPerClaim)
+			}
+			minDevicesPerClaim += minDevicesPerRequest
 		}
 		alloc.logger.V(6).Info("Checked claim", "claim", klog.KObj(claim), "minDevices", minDevicesPerClaim)
-		// Check that we don't end up with too many results.
-		// This isn't perfectly reliable because numDevicesPerClaim is
-		// only a lower bound, so allocation also has to check this.
-		if minDevicesPerClaim > resourceapi.AllocationResultsMaxSize {
-			return nil, fmt.Errorf("claim %s: number of requested devices %d exceeds the claim limit of %d", klog.KObj(claim), minDevicesPerClaim, resourceapi.AllocationResultsMaxSize)
-		}
 
-		// If we don't, then we can pre-allocate the result slices for
-		// appending the actual results later.
+		// Only a lower bound: a subrequest may pick more, so allocateOne checks the limit again.
 		alloc.result[claimIndex].devices = make([]internalDeviceResult, 0, minDevicesPerClaim)
 
 		// Constraints are assumed to be monotonic: once a constraint returns
@@ -877,13 +870,11 @@ func (alloc *allocator) allocateOne(r deviceIndices, allocateSubRequest bool) (b
 		return success, err
 	}
 
-	// Before trying to allocate devices, check if allocating the devices
-	// in the current request will put us over the threshold.
-	// We can calculate this by adding the number of already allocated devices with the number
-	// of devices in the current request, and then finally subtract the deviceIndex since we
-	// don't want to double count any devices already allocated for the current request.
-	numDevicesAfterAlloc := len(alloc.result[r.claimIndex].devices) + requestData.numDevices - r.deviceIndex
-	if numDevicesAfterAlloc > resourceapi.AllocationResultsMaxSize {
+	// Compare rather than add, so a large count cannot wrap the sum. deviceIndex
+	// is below numDevices here, checked above, so remaining stays positive.
+	remaining := requestData.numDevices - r.deviceIndex
+	available := resourceapi.AllocationResultsMaxSize - len(alloc.result[r.claimIndex].devices)
+	if remaining > available {
 		// Return a special error so we can identify this situation in the
 		// callers and do more aggressive backtracking.
 		return false, errAllocationResultMaxSizeExceeded

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_stable.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_stable.go
@@ -165,12 +165,10 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 				return nil, fmt.Errorf("claim %s, request %s: has subrequests, but the DRAPrioritizedList feature is disabled", klog.KObj(claim), request.Name)
 			}
 
+			var minDevicesPerRequest int
 			if hasSubRequests {
-				// We need to find the minimum number of devices that can be allocated
-				// for the request, so setting this to a high number so we can do the
-				// easy comparison in the loop.
-				minDevicesPerRequest := math.MaxInt
-
+				// Seeded high so the loop below can take the minimum.
+				minDevicesPerRequest = math.MaxInt
 				// A request with subrequests gets one entry per subrequest in alloc.requestData.
 				// We can only predict a lower number of devices because it depends on which
 				// subrequest gets chosen.
@@ -182,30 +180,25 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 					}
 					requestKey.subRequestIndex = i
 					alloc.requestData[requestKey] = reqData
-					if reqData.numDevices < minDevicesPerRequest {
-						minDevicesPerRequest = reqData.numDevices
-					}
+					minDevicesPerRequest = min(minDevicesPerRequest, reqData.numDevices)
 				}
-				minDevicesPerClaim += minDevicesPerRequest
 			} else {
 				reqData, err := alloc.validateDeviceRequest(&exactDeviceRequestAccessor{request: request}, nil, requestKey, pools)
 				if err != nil {
 					return nil, err
 				}
 				alloc.requestData[requestKey] = reqData
-				minDevicesPerClaim += reqData.numDevices
+				minDevicesPerRequest = reqData.numDevices
 			}
+			// Compare against the remaining capacity before adding, so a large count cannot overflow the total.
+			if minDevicesPerRequest > resourceapi.AllocationResultsMaxSize-minDevicesPerClaim {
+				return nil, fmt.Errorf("claim %s, request %s: adding %d devices exceeds the claim limit of %d, with %d already accounted for", klog.KObj(claim), request.Name, minDevicesPerRequest, resourceapi.AllocationResultsMaxSize, minDevicesPerClaim)
+			}
+			minDevicesPerClaim += minDevicesPerRequest
 		}
 		alloc.logger.V(6).Info("Checked claim", "claim", klog.KObj(claim), "minDevices", minDevicesPerClaim)
-		// Check that we don't end up with too many results.
-		// This isn't perfectly reliable because numDevicesPerClaim is
-		// only a lower bound, so allocation also has to check this.
-		if minDevicesPerClaim > resourceapi.AllocationResultsMaxSize {
-			return nil, fmt.Errorf("claim %s: number of requested devices %d exceeds the claim limit of %d", klog.KObj(claim), minDevicesPerClaim, resourceapi.AllocationResultsMaxSize)
-		}
 
-		// If we don't, then we can pre-allocate the result slices for
-		// appending the actual results later.
+		// Only a lower bound: a subrequest may pick more, so allocateOne checks the limit again.
 		alloc.result[claimIndex].devices = make([]internalDeviceResult, 0, minDevicesPerClaim)
 
 		// Constraints are assumed to be monotonic: once a constraint returns
@@ -790,11 +783,11 @@ func (alloc *allocator) allocateOne(r deviceIndices, allocateSubRequest bool) (b
 		return alloc.allocateOne(deviceIndices{claimIndex: r.claimIndex, requestIndex: r.requestIndex + 1}, false)
 	}
 
-	// We can calculate this by adding the number of already allocated devices with the number
-	// of devices in the current request, and then finally subtract the deviceIndex since we
-	// don't want to double count any devices already allocated for the current request.
-	numDevicesAfterAlloc := len(alloc.result[r.claimIndex].devices) + requestData.numDevices - r.deviceIndex
-	if numDevicesAfterAlloc > resourceapi.AllocationResultsMaxSize {
+	// Compare rather than add, so a large count cannot wrap the sum. deviceIndex
+	// is below numDevices here, checked above, so remaining stays positive.
+	remaining := requestData.numDevices - r.deviceIndex
+	available := resourceapi.AllocationResultsMaxSize - len(alloc.result[r.claimIndex].devices)
+	if remaining > available {
 		// Don't return an error here since we want to keep searching for
 		// a solution that works.
 		return false, nil


### PR DESCRIPTION
Cherry pick of #141307 on release-1.35.

#141307: DRA: avoid integer overflow in per-claim device-limit checks

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it
Backports the per-claim device-limit overflow fix. The pre-flight loop in `Allocate` sums each request's device count into `minDevicesPerClaim` as a native `int`, and `allocateOne` builds `len(results) + numDevices - deviceIndex` the same way. Two `ExactCount` requests of `math.MaxInt/2 + 1` wrap the sum negative, so the `> AllocationResultsMaxSize` check is false and the negative total goes on to size the result slice.

Reaching it takes no feature gate. `DeviceRequest.Count` is validated only as `> 0`, and all three allocator variants on this branch carry the unguarded arithmetic, so whichever one a feature configuration selects is affected.

#### Which issue(s) this PR fixes
Backport of #141307, which fixes #141323 on master. pohly asked for the cherry pick there, then reopened #141323 with the condition that it stays open until 1.34 through 1.37 all carry the fix. The full set is #141922 for release-1.37, #141923 for release-1.36, #141924 for release-1.35 and #141925 for release-1.34.

#### Special notes for your reviewer
Not a clean cherry-pick. Three files conflicted and each needed a decision.

1. `stable/allocator_stable.go`. Master returns `errAllocationResultMaxSizeExceeded` from the `allocateOne` size check. That sentinel does not exist in this branch's stable allocator, which returns `false, nil` and keeps searching. I took only the overflow-safe comparison and left the branch's return and comment alone. Nothing is lost by that: `stable.SupportedFeatures` is empty here, so stable is only selected when no allocator feature is enabled, and in that state it rejects a `firstAvailable` request outright rather than allocating one. The pruning the sentinel drives lives in incubating and experimental, which both keep it.

2. `incubating/allocator_incubating.go`. The three-way merge pulled a `DRAConsumableCapacity` feature check into the conflict as adjacent context. That check is not part of #141307 and is not on this branch, so I dropped it and kept only `var minDevicesPerRequest int` and the reseeding below it.

3. `allocatortesting/allocator_testing.go`. Master has a named `AllocatorTestCase` type and #141307 corrects its doc comment to say `expectNumAllocateOneInvocations` is asserted for every variant. Here the table is an anonymous struct inside the test function and the old comment still holds, because stable does not provide the stats on this branch. I kept the branch's struct and comment and took only the six new cases and the `math` import.

That leaves 4 files, +146/-72, against +148/-75 on master.

I built release-1.35 with the change and ran `go test ./staging/src/k8s.io/dynamic-resource-allocation/structured/...`, all green, and the six new cases pass.

Reverting the three production files and keeping the tests, on this branch:

```
--- FAIL: TestAllocator (0.00s)
    --- FAIL: TestAllocator/exact-count-total-overflows-claim-limit (0.00s)
        allocator_incubating.go:119: I0908 12:02:18.381842] Starting allocation numClaims=1 numSlices=0
        allocator_incubating.go:131: I0908 12:02:18.382134] Gathered pool information numPools=0 pools=[]
        allocator_incubating.go:208: I0908 12:02:18.382155] Checked claim claim="claim-0" minDevices=-9223372036854775808
        allocator_incubating.go:121: I0908 12:02:18.382169] Done with allocation success=false err=null
panic: runtime error: makeslice: cap out of range [recovered, repanicked]
```

The stack is trimmed there; the frame is `incubating.(*Allocator).Allocate` at `allocator_incubating.go:218`. `minDevices=-9223372036854775808` is the wrapped sum. The stable and experimental variants panic the same way.

This PR was written in part with the assistance of generative AI.

#### Does this PR introduce a user-facing change?

```release-note
kube-scheduler: a ResourceClaim whose device request counts add up past the int range no longer crashes the scheduler or skips the `firstAvailable` fallback in the DRA allocator. A request over the per-claim device limit is rejected with an error naming it, and an oversized `firstAvailable` alternative falls through to a smaller one.
```

