### PR TITLE
proxy: use atomic.Bool to store initialisation

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -146,7 +146,7 @@ type Proxier struct {
 	servicesSynced       bool
 	lastFullSync         time.Time
 	needFullSync         bool
-	initialized          int32
+	initialized          atomic.Bool
 	syncRunner           *runner.BoundedFrequencyRunner // governs calls to syncProxyRules
 	syncPeriod           time.Duration
 	lastIPTablesCleanup  time.Time
@@ -432,15 +432,11 @@ func (proxier *Proxier) SyncLoop() {
 }
 
 func (proxier *Proxier) setInitialized(value bool) {
-	var initialized int32
-	if value {
-		initialized = 1
-	}
-	atomic.StoreInt32(&proxier.initialized, initialized)
+	proxier.initialized.Store(value)
 }
 
 func (proxier *Proxier) isInitialized() bool {
-	return atomic.LoadInt32(&proxier.initialized) > 0
+	return proxier.initialized.Load()
 }
 
 // OnServiceAdd is called whenever creation of new service object

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -171,7 +171,7 @@ type Proxier struct {
 	// ipvs rules with some partial data after kube-proxy restart.
 	endpointSlicesSynced bool
 	servicesSynced       bool
-	initialized          int32
+	initialized          atomic.Bool
 	syncRunner           *runner.BoundedFrequencyRunner // governs calls to syncProxyRules
 
 	// These are effectively const and do not need the mutex to be held.
@@ -566,15 +566,11 @@ func (proxier *Proxier) SyncLoop() {
 }
 
 func (proxier *Proxier) setInitialized(value bool) {
-	var initialized int32
-	if value {
-		initialized = 1
-	}
-	atomic.StoreInt32(&proxier.initialized, initialized)
+	proxier.initialized.Store(value)
 }
 
 func (proxier *Proxier) isInitialized() bool {
-	return atomic.LoadInt32(&proxier.initialized) > 0
+	return proxier.initialized.Load()
 }
 
 // OnServiceAdd is called whenever creation of new service object is observed.

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -165,7 +165,7 @@ type Proxier struct {
 	servicesSynced       bool
 	lastFullSync         time.Time
 	needFullSync         bool
-	initialized          int32
+	initialized          atomic.Bool
 	syncRunner           *runner.BoundedFrequencyRunner // governs calls to syncProxyRules
 	syncPeriod           time.Duration
 	flushed              bool
@@ -821,15 +821,11 @@ func (proxier *Proxier) SyncLoop() {
 }
 
 func (proxier *Proxier) setInitialized(value bool) {
-	var initialized int32
-	if value {
-		initialized = 1
-	}
-	atomic.StoreInt32(&proxier.initialized, initialized)
+	proxier.initialized.Store(value)
 }
 
 func (proxier *Proxier) isInitialized() bool {
-	return atomic.LoadInt32(&proxier.initialized) > 0
+	return proxier.initialized.Load()
 }
 
 // OnServiceAdd is called whenever creation of new service object


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Proxier initialisation currently uses an int32 to track initialisation, requiring the use of atomic operations without being able to enforce them. atomic.Int32 could replace this while also enforing atomic primitives, but since the use of the field is boolean in nature, it seems more appropriate to use atomic.Bool.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

NO.