### PR TITLE
client-go: avoid nil deref in test

### DIFF
--- a/staging/src/k8s.io/client-go/rest/exec_test.go
+++ b/staging/src/k8s.io/client-go/rest/exec_test.go
@@ -322,7 +322,7 @@ func TestConfigToExecClusterRoundtrip(t *testing.T) {
 				t.Fatalf("failed to get url from actual proxy func: %s", actualErr.Error())
 			}
 			if expectedErr != nil {
-				t.Fatalf("failed to get url from expected proxy func: %s", actualErr.Error())
+				t.Fatalf("failed to get url from expected proxy func: %s", expectedErr.Error())
 			}
 			if diff := cmp.Diff(actualURL, expectedURL); diff != "" {
 				t.Fatal("we dropped the Config.Proxy field during conversion")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`TestConfigToExecClusterRoundtrip` checks `actualErr` and `expectedErr` for nilness, but dereferences `actualErr` in both cases, resulting in a nil dereference if `actualErr` is nil and `expectedErr` is not. This fixes the second dereference by referring to `expectedErr`.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

NO.