### PR TITLE
scheduler: parameterize topology-aware placement metrics with entity type

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -6519,11 +6519,12 @@
 - name: generated_placements_total
   subsystem: scheduler
   help: Number of candidate placements generated when scheduling pod groups, by scheduler
-    profile.
+    profile and entity type.
   type: Counter
   stabilityLevel: ALPHA
   labels:
   - profile
+  - type
   componentEndpoints:
   - component: kube-scheduler
     endpoint: /metrics
@@ -6574,13 +6575,14 @@
 - name: placement_evaluation_duration_seconds
   subsystem: scheduler
   help: Latency in seconds of evaluating a single candidate placement when scheduling
-    pod groups, by result and scheduler profile. 'feasible' means the pod group fit
-    into the placement, while 'infeasible' means it did not.
+    pod groups, by result, scheduler profile, and entity type. 'feasible' means the
+    pod group fit into the placement, while 'infeasible' means it did not.
   type: Histogram
   stabilityLevel: ALPHA
   labels:
   - profile
   - result
+  - type
   buckets:
   - 0.001
   - 0.002
@@ -6602,14 +6604,15 @@
     endpoint: /metrics
 - name: placement_evaluations_total
   subsystem: scheduler
-  help: Number of candidate placements evaluated when scheduling pod groups, by result
-    and scheduler profile. 'feasible' means the pod group fit into the placement,
-    while 'infeasible' means it did not.
+  help: Number of candidate placements evaluated when scheduling pod groups, by result,
+    scheduler profile, and entity type. 'feasible' means the pod group fit into the
+    placement, while 'infeasible' means it did not.
   type: Counter
   stabilityLevel: ALPHA
   labels:
   - profile
   - result
+  - type
   componentEndpoints:
   - component: kube-scheduler
     endpoint: /metrics

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -99,10 +99,11 @@ const (
 	QueueingHintResultError     = "Error"
 )
 
-// Entity label values used for queued_entities and queue_incoming_entities metrics.
+// Entity label values used for scheduling, queued_entities, and queue_incoming_entities metrics.
 const (
-	Pod      = "pod"
-	PodGroup = "podgroup"
+	Pod               = "pod"
+	PodGroup          = "podgroup"
+	CompositePodGroup = "compositepodgroup"
 )
 
 const (
@@ -674,24 +675,24 @@ func InitMetrics() {
 		&metrics.CounterOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "generated_placements_total",
-			Help:           "Number of candidate placements generated when scheduling pod groups, by scheduler profile.",
+			Help:           "Number of candidate placements generated when scheduling pod groups, by scheduler profile and entity type.",
 			StabilityLevel: metrics.ALPHA,
-		}, []string{"profile"})
+		}, []string{"profile", "type"})
 	PlacementEvaluations = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "placement_evaluations_total",
-			Help:           "Number of candidate placements evaluated when scheduling pod groups, by result and scheduler profile. 'feasible' means the pod group fit into the placement, while 'infeasible' means it did not.",
+			Help:           "Number of candidate placements evaluated when scheduling pod groups, by result, scheduler profile, and entity type. 'feasible' means the pod group fit into the placement, while 'infeasible' means it did not.",
 			StabilityLevel: metrics.ALPHA,
-		}, []string{"result", "profile"})
+		}, []string{"result", "profile", "type"})
 	PlacementEvaluationDuration = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "placement_evaluation_duration_seconds",
-			Help:           "Latency in seconds of evaluating a single candidate placement when scheduling pod groups, by result and scheduler profile. 'feasible' means the pod group fit into the placement, while 'infeasible' means it did not.",
+			Help:           "Latency in seconds of evaluating a single candidate placement when scheduling pod groups, by result, scheduler profile, and entity type. 'feasible' means the pod group fit into the placement, while 'infeasible' means it did not.",
 			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel: metrics.ALPHA,
-		}, []string{"result", "profile"})
+		}, []string{"result", "profile", "type"})
 
 	metricsList = []metrics.Registerable{
 		scheduleAttempts,

--- a/pkg/scheduler/metrics/profile_metrics.go
+++ b/pkg/scheduler/metrics/profile_metrics.go
@@ -79,15 +79,15 @@ func observePodGroupScheduleAttemptAndLatency(result, profile string, duration f
 	podGroupScheduleAttempts.WithLabelValues(result, profile).Inc()
 }
 
-// RecordGeneratedPlacements records the number of candidate placements generated for a
-// pod group in a single scheduling cycle.
-func RecordGeneratedPlacements(profile string, count int) {
-	GeneratedPlacementsTotal.WithLabelValues(profile).Add(float64(count))
+// RecordGeneratedPlacements records the number of candidate placements generated for an
+// entity in a single scheduling cycle.
+func RecordGeneratedPlacements(profile, entityType string, count int) {
+	GeneratedPlacementsTotal.WithLabelValues(profile, entityType).Add(float64(count))
 }
 
 // ObservePlacementEvaluation records a single candidate placement evaluation and the
 // duration, by result.
-func ObservePlacementEvaluation(result, profile string, duration float64) {
-	PlacementEvaluations.WithLabelValues(result, profile).Inc()
-	PlacementEvaluationDuration.WithLabelValues(result, profile).Observe(duration)
+func ObservePlacementEvaluation(result, profile, entityType string, duration float64) {
+	PlacementEvaluations.WithLabelValues(result, profile, entityType).Inc()
+	PlacementEvaluationDuration.WithLabelValues(result, profile, entityType).Observe(duration)
 }

--- a/pkg/scheduler/metrics/profile_metrics_test.go
+++ b/pkg/scheduler/metrics/profile_metrics_test.go
@@ -29,15 +29,17 @@ func TestRecordGeneratedPlacements(t *testing.T) {
 	registry := metrics.NewKubeRegistry()
 	registry.MustRegister(GeneratedPlacementsTotal)
 
-	RecordGeneratedPlacements("test-profile", 3)
-	RecordGeneratedPlacements("test-profile", 2)
-	RecordGeneratedPlacements("test-profile-2", 4)
+	RecordGeneratedPlacements("test-profile", PodGroup, 3)
+	RecordGeneratedPlacements("test-profile", PodGroup, 2)
+	RecordGeneratedPlacements("test-profile-2", PodGroup, 4)
+	RecordGeneratedPlacements("test-profile", CompositePodGroup, 1)
 
 	want := `
-		# HELP scheduler_generated_placements_total [ALPHA] Number of candidate placements generated when scheduling pod groups, by scheduler profile.
+		# HELP scheduler_generated_placements_total [ALPHA] Number of candidate placements generated when scheduling pod groups, by scheduler profile and entity type.
 		# TYPE scheduler_generated_placements_total counter
-		scheduler_generated_placements_total{profile="test-profile"} 5
-		scheduler_generated_placements_total{profile="test-profile-2"} 4
+		scheduler_generated_placements_total{profile="test-profile",type="compositepodgroup"} 1
+		scheduler_generated_placements_total{profile="test-profile",type="podgroup"} 5
+		scheduler_generated_placements_total{profile="test-profile-2",type="podgroup"} 4
 	`
 	if err := testutil.GatherAndCompare(registry, strings.NewReader(want), "scheduler_generated_placements_total"); err != nil {
 		t.Errorf("unexpected generated_placements_total metric output:\n%v", err)
@@ -50,43 +52,50 @@ func TestObservePlacementEvaluation(t *testing.T) {
 	registry.MustRegister(PlacementEvaluations)
 	registry.MustRegister(PlacementEvaluationDuration)
 
-	ObservePlacementEvaluation(FeasibleResult, "test-profile", 0.5)
-	ObservePlacementEvaluation(FeasibleResult, "test-profile", 0.5)
-	ObservePlacementEvaluation(InfeasibleResult, "test-profile", 0.1)
-	ObservePlacementEvaluation(FeasibleResult, "test-profile-2", 0.2)
-	ObservePlacementEvaluation(InfeasibleResult, "test-profile-2", 0.3)
+	ObservePlacementEvaluation(FeasibleResult, "test-profile", PodGroup, 0.5)
+	ObservePlacementEvaluation(FeasibleResult, "test-profile", PodGroup, 0.5)
+	ObservePlacementEvaluation(InfeasibleResult, "test-profile", PodGroup, 0.1)
+	ObservePlacementEvaluation(FeasibleResult, "test-profile-2", PodGroup, 0.2)
+	ObservePlacementEvaluation(InfeasibleResult, "test-profile-2", PodGroup, 0.3)
+	ObservePlacementEvaluation(FeasibleResult, "test-profile", CompositePodGroup, 0.4)
+	ObservePlacementEvaluation(InfeasibleResult, "test-profile", CompositePodGroup, 0.6)
 
 	wantCounter := `
-		# HELP scheduler_placement_evaluations_total [ALPHA] Number of candidate placements evaluated when scheduling pod groups, by result and scheduler profile. 'feasible' means the pod group fit into the placement, while 'infeasible' means it did not.
+		# HELP scheduler_placement_evaluations_total [ALPHA] Number of candidate placements evaluated when scheduling pod groups, by result, scheduler profile, and entity type. 'feasible' means the pod group fit into the placement, while 'infeasible' means it did not.
 		# TYPE scheduler_placement_evaluations_total counter
-		scheduler_placement_evaluations_total{profile="test-profile",result="feasible"} 2
-		scheduler_placement_evaluations_total{profile="test-profile",result="infeasible"} 1
-		scheduler_placement_evaluations_total{profile="test-profile-2",result="feasible"} 1
-		scheduler_placement_evaluations_total{profile="test-profile-2",result="infeasible"} 1
+		scheduler_placement_evaluations_total{profile="test-profile",result="feasible",type="compositepodgroup"} 1
+		scheduler_placement_evaluations_total{profile="test-profile",result="feasible",type="podgroup"} 2
+		scheduler_placement_evaluations_total{profile="test-profile",result="infeasible",type="compositepodgroup"} 1
+		scheduler_placement_evaluations_total{profile="test-profile",result="infeasible",type="podgroup"} 1
+		scheduler_placement_evaluations_total{profile="test-profile-2",result="feasible",type="podgroup"} 1
+		scheduler_placement_evaluations_total{profile="test-profile-2",result="infeasible",type="podgroup"} 1
 	`
 	if err := testutil.GatherAndCompare(registry, strings.NewReader(wantCounter), "scheduler_placement_evaluations_total"); err != nil {
 		t.Errorf("unexpected placement_evaluations_total metric output:\n%v", err)
 	}
 
 	// The duration histogram is recorded alongside the counter, so its sample
-	// count per profile/result must match the number of evaluations recorded above.
+	// count per profile/result/type must match the number of evaluations recorded above.
 	for _, tc := range []struct {
-		profile   string
-		result    string
-		wantCount uint64
+		profile    string
+		result     string
+		entityType string
+		wantCount  uint64
 	}{
-		{"test-profile", FeasibleResult, 2},
-		{"test-profile", InfeasibleResult, 1},
-		{"test-profile-2", FeasibleResult, 1},
-		{"test-profile-2", InfeasibleResult, 1},
+		{"test-profile", FeasibleResult, PodGroup, 2},
+		{"test-profile", InfeasibleResult, PodGroup, 1},
+		{"test-profile-2", FeasibleResult, PodGroup, 1},
+		{"test-profile-2", InfeasibleResult, PodGroup, 1},
+		{"test-profile", FeasibleResult, CompositePodGroup, 1},
+		{"test-profile", InfeasibleResult, CompositePodGroup, 1},
 	} {
-		gotCount, err := testutil.GetHistogramMetricCount(PlacementEvaluationDuration.WithLabelValues(tc.result, tc.profile))
+		gotCount, err := testutil.GetHistogramMetricCount(PlacementEvaluationDuration.WithLabelValues(tc.result, tc.profile, tc.entityType))
 		if err != nil {
-			t.Errorf("Failed to get sample count for placement_evaluation_duration_seconds{profile=%q,result=%q}: %v", tc.profile, tc.result, err)
+			t.Errorf("Failed to get sample count for placement_evaluation_duration_seconds{profile=%q,result=%q,type=%q}: %v", tc.profile, tc.result, tc.entityType, err)
 			continue
 		}
 		if gotCount != tc.wantCount {
-			t.Errorf("placement_evaluation_duration_seconds{profile=%q,result=%q}: got %d samples, want %d", tc.profile, tc.result, gotCount, tc.wantCount)
+			t.Errorf("placement_evaluation_duration_seconds{profile=%q,result=%q,type=%q}: got %d samples, want %d", tc.profile, tc.result, tc.entityType, gotCount, tc.wantCount)
 		}
 	}
 }

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -895,7 +895,7 @@ func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context
 			status:       status,
 		}, nil
 	}
-	metrics.RecordGeneratedPlacements(schedFwk.ProfileName(), len(placements))
+	metrics.RecordGeneratedPlacements(schedFwk.ProfileName(), string(podGroupInfo.GetType()), len(placements))
 
 	var anyResult *podGroupAlgorithmResult
 	successfulResults := make(map[*fwk.Placement]*podGroupAlgorithmResult)
@@ -940,7 +940,7 @@ func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context
 			evaluationResult = metrics.FeasibleResult
 			successfulResults[placement] = result
 		}
-		metrics.ObservePlacementEvaluation(evaluationResult, schedFwk.ProfileName(), metrics.SinceInSeconds(evaluationStart))
+		metrics.ObservePlacementEvaluation(evaluationResult, schedFwk.ProfileName(), string(podGroupInfo.GetType()), metrics.SinceInSeconds(evaluationStart))
 	}
 
 	if len(successfulResults) == 0 {
@@ -1001,6 +1001,7 @@ func (sched *Scheduler) compositePodGroupSchedulingPlacementAlgorithm(ctx contex
 			status:       status,
 		}, nil
 	}
+	metrics.RecordGeneratedPlacements(schedFwk.ProfileName(), string(podGroupInfo.GetType()), len(placements))
 
 	var anyResultSubtree map[fwk.EntityKey]*podGroupAlgorithmResult
 	successfulResults := make(map[*fwk.Placement]map[fwk.EntityKey]*podGroupAlgorithmResult)
@@ -1017,6 +1018,7 @@ func (sched *Scheduler) compositePodGroupSchedulingPlacementAlgorithm(ctx contex
 
 	for _, placement := range placements {
 		logger.V(4).Info("Assuming placement in snapshot", "placement", placement.Name)
+		evaluationStart := time.Now()
 		err := sched.nodeInfoSnapshot.AssumePlacement(placement)
 		if err != nil {
 			return &podGroupAlgorithmResult{
@@ -1042,9 +1044,12 @@ func (sched *Scheduler) compositePodGroupSchedulingPlacementAlgorithm(ctx contex
 			anyResultSubtree = subtreeResult
 		}
 
+		evaluationResult := metrics.InfeasibleResult
 		if result.status.IsSuccess() {
+			evaluationResult = metrics.FeasibleResult
 			successfulResults[placement] = subtreeResult
 		}
+		metrics.ObservePlacementEvaluation(evaluationResult, schedFwk.ProfileName(), string(podGroupInfo.GetType()), metrics.SinceInSeconds(evaluationStart))
 	}
 
 	if len(successfulResults) == 0 {

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -2454,14 +2454,14 @@ var statusCmpOpt = cmp.Comparer(func(s1 *fwk.Status, s2 *fwk.Status) bool {
 	return s1.Code() == s2.Code() && s1.Plugin() == s2.Plugin() && s1.Message() == s2.Message()
 })
 
-func assertCounterValueFromGatherer(t *testing.T, g componentmetrics.Gatherer, name, labelName, labelValue string, want int) {
+func assertCounterValueFromGatherer(t *testing.T, g componentmetrics.Gatherer, name string, fixedLabels map[string]string, labelName, labelValue string, want int) {
 	t.Helper()
 	got := 0
-	if vals, err := testutil.GetCounterValuesFromGatherer(g, name, nil, labelName); err == nil {
+	if vals, err := testutil.GetCounterValuesFromGatherer(g, name, fixedLabels, labelName); err == nil {
 		got = int(vals[labelValue])
 	}
 	if got != want {
-		t.Errorf("unexpected %s{%s=%q}: got %d, want %d", name, labelName, labelValue, got, want)
+		t.Errorf("unexpected %s with labels %v and %s=%q: got %d, want %d", name, fixedLabels, labelName, labelValue, got, want)
 	}
 }
 
@@ -2472,7 +2472,7 @@ func assertHistogramSampleCountFromGatherer(t *testing.T, g componentmetrics.Gat
 		got = int(vec.GetAggregatedSampleCount())
 	}
 	if got != want {
-		t.Errorf("unexpected %s%v sample count: got %d, want %d", name, labels, got, want)
+		t.Errorf("unexpected %s sample count with labels %v: got %d, want %d", name, labels, got, want)
 	}
 }
 
@@ -2914,13 +2914,21 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 					t.Fatalf("Unexpected algorithm result (-want,+got):\n%s", diff)
 				}
 
-				feasibleLabels := map[string]string{"profile": "test-scheduler", "result": metrics.FeasibleResult}
-				infeasibleLabels := map[string]string{"profile": "test-scheduler", "result": metrics.InfeasibleResult}
-				assertCounterValueFromGatherer(t, testRegistry, "scheduler_generated_placements_total", "profile", "test-scheduler", tt.expectedGeneratedPlacements)
-				assertCounterValueFromGatherer(t, testRegistry, "scheduler_placement_evaluations_total", "result", metrics.FeasibleResult, tt.expectedFeasibleEvaluations)
-				assertCounterValueFromGatherer(t, testRegistry, "scheduler_placement_evaluations_total", "result", metrics.InfeasibleResult, tt.expectedInfeasibleEvaluations)
+				baseLabels := map[string]string{"profile": "test-scheduler"}
+				fixedLabels := map[string]string{"profile": "test-scheduler", "type": metrics.PodGroup}
+				feasibleLabels := map[string]string{"profile": "test-scheduler", "result": metrics.FeasibleResult, "type": metrics.PodGroup}
+				infeasibleLabels := map[string]string{"profile": "test-scheduler", "result": metrics.InfeasibleResult, "type": metrics.PodGroup}
+				assertCounterValueFromGatherer(t, testRegistry, "scheduler_generated_placements_total", baseLabels, "type", metrics.PodGroup, tt.expectedGeneratedPlacements)
+				assertCounterValueFromGatherer(t, testRegistry, "scheduler_placement_evaluations_total", fixedLabels, "result", metrics.FeasibleResult, tt.expectedFeasibleEvaluations)
+				assertCounterValueFromGatherer(t, testRegistry, "scheduler_placement_evaluations_total", fixedLabels, "result", metrics.InfeasibleResult, tt.expectedInfeasibleEvaluations)
 				assertHistogramSampleCountFromGatherer(t, testRegistry, "scheduler_placement_evaluation_duration_seconds", feasibleLabels, tt.expectedFeasibleEvaluations)
 				assertHistogramSampleCountFromGatherer(t, testRegistry, "scheduler_placement_evaluation_duration_seconds", infeasibleLabels, tt.expectedInfeasibleEvaluations)
+
+				// Verify compositepodgroup metrics are 0
+				cpgFixedLabels := map[string]string{"profile": "test-scheduler", "type": metrics.CompositePodGroup}
+				assertCounterValueFromGatherer(t, testRegistry, "scheduler_generated_placements_total", baseLabels, "type", metrics.CompositePodGroup, 0)
+				assertCounterValueFromGatherer(t, testRegistry, "scheduler_placement_evaluations_total", cpgFixedLabels, "result", metrics.FeasibleResult, 0)
+				assertCounterValueFromGatherer(t, testRegistry, "scheduler_placement_evaluations_total", cpgFixedLabels, "result", metrics.InfeasibleResult, 0)
 			})
 		}
 	}
@@ -3563,6 +3571,8 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 		features.GenericWorkload:                 true,
 		features.CompositePodGroup:               true,
 	})
+	testRegistry := componentmetrics.NewKubeRegistry()
+	testRegistry.MustRegister(metrics.GeneratedPlacementsTotal, metrics.PlacementEvaluations, metrics.PlacementEvaluationDuration)
 
 	nodes := []*v1.Node{
 		st.MakeNode().Name("node1").Obj(),
@@ -3617,9 +3627,12 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		placementPlugin           fakePlacementPlugin
-		placementFeasibleStatuses [][]fwk.Code
-		expectedResults           map[fwk.EntityKey]podGroupAlgorithmResult
+		placementPlugin               fakePlacementPlugin
+		placementFeasibleStatuses     [][]fwk.Code
+		expectedResults               map[fwk.EntityKey]podGroupAlgorithmResult
+		expectedGeneratedPlacements   map[string]int
+		expectedFeasibleEvaluations   map[string]int
+		expectedInfeasibleEvaluations map[string]int
 	}{
 		"respects higher score of parent placement": {
 			placementPlugin: fakePlacementPlugin{
@@ -3669,6 +3682,18 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 						},
 					},
 				},
+			},
+			expectedGeneratedPlacements: map[string]int{
+				metrics.CompositePodGroup: 2,
+				metrics.PodGroup:          8,
+			},
+			expectedFeasibleEvaluations: map[string]int{
+				metrics.CompositePodGroup: 2,
+				metrics.PodGroup:          8,
+			},
+			expectedInfeasibleEvaluations: map[string]int{
+				metrics.CompositePodGroup: 0,
+				metrics.PodGroup:          0,
 			},
 		},
 		"discards infeasible placements": {
@@ -3725,6 +3750,18 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 					},
 				},
 			},
+			expectedGeneratedPlacements: map[string]int{
+				metrics.CompositePodGroup: 2,
+				metrics.PodGroup:          4,
+			},
+			expectedFeasibleEvaluations: map[string]int{
+				metrics.CompositePodGroup: 1,
+				metrics.PodGroup:          4,
+			},
+			expectedInfeasibleEvaluations: map[string]int{
+				metrics.CompositePodGroup: 1,
+				metrics.PodGroup:          0,
+			},
 		},
 		"returns unschedulable if no pods got scheduled": {
 			placementPlugin: fakePlacementPlugin{
@@ -3774,6 +3811,18 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 						},
 					},
 				},
+			},
+			expectedGeneratedPlacements: map[string]int{
+				metrics.CompositePodGroup: 2,
+				metrics.PodGroup:          8,
+			},
+			expectedFeasibleEvaluations: map[string]int{
+				metrics.CompositePodGroup: 2,
+				metrics.PodGroup:          8,
+			},
+			expectedInfeasibleEvaluations: map[string]int{
+				metrics.CompositePodGroup: 0,
+				metrics.PodGroup:          0,
 			},
 		},
 		"returns unschedulable if no pods got scheduled and placement feasible rejected pods": {
@@ -3849,6 +3898,18 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 					status: fwk.NewStatus(fwk.Unschedulable, "0/2 placements are available, first placement status: injected placementFeasible status"),
 				},
 			},
+			expectedGeneratedPlacements: map[string]int{
+				metrics.CompositePodGroup: 2,
+				metrics.PodGroup:          8,
+			},
+			expectedFeasibleEvaluations: map[string]int{
+				metrics.CompositePodGroup: 0,
+				metrics.PodGroup:          0,
+			},
+			expectedInfeasibleEvaluations: map[string]int{
+				metrics.CompositePodGroup: 2,
+				metrics.PodGroup:          8,
+			},
 		},
 		"respects pods already scheduled in sibling pod groups": {
 			placementPlugin: fakePlacementPlugin{
@@ -3894,6 +3955,18 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 					},
 				},
 			},
+			expectedGeneratedPlacements: map[string]int{
+				metrics.CompositePodGroup: 2,
+				metrics.PodGroup:          8,
+			},
+			expectedFeasibleEvaluations: map[string]int{
+				metrics.CompositePodGroup: 2,
+				metrics.PodGroup:          8,
+			},
+			expectedInfeasibleEvaluations: map[string]int{
+				metrics.CompositePodGroup: 0,
+				metrics.PodGroup:          0,
+			},
 		},
 		"when generate plugin fails at CPG, returns error": {
 			placementPlugin: fakePlacementPlugin{
@@ -3906,6 +3979,18 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 				rootPGInfo.GetKey(): {
 					status: fwk.NewStatus(fwk.Error, "injected error"),
 				},
+			},
+			expectedGeneratedPlacements: map[string]int{
+				metrics.CompositePodGroup: 0,
+				metrics.PodGroup:          0,
+			},
+			expectedFeasibleEvaluations: map[string]int{
+				metrics.CompositePodGroup: 0,
+				metrics.PodGroup:          0,
+			},
+			expectedInfeasibleEvaluations: map[string]int{
+				metrics.CompositePodGroup: 0,
+				metrics.PodGroup:          0,
 			},
 		},
 		"when generate plugin fails at PG, returns error": {
@@ -3947,6 +4032,18 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 				childPGInfo2.GetKey(): {
 					status: fwk.AsStatus(fmt.Errorf("injected error")),
 				},
+			},
+			expectedGeneratedPlacements: map[string]int{
+				metrics.CompositePodGroup: 2,
+				metrics.PodGroup:          2,
+			},
+			expectedFeasibleEvaluations: map[string]int{
+				metrics.CompositePodGroup: 0,
+				metrics.PodGroup:          2,
+			},
+			expectedInfeasibleEvaluations: map[string]int{
+				metrics.CompositePodGroup: 0,
+				metrics.PodGroup:          0,
 			},
 		},
 	}
@@ -4021,6 +4118,10 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 				t.Fatalf("Failed to update snapshot: %v", err)
 			}
 
+			metrics.GeneratedPlacementsTotal.Reset()
+			metrics.PlacementEvaluations.Reset()
+			metrics.PlacementEvaluationDuration.Reset()
+
 			cpgInfo := &framework.QueuedPodGroupInfo{
 				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{
 					childPGInfo1.GetKey(): {queuedPodInfo1},
@@ -4051,6 +4152,24 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 
 			if diff := cmp.Diff(tt.expectedResults, gotResults, opts...); diff != "" {
 				t.Fatalf("Unexpected algorithm results (-want,+got):\n%s", diff)
+			}
+
+			baseLabels := map[string]string{"profile": "test-scheduler"}
+			for _, entityType := range []string{metrics.CompositePodGroup, metrics.PodGroup} {
+				wantGen := tt.expectedGeneratedPlacements[entityType]
+				wantFeas := tt.expectedFeasibleEvaluations[entityType]
+				wantInfeas := tt.expectedInfeasibleEvaluations[entityType]
+
+				fixedLabels := map[string]string{"profile": "test-scheduler", "type": entityType}
+				feasibleLabels := map[string]string{"profile": "test-scheduler", "result": metrics.FeasibleResult, "type": entityType}
+				infeasibleLabels := map[string]string{"profile": "test-scheduler", "result": metrics.InfeasibleResult, "type": entityType}
+
+				assertCounterValueFromGatherer(t, testRegistry, "scheduler_generated_placements_total", baseLabels, "type", entityType, wantGen)
+				assertCounterValueFromGatherer(t, testRegistry, "scheduler_placement_evaluations_total", fixedLabels, "result", metrics.FeasibleResult, wantFeas)
+				assertCounterValueFromGatherer(t, testRegistry, "scheduler_placement_evaluations_total", fixedLabels, "result", metrics.InfeasibleResult, wantInfeas)
+
+				assertHistogramSampleCountFromGatherer(t, testRegistry, "scheduler_placement_evaluation_duration_seconds", feasibleLabels, wantFeas)
+				assertHistogramSampleCountFromGatherer(t, testRegistry, "scheduler_placement_evaluation_duration_seconds", infeasibleLabels, wantInfeas)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Parameterizes Topology-Aware Scheduling (TAS) candidate placement metrics with the entity `type` label (`podgroup` vs `compositepodgroup`) to support `CompositePodGroup` workloads alongside standard `PodGroup`s.

Note that candidate placement generation and evaluation metrics are emitted for both the root `CompositePodGroup` and recursively for its nested child `PodGroup`s during simulation.

#### Which issue(s) this PR is related to:

KEP: [KEP-6012](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/6012-composite-podgroup-api#readme)

#### Special notes for your reviewer:

/sig scheduling
/wg workload-aware-scheduling

#### Does this PR introduce a user-facing change?
```release-note
Extends topology-aware placement metrics with type to support `CompositePodGroup`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

#### AI usage disclosure:

YES, AI supported