### PR TITLE
Prefer reschedulable victims when reprieving same-priority pods

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -419,7 +419,11 @@ func (pl *DefaultPreemption) SelectVictimsOnNode(
 		}
 	}
 
-	// Now we try to reprieve non-violating victims.
+	// Now we try to reprieve non-violating victims. Between two same-priority
+	// standalone victims, the one whose replacement cannot reschedule elsewhere
+	// is reprieved first (kubernetes/kubernetes#141227), so a hard-pinned victim
+	// is only evicted when a reschedulable victim alone cannot make room.
+	pl.sortVictimsForReprieve(logger, nonViolatingVictims)
 	for _, v := range nonViolatingVictims {
 		if _, err := reprieveVictim(v); err != nil {
 			return nil, 0, fwk.AsStatus(err)
@@ -438,6 +442,72 @@ func (pl *DefaultPreemption) SelectVictimsOnNode(
 	}
 
 	return victimPods, numViolatingVictim, nil
+}
+
+// sortVictimsForReprieve orders victims for the reprieve pass, most important
+// first. It follows MoreImportantVictim, except that between two same-priority
+// standalone pods it prefers the one whose replacement cannot reschedule
+// elsewhere: when either victim alone is enough for the preemptor, sparing the
+// hard-pinned victim lets its replacement stay put, while the reschedulable
+// victim's replacement can start on another node. Evicting the pinned victim
+// instead leaves its replacement permanently unschedulable, because
+// same-priority pods cannot preempt each other and its only legal node stays
+// occupied. Victims of different priority, group victims and victims whose
+// recoverability cannot be told apart keep the age-based ordering unchanged.
+func (pl *DefaultPreemption) sortVictimsForReprieve(logger klog.Logger, victims []*preemption.DomainVictim) {
+	// The ordering can only change when at least two same-priority standalone
+	// pods compete for the reprieve pass. Skip the snapshot listing otherwise,
+	// so the common case stays on the plain importance ordering.
+	standaloneByPriority := make(map[int32]int, len(victims))
+	needsRecoverability := false
+	for _, dv := range victims {
+		if dv.Type() != fwk.PodKeyType || len(dv.Pods()) != 1 {
+			continue
+		}
+		standaloneByPriority[dv.Priority()]++
+		if standaloneByPriority[dv.Priority()] > 1 {
+			needsRecoverability = true
+			break
+		}
+	}
+	if !needsRecoverability {
+		return
+	}
+
+	pinned := pl.pinnedVictims(logger, victims)
+	sort.Slice(victims, func(i, j int) bool {
+		vi, vj := victims[i].Victim, victims[j].Victim
+		if vi.Priority() == vj.Priority() && vi.Type() == fwk.PodKeyType && vj.Type() == fwk.PodKeyType {
+			pi, pj := pinned[victims[i]], pinned[victims[j]]
+			if pi != pj {
+				return pi
+			}
+		}
+		return pl.MoreImportantVictim(vi, vj)
+	})
+}
+
+// pinnedVictims reports, for each standalone-pod victim, whether its replacement
+// can only run on the pod's current node. Group victims are not classified.
+func (pl *DefaultPreemption) pinnedVictims(logger klog.Logger, victims []*preemption.DomainVictim) map[*preemption.DomainVictim]bool {
+	pinned := make(map[*preemption.DomainVictim]bool, len(victims))
+	nodeInfos, err := pl.fh.SnapshotSharedLister().NodeInfos().List()
+	if err != nil {
+		logger.Error(err, "Failed to list nodes for recoverability-aware victim ordering; falling back to the default ordering")
+		return pinned
+	}
+	nodes := make([]*v1.Node, 0, len(nodeInfos))
+	for _, nodeInfo := range nodeInfos {
+		nodes = append(nodes, nodeInfo.Node())
+	}
+	for _, dv := range victims {
+		if dv.Type() != fwk.PodKeyType || len(dv.Pods()) != 1 {
+			continue
+		}
+		pod := dv.Pods()[0].GetPod()
+		pinned[dv] = !preemption.CanRescheduleElsewhere(logger, pod, pod.Spec.NodeName, nodes, pl.fts.EnableTaintTolerationComparisonOperators)
+	}
+	return pinned
 }
 
 // PodEligibleToPreemptOthers returns one bool and one string. The bool

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -3084,6 +3084,91 @@ func TestSelectVictimsOnNode(t *testing.T) {
 			expectedNumViolatingVictim: 0,
 		},
 		{
+			// Repro for kubernetes/kubernetes#141227: two same-priority victims on one node,
+			// either one sufficient for the preemptor. movable-early can reschedule on node2;
+			// pinned-late (nodeSelector hostname=node1) cannot. Age decides today, so the later
+			// pinned pod is preempted and its replacement can never start on its only node.
+			name:      "#141227 repro: later pinned victim is preempted although an earlier movable victim exists",
+			nodeNames: []string{"node1", "node2"},
+			mainNode:  "node1",
+			initPods: []*v1.Pod{
+				st.MakePod().Name("movable-early").UID("m1").Node("node1").Priority(midPriority).Req(mediumRes).StartTime(epochTime1).Obj(),
+				st.MakePod().Name("pinned-late").UID("p1").Node("node1").Priority(midPriority).Req(mediumRes).StartTime(epochTime2).NodeSelector(map[string]string{"hostname": "node1"}).Obj(),
+			},
+			preemptor:    st.MakePod().Name("p").UID("p").Priority(highPriority).Req(largeRes).Obj(),
+			expectedPods: sets.New("movable-early"),
+		},
+		{
+			// #141227 control: when both victims can reschedule elsewhere, recoverability
+			// cannot tell them apart and the age tie-break is preserved.
+			name:      "#141227 control: both movable - age tie-break preserved",
+			nodeNames: []string{"node1", "node2"},
+			mainNode:  "node1",
+			initPods: []*v1.Pod{
+				st.MakePod().Name("movable-early").UID("m1").Node("node1").Priority(midPriority).Req(mediumRes).StartTime(epochTime1).Obj(),
+				st.MakePod().Name("movable-late").UID("m2").Node("node1").Priority(midPriority).Req(mediumRes).StartTime(epochTime2).Obj(),
+			},
+			preemptor:    st.MakePod().Name("p").UID("p").Priority(highPriority).Req(largeRes).Obj(),
+			expectedPods: sets.New("movable-late"),
+		},
+		{
+			// #141227 control: when neither victim can reschedule elsewhere, evicting
+			// either one leaves a stuck replacement, so the age tie-break is preserved.
+			name:      "#141227 control: both pinned - age tie-break preserved",
+			nodeNames: []string{"node1", "node2"},
+			mainNode:  "node1",
+			initPods: []*v1.Pod{
+				st.MakePod().Name("pinned-early").UID("p1").Node("node1").Priority(midPriority).Req(mediumRes).StartTime(epochTime1).NodeSelector(map[string]string{"hostname": "node1"}).Obj(),
+				st.MakePod().Name("pinned-late").UID("p2").Node("node1").Priority(midPriority).Req(mediumRes).StartTime(epochTime2).NodeSelector(map[string]string{"hostname": "node1"}).Obj(),
+			},
+			preemptor:    st.MakePod().Name("p").UID("p").Priority(highPriority).Req(largeRes).Obj(),
+			expectedPods: sets.New("pinned-late"),
+		},
+		{
+			// #141227 control: priority stays the explicit importance signal; a pinned
+			// mid-priority victim is still preempted when a reschedulable high-priority
+			// victim of the preemptor's space is available.
+			name:      "#141227 control: priority beats recoverability",
+			nodeNames: []string{"node1", "node2"},
+			mainNode:  "node1",
+			initPods: []*v1.Pod{
+				st.MakePod().Name("movable-high").UID("m1").Node("node1").Priority(highPriority).Req(mediumRes).StartTime(epochTime2).Obj(),
+				st.MakePod().Name("pinned-mid").UID("p1").Node("node1").Priority(midPriority).Req(mediumRes).StartTime(epochTime1).NodeSelector(map[string]string{"hostname": "node1"}).Obj(),
+			},
+			preemptor:    st.MakePod().Name("p").UID("p").Priority(veryHighPriority).Req(largeRes).Obj(),
+			expectedPods: sets.New("pinned-mid"),
+		},
+		{
+			// #141227 control: a victim pinned through required nodeAffinity (the shape
+			// DaemonSet controllers generate) is treated like a nodeSelector pin; the
+			// signal reads the pod's own constraints, not its owner.
+			name:      "#141227 control: nodeAffinity pin - movable victim preempted",
+			nodeNames: []string{"node1", "node2"},
+			mainNode:  "node1",
+			initPods: []*v1.Pod{
+				st.MakePod().Name("movable-early").UID("m1").Node("node1").Priority(midPriority).Req(mediumRes).StartTime(epochTime1).Obj(),
+				st.MakePod().Name("affinity-pinned-late").UID("p1").Node("node1").Priority(midPriority).Req(mediumRes).StartTime(epochTime2).NodeAffinityIn("hostname", []string{"node1"}, st.NodeSelectorTypeMatchExpressions).Obj(),
+			},
+			preemptor:    st.MakePod().Name("p").UID("p").Priority(highPriority).Req(largeRes).Obj(),
+			expectedPods: sets.New("movable-early"),
+		},
+		{
+			// #141227: with three same-priority victims where two must go, the pinned
+			// victim is still spared and both reschedulable victims are preempted;
+			// their replacements can start on node2, while evicting the pinned pod
+			// would leave a permanently unschedulable replacement.
+			name:      "#141227: two of three victims needed - pinned victim spared",
+			nodeNames: []string{"node1", "node2"},
+			mainNode:  "node1",
+			initPods: []*v1.Pod{
+				st.MakePod().Name("pinned").UID("p1").Node("node1").Priority(midPriority).Req(mediumRes).StartTime(epochTime1).NodeSelector(map[string]string{"hostname": "node1"}).Obj(),
+				st.MakePod().Name("movable-old").UID("m1").Node("node1").Priority(midPriority).Req(mediumRes).StartTime(epochTime2).Obj(),
+				st.MakePod().Name("movable-new").UID("m2").Node("node1").Priority(midPriority).Req(mediumRes).StartTime(epochTime3).Obj(),
+			},
+			preemptor:    st.MakePod().Name("p").UID("p").Priority(highPriority).Req(largeRes).Obj(),
+			expectedPods: sets.New("movable-old", "movable-new"),
+		},
+		{
 			name:      "PDB: Prefer non-violating victim with higher priority over violating victim with lower priority",
 			nodeNames: []string{"node1"},
 			mainNode:  "node1",

--- a/pkg/scheduler/framework/preemption/recoverability.go
+++ b/pkg/scheduler/framework/preemption/recoverability.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preemption
+
+import (
+	v1 "k8s.io/api/core/v1"
+	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
+	nodeaffinity "k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
+	"k8s.io/klog/v2"
+)
+
+// CanRescheduleElsewhere reports whether a replacement of pod, rebuilt from the
+// same spec without a node assignment, could satisfy pod's own hard scheduling
+// constraints (nodeSelector, required nodeAffinity and taints) on at least one
+// node other than current.
+//
+// Only the pod's own constraints are read; owner, priority and PDB state are
+// ignored. Resources, cordon state and soft constraints (preferred nodeAffinity,
+// topology spread) are deliberately not considered: a resource shortfall may
+// clear up by queueing, while a constraint mismatch cannot.
+func CanRescheduleElsewhere(logger klog.Logger, pod *v1.Pod, current string, nodes []*v1.Node, enableComparisonOperators bool) bool {
+	for _, node := range nodes {
+		if node == nil || node.Name == current {
+			continue
+		}
+		if podMatchesNodeConstraints(logger, pod, node, enableComparisonOperators) {
+			return true
+		}
+	}
+	return false
+}
+
+func podMatchesNodeConstraints(logger klog.Logger, pod *v1.Pod, node *v1.Node, enableComparisonOperators bool) bool {
+	// Reuse the same required node affinity evaluation as the nodeaffinity
+	// Filter plugin: pod.Spec.NodeSelector and required nodeAffinity together
+	// form the scheduler's node constraints for a pod.
+	if ok, err := nodeaffinity.NewRequiredNodeAffinity(pod.Spec.NodeSelector, pod.Spec.Affinity).Match(node); err != nil || !ok {
+		return false
+	}
+	if _, untolerated := corev1helpers.FindMatchingUntoleratedTaint(logger, node.Spec.Taints, pod.Spec.Tolerations, doNotScheduleTaintsFilterFunc, enableComparisonOperators); untolerated {
+		return false
+	}
+	return true
+}
+
+// doNotScheduleTaintsFilterFunc mirrors the taint-toleration Filter plugin: only
+// NoSchedule and NoExecute taints prevent a pod from being scheduled on a node.
+func doNotScheduleTaintsFilterFunc(t *v1.Taint) bool {
+	return t.Effect == v1.TaintEffectNoSchedule || t.Effect == v1.TaintEffectNoExecute
+}

--- a/pkg/scheduler/framework/preemption/recoverability_test.go
+++ b/pkg/scheduler/framework/preemption/recoverability_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preemption
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2/ktesting"
+)
+
+func TestCanRescheduleElsewhere(t *testing.T) {
+	node1 := makeNode("node1", map[string]string{"hostname": "node1"})
+	node2 := makeNode("node2", map[string]string{"hostname": "node2"})
+	taintedNode := makeNode("node3", map[string]string{"hostname": "node3"})
+	taintedNode.Spec.Taints = []v1.Taint{{Key: "dedicated", Value: "foo", Effect: v1.TaintEffectNoSchedule}}
+
+	testCases := map[string]struct {
+		pod         *v1.Pod
+		current     string
+		nodes       []*v1.Node
+		wantResched bool
+	}{
+		"unconstrained pod can move to another node": {
+			pod:         makePod("p", nil, nil, nil),
+			current:     "node1",
+			nodes:       []*v1.Node{node1, node2},
+			wantResched: true,
+		},
+		"no other node: unconstrained pod is treated as pinned": {
+			pod:         makePod("p", nil, nil, nil),
+			current:     "node1",
+			nodes:       []*v1.Node{node1},
+			wantResched: false,
+		},
+		"nodeSelector matching another node allows rescheduling": {
+			pod:         makePod("p", map[string]string{"hostname": "node2"}, nil, nil),
+			current:     "node1",
+			nodes:       []*v1.Node{node1, node2},
+			wantResched: true,
+		},
+		"nodeSelector matching only the current node pins the pod": {
+			pod:         makePod("p", map[string]string{"hostname": "node1"}, nil, nil),
+			current:     "node1",
+			nodes:       []*v1.Node{node1, node2},
+			wantResched: false,
+		},
+		"required nodeAffinity matching another node allows rescheduling": {
+			pod:         makePod("p", nil, affinityFor("node2"), nil),
+			current:     "node1",
+			nodes:       []*v1.Node{node1, node2},
+			wantResched: true,
+		},
+		"required nodeAffinity matching only the current node pins the pod": {
+			pod:         makePod("p", nil, affinityFor("node1"), nil),
+			current:     "node1",
+			nodes:       []*v1.Node{node1, node2},
+			wantResched: false,
+		},
+		"untolerated NoSchedule taint on every other node pins the pod": {
+			pod:         makePod("p", nil, nil, nil),
+			current:     "node1",
+			nodes:       []*v1.Node{node1, taintedNode},
+			wantResched: false,
+		},
+		"tolerated taint on another node allows rescheduling": {
+			pod: makePod("p", nil, nil, []v1.Toleration{
+				{Key: "dedicated", Value: "foo", Operator: v1.TolerationOpEqual, Effect: v1.TaintEffectNoSchedule},
+			}),
+			current:     "node1",
+			nodes:       []*v1.Node{node1, taintedNode},
+			wantResched: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+			got := CanRescheduleElsewhere(logger, tc.pod, tc.current, tc.nodes, false)
+			if got != tc.wantResched {
+				t.Errorf("CanRescheduleElsewhere() = %v, want %v", got, tc.wantResched)
+			}
+		})
+	}
+}
+
+func makeNode(name string, labels map[string]string) *v1.Node {
+	return &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+	}
+}
+
+func makePod(name string, nodeSelector map[string]string, affinity *v1.Affinity, tolerations []v1.Toleration) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1.PodSpec{
+			NodeSelector: nodeSelector,
+			Affinity:     affinity,
+			Tolerations:  tolerations,
+		},
+	}
+}
+
+func affinityFor(nodeName string) *v1.Affinity {
+	return &v1.Affinity{
+		NodeAffinity: &v1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{Key: "hostname", Operator: v1.NodeSelectorOpIn, Values: []string{nodeName}},
+						},
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When the preemptor fits as soon as either of two same-priority pods is
gone, the default preemption plugin picks the victim by age only, so the
later-started pod is always sacrificed. If that pod is hard-pinned to
its node (DaemonSet generated nodeAffinity, a nodeSelector matching a
single node, or an untolerated taint on every other node), its
replacement cannot start anywhere else: it cannot preempt the reprieved
same-priority pod, and its only legal node stays occupied by the
preemptor. The eviction leaves a permanently unschedulable pod, even
though evicting the other victim would have let its replacement run on
another node. See #141227 for the cluster reproduction where flipping
only the creation order flips the outcome between full recovery and a
permanently stuck DaemonSet replacement.

In the non-violating reprieve pass, this PR reprieves a same-priority
standalone victim whose replacement cannot reschedule elsewhere before
one whose replacement can, so the reschedulable victim is sacrificed
when either alone is enough for the preemptor.

The signal reads only the victim pod's own constraints: nodeSelector,
required nodeAffinity and taints. It never consults the owner, so a
Deployment pod pinned by a nodeSelector is treated exactly like a
DaemonSet pod, matching the discussion in the issue. Priority, PDB
handling and group victims keep their existing semantics:
- victims of different priority keep the priority ordering;
- only the non-violating group is reordered, so PDB violation
  classification is untouched;
- group victims (PodGroup / CompositePodGroup) are not classified;
- when both victims are pinned or both can reschedule, the age-based
  tie-break is preserved unchanged.

#### Which issue(s) this PR fixes:

Fixes #141227

#### Special notes for your reviewer:

- The reprieve ordering is only consulted when at least two
  same-priority standalone pods compete, so the common path does not
  list the node snapshot at all.
- Red/green: the repro test expects the movable victim with this change
  and fails on current master, where the pinned victim is selected.
  Controls cover both-movable, both-pinned, priority-vs-recoverability,
  a nodeAffinity pin and a three-victim case where two must be evicted.
- The constraint helper is unit tested for nodeSelector, required
  nodeAffinity, taints and the no-other-node case.
- The classification is deliberately resource- and cordon-blind, as
  scoped in the issue discussion. That is safe by construction: a
  hard-pinned victim is only evicted when the reprieve pass cannot fit
  the preemptor with it present, which is exactly when its replacement
  would not fit on the node either, so evicting a pinned victim always
  strands its replacement. With uneven pod sizes, sparing the pinned
  victim can require evicting several smaller reschedulable victims
  where today one pinned victim would be evicted; their replacements
  restart elsewhere, while today's choice leaves a pod that cannot
  start anywhere.
- Full pkg/scheduler test suite is green; gofmt and go vet are clean.

#### Does this PR introduce a user-facing change?

```release-note
The default preemption plugin now spares a hard-pinned same-priority
victim (for example a DaemonSet pod or a pod with a nodeSelector
matching a single node) when a same-priority victim whose replacement
can run on another node is available. Previously the later-started pod
was always sacrificed, which could leave a permanently unschedulable
replacement.
```

This PR was written in part with the assistance of generative AI.