### PR TITLE
Use unsafe conversion for declarative validation

### DIFF
--- a/pkg/apis/core/v1/conversion_test.go
+++ b/pkg/apis/core/v1/conversion_test.go
@@ -882,6 +882,30 @@ func TestConvert_core_Pod_To_v1_Pod(t *testing.T) {
 	}
 }
 
+func BenchmarkPodConvertToVersion(b *testing.B) {
+	in := &core.Pod{}
+	if err := legacyscheme.Scheme.Convert(loadExemplarPod(), in, nil); err != nil {
+		b.Fatalf("unexpected setup conversion error: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		convert func(runtime.Object, runtime.GroupVersioner) (runtime.Object, error)
+	}{
+		{name: "safe", convert: legacyscheme.Scheme.ConvertToVersion},
+		{name: "unsafe", convert: legacyscheme.Scheme.UnsafeConvertToVersion},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if _, err := tc.convert(in, v1.SchemeGroupVersion); err != nil {
+					b.Fatalf("unexpected conversion error: %v", err)
+				}
+			}
+		})
+	}
+}
+
 // TestPodMemoryIdenticalConversion ensures the internal and v1 Pod types
 // remain memory-identical. These types must be kept memory-identical
 // for performance reasons.

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
@@ -128,7 +128,7 @@ func validateDeclaratively(ctx context.Context, scheme *runtime.Scheme, obj, old
 	if err != nil {
 		return field.ErrorList{field.InternalError(nil, err)}
 	}
-	versionedObj, err := scheme.ConvertToVersion(obj, versionedGroupVersion)
+	versionedObj, err := scheme.UnsafeConvertToVersion(obj, versionedGroupVersion)
 	if err != nil {
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("unexpected error converting to versioned type: %w", err))}
 	}
@@ -138,7 +138,7 @@ func validateDeclaratively(ctx context.Context, scheme *runtime.Scheme, obj, old
 	case operation.Create:
 		return scheme.Validate(ctx, o.Options, versionedObj, subresources...)
 	case operation.Update:
-		versionedOldObj, err = scheme.ConvertToVersion(oldObj, versionedGroupVersion)
+		versionedOldObj, err = scheme.UnsafeConvertToVersion(oldObj, versionedGroupVersion)
 		if err != nil {
 			return field.ErrorList{field.InternalError(nil, fmt.Errorf("unexpected error converting to versioned type: %w", err))}
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Uses the unsafe converter in declarative validation to avoid deep-copying the object on every write.

I found this while testing apiserver throughput. I think this is safe, but I would like confirmation from the DV experts that declarative validation never mutates the objects it is given, since the unsafe converter lets the versioned object alias the caller's object.

```
goos: linux
goarch: amd64
pkg: k8s.io/kubernetes/pkg/apis/core/v1
cpu: Intel(R) Xeon(R) CPU @ 2.80GHz
BenchmarkPodConvertToVersion/safe-32         	   77598	     15325 ns/op	   21384 B/op	     119 allocs/op
BenchmarkPodConvertToVersion/safe-32         	   77181	     15443 ns/op	   21384 B/op	     119 allocs/op
BenchmarkPodConvertToVersion/safe-32         	   78014	     15305 ns/op	   21384 B/op	     119 allocs/op
BenchmarkPodConvertToVersion/safe-32         	   77994	     15406 ns/op	   21384 B/op	     119 allocs/op
BenchmarkPodConvertToVersion/safe-32         	   77028	     15571 ns/op	   21384 B/op	     119 allocs/op
BenchmarkPodConvertToVersion/safe-32         	   77482	     15650 ns/op	   21384 B/op	     119 allocs/op
BenchmarkPodConvertToVersion/unsafe-32       	 1437164	     843.6 ns/op	    1344 B/op	       4 allocs/op
BenchmarkPodConvertToVersion/unsafe-32       	 1436974	     829.9 ns/op	    1344 B/op	       4 allocs/op
BenchmarkPodConvertToVersion/unsafe-32       	 1442731	     833.8 ns/op	    1344 B/op	       4 allocs/op
BenchmarkPodConvertToVersion/unsafe-32       	 1416578	     840.3 ns/op	    1344 B/op	       4 allocs/op
BenchmarkPodConvertToVersion/unsafe-32       	 1435203	     840.0 ns/op	    1344 B/op	       4 allocs/op
BenchmarkPodConvertToVersion/unsafe-32       	 1434022	     838.5 ns/op	    1344 B/op	       4 allocs/op
```

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
