### PR TITLE
golangci-lint: disable embedlit till Kubernetes 1.39

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -535,6 +535,16 @@ linters:
       # Analyzers which are kept enabled are not
       # called out here, see https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#section-documentation
       # for the full list.
+      #
+      # We don't pro-actively modernize existing code, so checks need to be disabled
+      # for the base config unless we happen to pass the check already.
+      # For new language features (identified with e.g. "go 1.27" for a feature added in 1.27)
+      # we hold back enabling as hint to reduce the risk that usage of the feature makes
+      # backporting harder. Waiting until all supported releases support the feature is safe,
+      # but it's also okay to go faster because backports to very old releases become less
+      # likely over time and some features might be worth a hint sooner - use common sense.
+      #
+      # Please keep sorted alphabetically.
       disable:
         # Replace interface{} with any.
         #
@@ -543,6 +553,9 @@ linters:
         # consistency with existing code
         # and it's just syntactic sugar.
         - any
+        # go 1.27: can declare embedded fields inline
+        # TODO Kubernetes 1.39: limit to base config
+        - embedlit
         # Suggest replacing omitempty with omitzero for struct fields.
         #
         # Disabled because might interfere

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -560,6 +560,16 @@ linters:
       # Analyzers which are kept enabled are not
       # called out here, see https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#section-documentation
       # for the full list.
+      #
+      # We don't pro-actively modernize existing code, so checks need to be disabled
+      # for the base config unless we happen to pass the check already.
+      # For new language features (identified with e.g. "go 1.27" for a feature added in 1.27)
+      # we hold back enabling as hint to reduce the risk that usage of the feature makes
+      # backporting harder. Waiting until all supported releases support the feature is safe,
+      # but it's also okay to go faster because backports to very old releases become less
+      # likely over time and some features might be worth a hint sooner - use common sense.
+      #
+      # Please keep sorted alphabetically.
       disable:
         # Replace interface{} with any.
         #
@@ -568,6 +578,13 @@ linters:
         # consistency with existing code
         # and it's just syntactic sugar.
         - any
+        # go 1.19: can simplify atomic int assignment/access
+        - atomictypes
+        # go 1.27: can declare embedded fields inline
+        # TODO Kubernetes 1.39: limit to base config
+        - embedlit
+        # go 1.26: can simplify with errors.AsType
+        - errorsastype
         # Replace explicit loops over maps with calls to maps package.
         #
         # Completely disabled because the benefit
@@ -577,36 +594,27 @@ linters:
         #
         # A useful hint for new code.
         - minmax
-
-        # Disable things that should only be updated in old code where it really matters.
-
         # go 1.26: can simplify with new(expr)
         - newexpr
+        # Replace 3-clause for loops with for-range over integers.
+        #
+        # A useful hint for new code (makes it shorter).
+        - rangeint
         # go 1.26: can use iterators instead of Len/At-style APIs
         - stditerators
-        # go 1.27: can declare embedded fields inline
-        - embedlit
-        # go 1.27: can simplify with reflect.TypeAssert
+        # go 1.25: can simplify with reflect.TypeAssert
         - reflecttypeassert
-        # go 1.27: can simplify atomic int assignment/access
-        - atomictypes
-        # go 1.27: can simplify with errors.AsType
-        - errorsastype
-        # go 1.27: can simplify with slices.Backward
+        # Replace reflect.TypeOf(x) with TypeFor[T]().
+        #
+        # A useful hint for new code, it could be more efficient.
+        - reflecttypefor
+        # go 1.23: can simplify with slices.Backward
         - slicesbackward
         # Suggest replacing omitempty with omitzero for struct fields.
         #
         # Disabled because might interfere
         # with encoding of API structs.
         - omitzero
-        # Replace 3-clause for loops with for-range over integers.
-        #
-        # A useful hint for new code (makes it shorter).
-        - rangeint
-        # Replace reflect.TypeOf(x) with TypeFor[T]().
-        #
-        # A useful hint for new code, it could be more efficient.
-        - reflecttypefor
         # Replace loops with slices.Contains or slices.ContainsFunc.
         #
         # A useful hint because it can make code more obvious

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -275,6 +275,16 @@ linters:
       # Analyzers which are kept enabled are not
       # called out here, see https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#section-documentation
       # for the full list.
+      #
+      # We don't pro-actively modernize existing code, so checks need to be disabled
+      # for the base config unless we happen to pass the check already.
+      # For new language features (identified with e.g. "go 1.27" for a feature added in 1.27)
+      # we hold back enabling as hint to reduce the risk that usage of the feature makes
+      # backporting harder. Waiting until all supported releases support the feature is safe,
+      # but it's also okay to go faster because backports to very old releases become less
+      # likely over time and some features might be worth a hint sooner - use common sense.
+      #
+      # Please keep sorted alphabetically.
       disable:
         # Replace interface{} with any.
         #
@@ -283,6 +293,17 @@ linters:
         # consistency with existing code
         # and it's just syntactic sugar.
         - any
+        {{- if .Base }}
+        # go 1.19: can simplify atomic int assignment/access
+        - atomictypes
+        {{- end }}
+        # go 1.27: can declare embedded fields inline
+        # TODO Kubernetes 1.39: limit to base config
+        - embedlit
+        {{- if .Base }}
+        # go 1.26: can simplify with errors.AsType
+        - errorsastype
+        {{- end }}
         {{- if .Base }}
         # Replace explicit loops over maps with calls to maps package.
         #
@@ -293,22 +314,21 @@ linters:
         #
         # A useful hint for new code.
         - minmax
-
-        # Disable things that should only be updated in old code where it really matters.
-
         # go 1.26: can simplify with new(expr)
         - newexpr
+        # Replace 3-clause for loops with for-range over integers.
+        #
+        # A useful hint for new code (makes it shorter).
+        - rangeint
         # go 1.26: can use iterators instead of Len/At-style APIs
         - stditerators
-        # go 1.27: can declare embedded fields inline
-        - embedlit
-        # go 1.27: can simplify with reflect.TypeAssert
+        # go 1.25: can simplify with reflect.TypeAssert
         - reflecttypeassert
-        # go 1.27: can simplify atomic int assignment/access
-        - atomictypes
-        # go 1.27: can simplify with errors.AsType
-        - errorsastype
-        # go 1.27: can simplify with slices.Backward
+        # Replace reflect.TypeOf(x) with TypeFor[T]().
+        #
+        # A useful hint for new code, it could be more efficient.
+        - reflecttypefor
+        # go 1.23: can simplify with slices.Backward
         - slicesbackward
         {{- end }}
         # Suggest replacing omitempty with omitzero for struct fields.
@@ -317,14 +337,6 @@ linters:
         # with encoding of API structs.
         - omitzero
         {{- if .Base }}
-        # Replace 3-clause for loops with for-range over integers.
-        #
-        # A useful hint for new code (makes it shorter).
-        - rangeint
-        # Replace reflect.TypeOf(x) with TypeFor[T]().
-        #
-        # A useful hint for new code, it could be more efficient.
-        - reflecttypefor
         # Replace loops with slices.Contains or slices.ContainsFunc.
         #
         # A useful hint because it can make code more obvious


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

embedlit depends on Go 1.27, so let's not encourage contributors to use it because it can make backporting harder. Should be okay to enable as hint in 1.38.

#### Which issue(s) this PR is related to:

Follow-up to https://github.com/kubernetes/kubernetes/pull/141663

#### Special notes for your reviewer:

While at it:
- sorting the disable section alphabetically to make it more deterministic where to find something
- fixing the "go" version comments (only embedlit is a new language feature in 1.27)
- documenting the section a bit better

/assign @skitt 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### AI usage disclosure:

NO