### PR TITLE
DRA:remove custom IncludesOption() registration 

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/library/lists.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/lists.go
@@ -219,13 +219,6 @@ func (l *lists) CompileOptions() []cel.EnvOption {
 	return options
 }
 
-// IncludesOption returns the EnvOption to register the includes function directly.
-func IncludesOption() cel.EnvOption {
-	return cel.Function("includes",
-		cel.MemberOverload("list_includes_dyn_dyn", []*cel.Type{cel.DynType, cel.DynType}, cel.BoolType,
-			cel.BinaryBinding(includes)))
-}
-
 func (*lists) ProgramOptions() []cel.ProgramOption {
 	return []cel.ProgramOption{}
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/cel/compile.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/cel/compile.go
@@ -647,16 +647,6 @@ func newCompiler(features Features) *compiler {
 				deviceTypeV136ConsumableCapacityListTypeAttributes,
 			},
 		},
-		{
-			IntroducedVersion: version.MajorMinor(1, 36),
-			FeatureEnabled: func() bool {
-				return features.EnableListTypeAttributes
-			},
-			EnvOptions: []cel.EnvOption{
-				// TODO(https://github.com/kubernetes/kubernetes/issues/140074): Remove in 1.38 when 1.36 support is dropped and includes is natively provided by Lists(ListsVersion(1)) starting in 1.37.
-				library.IncludesOption(),
-			},
-		},
 	}
 	envset, err := envset.Extend(versioned...)
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Resolves the TODO left in #140016

The `library.IncludesOption()` shim registered in the DRA CEL compiler at emulated version 1.36 in now dead code. `.includes()` has been natively provided by `Lists(ListsVersion(1))` since 1.37, and 1.36 emulation is dropped in 1.38. 

#### Which issue(s) this PR is related to:
Fixes  #140074

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```