### PR TITLE
networking: enable optionalorrequired kube-api-linter rule

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15025,6 +15025,9 @@
           "description": "spec is the desired state of the IngressClass. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
+      "required": [
+        "spec"
+      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -15111,6 +15114,9 @@
           "description": "parameters is a link to a custom resource containing additional configuration for the controller. This is optional if the controller does not require extra parameters."
         }
       },
+      "required": [
+        "controller"
+      ],
       "type": "object"
     },
     "io.k8s.api.networking.v1.IngressList": {
@@ -15201,10 +15207,6 @@
           "type": "string"
         }
       },
-      "required": [
-        "port",
-        "protocol"
-      ],
       "type": "object"
     },
     "io.k8s.api.networking.v1.IngressRule": {

--- a/api/openapi-spec/v3/apis__networking.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__networking.k8s.io__v1_openapi.json
@@ -291,6 +291,9 @@
             "description": "spec is the desired state of the IngressClass. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
           }
         },
+        "required": [
+          "spec"
+        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {
@@ -388,6 +391,9 @@
             "description": "parameters is a link to a custom resource containing additional configuration for the controller. This is optional if the controller does not require extra parameters."
           }
         },
+        "required": [
+          "controller"
+        ],
         "type": "object"
       },
       "io.k8s.api.networking.v1.IngressList": {
@@ -485,10 +491,6 @@
             "type": "string"
           }
         },
-        "required": [
-          "port",
-          "protocol"
-        ],
         "type": "object"
       },
       "io.k8s.api.networking.v1.IngressRule": {

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -230,7 +230,18 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|certificates|core|extensions|networking)"
+        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|certificates|core|extensions)"
+      
+      # nonpointerstructs/optionalorrequired - IngressBackend and ServiceBackendPort are "oneOf"-shaped
+      # structs (validation requires exactly one of Resource/Service, or Name/Number, to be set) but
+      # neither individual field is itself marked required, so the linter can't see the real cross-field
+      # constraint and would force the container to be marked +optional - which is misleading, since an
+      # empty value does fail validation. Suppressing rather than mismarking (per danwinship's review on
+      # #141944).
+      - text: "field HTTPIngressPath.Backend (is a non-pointer struct with no required fields. It must be marked as optional.|must be marked as optional or required)"
+        path: "staging/src/k8s.io/api/networking/"
+      - text: "field IngressServiceBackend.Port (is a non-pointer struct with no required fields. It must be marked as optional.|must be marked as optional or required)"
+        path: "staging/src/k8s.io/api/networking/v1/types.go"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -245,7 +245,18 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|certificates|core|extensions|networking)"
+        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|certificates|core|extensions)"
+      
+      # nonpointerstructs/optionalorrequired - IngressBackend and ServiceBackendPort are "oneOf"-shaped
+      # structs (validation requires exactly one of Resource/Service, or Name/Number, to be set) but
+      # neither individual field is itself marked required, so the linter can't see the real cross-field
+      # constraint and would force the container to be marked +optional - which is misleading, since an
+      # empty value does fail validation. Suppressing rather than mismarking (per danwinship's review on
+      # #141944).
+      - text: "field HTTPIngressPath.Backend (is a non-pointer struct with no required fields. It must be marked as optional.|must be marked as optional or required)"
+        path: "staging/src/k8s.io/api/networking/"
+      - text: "field IngressServiceBackend.Port (is a non-pointer struct with no required fields. It must be marked as optional.|must be marked as optional or required)"
+        path: "staging/src/k8s.io/api/networking/v1/types.go"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -117,7 +117,18 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|certificates|core|extensions|networking)"
+  path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|certificates|core|extensions)"
+
+# nonpointerstructs/optionalorrequired - IngressBackend and ServiceBackendPort are "oneOf"-shaped
+# structs (validation requires exactly one of Resource/Service, or Name/Number, to be set) but
+# neither individual field is itself marked required, so the linter can't see the real cross-field
+# constraint and would force the container to be marked +optional - which is misleading, since an
+# empty value does fail validation. Suppressing rather than mismarking (per danwinship's review on
+# #141944).
+- text: "field HTTPIngressPath.Backend (is a non-pointer struct with no required fields. It must be marked as optional.|must be marked as optional or required)"
+  path: "staging/src/k8s.io/api/networking/"
+- text: "field IngressServiceBackend.Port (is a non-pointer struct with no required fields. It must be marked as optional.|must be marked as optional or required)"
+  path: "staging/src/k8s.io/api/networking/v1/types.go"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -42752,6 +42752,7 @@ func schema_k8sio_api_networking_v1_IngressClass(ref common.ReferenceCallback) c
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -42881,6 +42882,7 @@ func schema_k8sio_api_networking_v1_IngressClassSpec(ref common.ReferenceCallbac
 						},
 					},
 				},
+				Required: []string{"controller"},
 			},
 		},
 		Dependencies: []string{
@@ -43050,7 +43052,6 @@ func schema_k8sio_api_networking_v1_IngressPortStatus(ref common.ReferenceCallba
 						},
 					},
 				},
-				Required: []string{"port", "protocol"},
 			},
 		},
 	}
@@ -44154,6 +44155,7 @@ func schema_k8sio_api_networking_v1beta1_IngressClass(ref common.ReferenceCallba
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -44243,7 +44245,7 @@ func schema_k8sio_api_networking_v1beta1_IngressClassParametersReference(ref com
 					},
 					"scope": {
 						SchemaProps: spec.SchemaProps{
-							Description: "scope represents if this refers to a cluster or namespace scoped resource. This may be set to \"Cluster\" (default) or \"Namespace\".",
+							Description: "scope represents if this refers to a cluster or namespace scoped resource. This may be set to \"Cluster\" (default) or \"Namespace\". Note: unlike networking.k8s.io/v1, this API version has no defaulting for this field, so it must be set explicitly.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -44283,6 +44285,7 @@ func schema_k8sio_api_networking_v1beta1_IngressClassSpec(ref common.ReferenceCa
 						},
 					},
 				},
+				Required: []string{"controller"},
 			},
 		},
 		Dependencies: []string{
@@ -44452,7 +44455,6 @@ func schema_k8sio_api_networking_v1beta1_IngressPortStatus(ref common.ReferenceC
 						},
 					},
 				},
-				Required: []string{"port", "protocol"},
 			},
 		},
 	}

--- a/staging/src/k8s.io/api/networking/v1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1/generated.proto
@@ -54,6 +54,7 @@ message HTTPIngressPath {
   //   the IngressClass. Implementations can treat this as a separate PathType
   //   or treat it identically to Prefix or Exact path types.
   // Implementations are required to support all path types.
+  // +required
   optional string pathType = 3;
 
   // backend defines the referenced service endpoint to which the traffic
@@ -69,6 +70,7 @@ message HTTPIngressPath {
 message HTTPIngressRuleValue {
   // paths is a collection of paths that map requests to backends.
   // +listType=atomic
+  // +required
   repeated HTTPIngressPath paths = 1;
 }
 
@@ -180,7 +182,7 @@ message IngressClass {
 
   // spec is the desired state of the IngressClass.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional IngressClassSpec spec = 2;
 }
 
@@ -233,6 +235,7 @@ message IngressClassSpec {
   // same implementing controller. This should be specified as a
   // domain-prefixed path no more than 250 characters in length, e.g.
   // "acme.io/ingress-controller". This field is immutable.
+  // +required
   optional string controller = 1;
 
   // parameters is a link to a custom resource containing additional
@@ -281,10 +284,12 @@ message IngressLoadBalancerStatus {
 // IngressPortStatus represents the error condition of a service port
 message IngressPortStatus {
   // port is the port number of the ingress port.
+  // +optional
   optional int32 port = 1;
 
   // protocol is the protocol of the ingress port.
   // The supported values are: "TCP", "UDP", "SCTP"
+  // +optional
   optional string protocol = 2;
 
   // error is to record the problem with the service port
@@ -354,6 +359,7 @@ message IngressRuleValue {
 message IngressServiceBackend {
   // name is the referenced service. The service must exist in
   // the same namespace as the Ingress object.
+  // +required
   optional string name = 1;
 
   // port of the referenced service. A port name or port number

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -373,10 +373,12 @@ type IngressLoadBalancerIngress struct {
 // IngressPortStatus represents the error condition of a service port
 type IngressPortStatus struct {
 	// port is the port number of the ingress port.
+	// +optional
 	Port int32 `json:"port" protobuf:"varint,1,opt,name=port"`
 
 	// protocol is the protocol of the ingress port.
 	// The supported values are: "TCP", "UDP", "SCTP"
+	// +optional
 	Protocol v1.Protocol `json:"protocol" protobuf:"bytes,2,opt,name=protocol,casttype=Protocol"`
 
 	// error is to record the problem with the service port
@@ -449,6 +451,7 @@ type IngressRuleValue struct {
 type HTTPIngressRuleValue struct {
 	// paths is a collection of paths that map requests to backends.
 	// +listType=atomic
+	// +required
 	Paths []HTTPIngressPath `json:"paths" protobuf:"bytes,1,rep,name=paths"`
 }
 
@@ -507,6 +510,7 @@ type HTTPIngressPath struct {
 	//   the IngressClass. Implementations can treat this as a separate PathType
 	//   or treat it identically to Prefix or Exact path types.
 	// Implementations are required to support all path types.
+	// +required
 	PathType *PathType `json:"pathType" protobuf:"bytes,3,opt,name=pathType"`
 
 	// backend defines the referenced service endpoint to which the traffic
@@ -533,6 +537,7 @@ type IngressBackend struct {
 type IngressServiceBackend struct {
 	// name is the referenced service. The service must exist in
 	// the same namespace as the Ingress object.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 
 	// port of the referenced service. A port name or port number
@@ -574,7 +579,7 @@ type IngressClass struct {
 
 	// spec is the desired state of the IngressClass.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec IngressClassSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 
@@ -586,6 +591,7 @@ type IngressClassSpec struct {
 	// same implementing controller. This should be specified as a
 	// domain-prefixed path no more than 250 characters in length, e.g.
 	// "acme.io/ingress-controller". This field is immutable.
+	// +required
 	Controller string `json:"controller,omitempty" protobuf:"bytes,1,opt,name=controller"`
 
 	// parameters is a link to a custom resource containing additional

--- a/staging/src/k8s.io/api/networking/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1beta1/generated.proto
@@ -55,6 +55,7 @@ message HTTPIngressPath {
   //   or treat it identically to Prefix or Exact path types.
   // Implementations are required to support all path types.
   // Defaults to ImplementationSpecific.
+  // +optional
   optional string pathType = 3;
 
   // backend defines the referenced service endpoint to which the traffic
@@ -70,6 +71,7 @@ message HTTPIngressPath {
 message HTTPIngressRuleValue {
   // paths is a collection of paths that map requests to backends.
   // +listType=atomic
+  // +required
   repeated HTTPIngressPath paths = 1;
 }
 
@@ -165,7 +167,7 @@ message IngressClass {
 
   // spec is the desired state of the IngressClass.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional IngressClassSpec spec = 2;
 }
 
@@ -200,6 +202,9 @@ message IngressClassParametersReference {
 
   // scope represents if this refers to a cluster or namespace scoped resource.
   // This may be set to "Cluster" (default) or "Namespace".
+  // Note: unlike networking.k8s.io/v1, this API version has no defaulting
+  // for this field, so it must be set explicitly.
+  // +required
   optional string scope = 4;
 
   // namespace is the namespace of the resource being referenced. This field is
@@ -217,6 +222,7 @@ message IngressClassSpec {
   // same implementing controller. This should be specified as a
   // domain-prefixed path no more than 250 characters in length, e.g.
   // "acme.io/ingress-controller". This field is immutable.
+  // +required
   optional string controller = 1;
 
   // parameters is a link to a custom resource containing additional
@@ -265,10 +271,12 @@ message IngressLoadBalancerStatus {
 // IngressPortStatus represents the error condition of a service port
 message IngressPortStatus {
   // port is the port number of the ingress port.
+  // +optional
   optional int32 port = 1;
 
   // protocol is the protocol of the ingress port.
   // The supported values are: "TCP", "UDP", "SCTP"
+  // +optional
   optional string protocol = 2;
 
   // error is to record the problem with the service port

--- a/staging/src/k8s.io/api/networking/v1beta1/types.go
+++ b/staging/src/k8s.io/api/networking/v1beta1/types.go
@@ -163,10 +163,12 @@ type IngressLoadBalancerIngress struct {
 // IngressPortStatus represents the error condition of a service port
 type IngressPortStatus struct {
 	// port is the port number of the ingress port.
+	// +optional
 	Port int32 `json:"port" protobuf:"varint,1,opt,name=port"`
 
 	// protocol is the protocol of the ingress port.
 	// The supported values are: "TCP", "UDP", "SCTP"
+	// +optional
 	Protocol v1.Protocol `json:"protocol" protobuf:"bytes,2,opt,name=protocol,casttype=Protocol"`
 
 	// error is to record the problem with the service port
@@ -246,6 +248,7 @@ type IngressRuleValue struct {
 type HTTPIngressRuleValue struct {
 	// paths is a collection of paths that map requests to backends.
 	// +listType=atomic
+	// +required
 	Paths []HTTPIngressPath `json:"paths" protobuf:"bytes,1,rep,name=paths"`
 	// TODO: Consider adding fields for ingress-type specific global
 	// options usable by a loadbalancer, like http keep-alive.
@@ -306,6 +309,7 @@ type HTTPIngressPath struct {
 	//   or treat it identically to Prefix or Exact path types.
 	// Implementations are required to support all path types.
 	// Defaults to ImplementationSpecific.
+	// +optional
 	PathType *PathType `json:"pathType,omitempty" protobuf:"bytes,3,opt,name=pathType"`
 
 	// backend defines the referenced service endpoint to which the traffic
@@ -352,7 +356,7 @@ type IngressClass struct {
 
 	// spec is the desired state of the IngressClass.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec IngressClassSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 
@@ -364,6 +368,7 @@ type IngressClassSpec struct {
 	// same implementing controller. This should be specified as a
 	// domain-prefixed path no more than 250 characters in length, e.g.
 	// "acme.io/ingress-controller". This field is immutable.
+	// +required
 	Controller string `json:"controller,omitempty" protobuf:"bytes,1,opt,name=controller"`
 
 	// parameters is a link to a custom resource containing additional
@@ -404,6 +409,9 @@ type IngressClassParametersReference struct {
 
 	// scope represents if this refers to a cluster or namespace scoped resource.
 	// This may be set to "Cluster" (default) or "Namespace".
+	// Note: unlike networking.k8s.io/v1, this API version has no defaulting
+	// for this field, so it must be set explicitly.
+	// +required
 	Scope *string `json:"scope" protobuf:"bytes,4,opt,name=scope"`
 
 	// namespace is the namespace of the resource being referenced. This field is

--- a/staging/src/k8s.io/api/networking/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/networking/v1beta1/types_swagger_doc_generated.go
@@ -123,7 +123,7 @@ var map_IngressClassParametersReference = map[string]string{
 	"apiGroup":  "apiGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
 	"kind":      "kind is the type of resource being referenced.",
 	"name":      "name is the name of resource being referenced.",
-	"scope":     "scope represents if this refers to a cluster or namespace scoped resource. This may be set to \"Cluster\" (default) or \"Namespace\".",
+	"scope":     "scope represents if this refers to a cluster or namespace scoped resource. This may be set to \"Cluster\" (default) or \"Namespace\". Note: unlike networking.k8s.io/v1, this API version has no defaulting for this field, so it must be set explicitly.",
 	"namespace": "namespace is the namespace of the resource being referenced. This field is required when scope is set to \"Namespace\" and must be unset when scope is set to \"Cluster\".",
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressclassparametersreference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressclassparametersreference.go
@@ -34,6 +34,8 @@ type IngressClassParametersReferenceApplyConfiguration struct {
 	Name *string `json:"name,omitempty"`
 	// scope represents if this refers to a cluster or namespace scoped resource.
 	// This may be set to "Cluster" (default) or "Namespace".
+	// Note: unlike networking.k8s.io/v1, this API version has no defaulting
+	// for this field, so it must be set explicitly.
 	Scope *string `json:"scope,omitempty"`
 	// namespace is the namespace of the resource being referenced. This field is
 	// required when scope is set to "Namespace" and must be unset when scope is set to


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

Enables `optionalorrequired` and `nonpointerstructs` kube-api-linter rules for the `networking` API group (part of #134671).

- Added `+optional` / `+required` markers across `networking/v1` and `v1beta1` types based on validation rules in `pkg/apis/networking/validation/`.
- Updated `IngressClassSpec.Controller`, `IngressServiceBackend.Name`, `HTTPIngressRuleValue.Paths`, and `HTTPIngressPath.PathType` to `+required`.
- Suppressed `HTTPIngressPath.Backend` and `IngressServiceBackend.Port` in `exceptions.yaml` per reviewer feedback (`oneOf` struct fields enforcing cross-field validation).
- Regenerated OpenAPI specs, swagger, and protobuf definitions.

Verified with `hack/verify-golangci-lint.sh` (0 issues).

```release-note
NONE
```

/sig network