### PR TITLE
Clean up workflow runner to use native for loop

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/workflow/runner.go
+++ b/cmd/kubeadm/app/cmd/phases/workflow/runner.go
@@ -120,7 +120,7 @@ func (e *Runner) computePhaseRunFlags() (map[string]bool, error) {
 	// Initialize support data structure
 	phaseRunFlags := map[string]bool{}
 	phaseHierarchy := map[string][]string{}
-	e.visitAll(func(p *phaseRunner) error {
+	for _, p := range e.phaseRunners {
 		// Initialize phaseRunFlags assuming that all the phases should be run.
 		phaseRunFlags[p.generatedName] = true
 
@@ -134,8 +134,7 @@ func (e *Runner) computePhaseRunFlags() (map[string]bool, error) {
 			phaseHierarchy[parent.generatedName] = append(phaseHierarchy[parent.generatedName], p.generatedName)
 			parent = parent.parent
 		}
-		return nil
-	})
+	}
 
 	// If a filter option is specified, set all phaseRunFlags to false except for
 	// the phases included in the filter and their hierarchy of nested phases.
@@ -231,10 +230,10 @@ func (e *Runner) Run(args []string) error {
 		}
 	}
 
-	err = e.visitAll(func(p *phaseRunner) error {
+	for _, p := range e.phaseRunners {
 		// if the phase should not be run, skip the phase.
 		if run, ok := phaseRunFlags[p.generatedName]; !run || !ok {
-			return nil
+			continue
 		}
 
 		// Errors if phases that are meant to create special subcommands only
@@ -252,7 +251,7 @@ func (e *Runner) Run(args []string) error {
 			}
 
 			if !ok {
-				return nil
+				continue
 			}
 		}
 
@@ -262,11 +261,9 @@ func (e *Runner) Run(args []string) error {
 				return errors.Wrapf(err, "error execution phase %s", p.generatedName)
 			}
 		}
+	}
 
-		return nil
-	})
-
-	return err
+	return nil
 }
 
 // Help returns text with the list of phases included in the workflow.
@@ -275,22 +272,21 @@ func (e *Runner) Help(cmdUse string) string {
 
 	// computes the max length of for each phase use line
 	maxLength := 0
-	e.visitAll(func(p *phaseRunner) error {
+	for _, p := range e.phaseRunners {
 		if !p.Hidden && !p.RunAllSiblings {
 			length := len(p.use)
 			if maxLength < length {
 				maxLength = length
 			}
 		}
-		return nil
-	})
+	}
 
 	// prints the list of phases indented by level and formatted using the maxlength
 	// the list is enclosed in a markdown code block for ensuring better readability in the public web site
 	line := fmt.Sprintf("The %q command executes the following phases:\n", cmdUse)
 	line += "```\n"
 	offset := 2
-	e.visitAll(func(p *phaseRunner) error {
+	for _, p := range e.phaseRunners {
 		if !p.Hidden && !p.RunAllSiblings {
 			padding := maxLength - len(p.use) + offset
 			line += strings.Repeat(" ", offset*p.level) // indentation
@@ -299,9 +295,7 @@ func (e *Runner) Help(cmdUse string) string {
 			line += p.Short                             // phase short description
 			line += "\n"
 		}
-
-		return nil
-	})
+	}
 	line += "```"
 	return line
 }
@@ -342,10 +336,10 @@ func (e *Runner) BindToCommand(cmd *cobra.Command) {
 
 	// generate all the nested subcommands for invoking single phases
 	subcommands := map[string]*cobra.Command{}
-	e.visitAll(func(p *phaseRunner) error {
+	for _, p := range e.phaseRunners {
 		// skip hidden phases
 		if p.Hidden {
-			return nil
+			continue
 		}
 
 		// initialize phase selector
@@ -412,8 +406,7 @@ func (e *Runner) BindToCommand(cmd *cobra.Command) {
 		}
 
 		subcommands[p.generatedName] = phaseCmd
-		return nil
-	})
+	}
 
 	// alters the command description to show available phases
 	if cmd.Long != "" {
@@ -440,18 +433,6 @@ func inheritsFlags(sourceFlags, targetFlags *pflag.FlagSet, cmdFlags []string) {
 			}
 		}
 	})
-}
-
-// visitAll provides a utility method for visiting all the phases in the workflow
-// in the execution order and executing a func on each phase.
-// Nested phase are visited immediately after their parent phase.
-func (e *Runner) visitAll(fn func(*phaseRunner) error) error {
-	for _, currentRunner := range e.phaseRunners {
-		if err := fn(currentRunner); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // prepareForExecution initialize the internal state of the Runner (the list of phaseRunner).


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
`workflow.visitAll` adds almost nothing except confusion. It gives the illusion that a workflow is more than just a loop of phases. We should instead just replace it with a native for-loop for clarity.

#### Which issue(s) this PR is related to:
N/A

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A

#### AI usage disclosure:
YES: to replace the usages of `visitAll` with a basic for loop.

