### PR TITLE
Signal completion using a channel instead of a spinlock

### DIFF
--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -718,18 +717,16 @@ func wrapTestWithInjectedOperation(ctx context.Context, toWrap testCall, injectB
 		// Run the tested function (typically syncClaim/syncVolume) in a
 		// separate goroutine.
 		var testError error
-		var testFinished int32
+		done := make(chan struct{})
 
 		go func() {
 			testError = toWrap(ctrl, reactor, test)
 			// Let the "main" test function know that syncVolume has finished.
-			atomic.StoreInt32(&testFinished, 1)
+			close(done)
 		}()
 
 		// Wait for the controller to finish the test function.
-		for atomic.LoadInt32(&testFinished) == 0 {
-			time.Sleep(time.Millisecond * 10)
-		}
+		<-done
 
 		return testError
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`wrapTestWithInjectedOperation` uses a spinlock to wait for a goroutine; the idiomatic Go approach is to signal completion using a channel, which is what this PR does. This also avoids an unenforced `int32` used as an atomic. (The obvious fix would be to use `atomic.Int32` but I think this is better.)

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

NO.