### PR TITLE
fix: asApproximateFloat64 NaN for zero quantity (rebased)

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -488,7 +488,8 @@ func (q *Quantity) AsApproximateFloat64() float64 {
 		base = float64(q.i.value)
 		exponent = int(q.i.scale)
 	}
-	if exponent == 0 {
+	// Avoid 0 * Inf, which returns NaN.
+	if base == 0 || exponent == 0 {
 		return base
 	}
 

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_overflow_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_overflow_test.go
@@ -366,7 +366,7 @@ func quantityAccessorCases() []accessorCase {
 			wantMilli:      0,
 			wantScaledKilo: 0,
 			wantAsInt64:    0, wantAsInt64OK: true,
-			wantFloat: math.NaN(), floatTODO: "want 0 once #139893 guards zero before the Pow10 multiply",
+			wantFloat:  0,
 			wantString: "0",
 		},
 		{
@@ -388,7 +388,7 @@ func quantityAccessorCases() []accessorCase {
 			wantMilli:      0,
 			wantScaledKilo: 0,
 			wantAsInt64:    0, wantAsInt64OK: false,
-			wantFloat: math.NaN(), floatTODO: "want 0 once #139893 guards zero before the Pow10 multiply",
+			wantFloat:  0,
 			wantString: "0",
 		},
 		{

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -1639,6 +1639,10 @@ func TestQuantityAsApproximateFloat64(t *testing.T) {
 		{decQuantity(0, 0, DecimalSI), 0.0},
 		{decQuantity(0, 0, DecimalExponent), 0.0},
 		{decQuantity(0, 0, BinarySI), 0.0},
+		{decQuantity(0, 500, DecimalSI), 0.0},
+		{intQuantity(0, 500, DecimalSI), 0.0},
+		{decQuantity(0, -500, DecimalSI), 0.0},
+		{intQuantity(0, -500, DecimalSI), 0.0},
 
 		{decQuantity(1, 0, DecimalSI), 1},
 		{decQuantity(1, 0, DecimalExponent), 1},
@@ -1710,6 +1714,10 @@ func TestQuantityAsFloat64Slow(t *testing.T) {
 		{decQuantity(0, 0, DecimalSI), 0.0},
 		{decQuantity(0, 0, DecimalExponent), 0.0},
 		{decQuantity(0, 0, BinarySI), 0.0},
+		{decQuantity(0, 500, DecimalSI), 0.0},
+		{intQuantity(0, 500, DecimalSI), 0.0},
+		{decQuantity(0, -500, DecimalSI), 0.0},
+		{intQuantity(0, -500, DecimalSI), 0.0},
 
 		{decQuantity(1, 0, DecimalSI), 1},
 		{decQuantity(1, 0, DecimalExponent), 1},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This is a copy of #139893 but rebased and with the the fix mentioned in https://github.com/kubernetes/kubernetes/pull/139893#pullrequestreview-5083584887 applied. Commit attribution is retained.

#### Which issue(s) this PR is related to:

See #139893

Fixes #139894

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fixed `resource.Quantity.AsApproximateFloat64` returning NaN instead of 0 for a zero-valued quantity with a large scale.
```
