### PR TITLE
kubelet: fix restartPolicy=Never pods stuck Pending forever after node reboot

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -676,6 +676,19 @@ func shouldRestartOnFailure(pod *v1.Pod) bool {
 	return pod.Spec.RestartPolicy != v1.RestartPolicyNever
 }
 
+// anyContainerCreatedButNotStarted returns true if any init or regular
+// container has been created by the runtime but was never started, so it has
+// neither a start time nor an exit code.
+func anyContainerCreatedButNotStarted(pod *v1.Pod, podStatus *kubecontainer.PodStatus) bool {
+	for c := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
+		status := podStatus.FindContainerStatusByName(c.Name)
+		if status != nil && status.State == kubecontainer.ContainerStateCreated {
+			return true
+		}
+	}
+	return false
+}
+
 func containerSucceeded(c *v1.Container, podStatus *kubecontainer.PodStatus) bool {
 	cStatus := podStatus.FindContainerStatusByName(c.Name)
 	if cStatus == nil {
@@ -1304,7 +1317,12 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 	// If we need to (re-)create the pod sandbox, everything will need to be
 	// killed and recreated, and init containers should be purged.
 	if createPodSandbox {
-		if !shouldRestartOnFailure(pod) && attempt != 0 && len(podStatus.ContainerStatuses) != 0 {
+		// A container that the runtime created but never started also has a
+		// status, yet it has not run, so the early return below would leave the
+		// pod Pending forever with the sandbox never recreated. Exclude that
+		// case so the sandbox is retried.
+		if !shouldRestartOnFailure(pod) && attempt != 0 && len(podStatus.ContainerStatuses) != 0 &&
+			!anyContainerCreatedButNotStarted(pod, podStatus) {
 			// Should not restart the pod, just return.
 			// we should not create a sandbox, and just kill the pod if it is already done.
 			// if all containers are done and should not be started, there is no need to create a new sandbox.
@@ -1317,22 +1335,22 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 			return changes
 		}
 
-		// Get the containers to start, excluding the ones that succeeded if RestartPolicy is OnFailure.
+		// Get the containers to start in the replacement sandbox, excluding the
+		// ones that must not run again.
 		var containersToStart []int
 		for idx, c := range pod.Spec.Containers {
-			runOnce := pod.Spec.RestartPolicy == v1.RestartPolicyOnFailure
-			if utilfeature.DefaultFeatureGate.Enabled(features.ContainerRestartRules) {
-				if c.RestartPolicy != nil {
-					runOnce = *c.RestartPolicy == v1.ContainerRestartPolicyOnFailure
-				}
-			}
-			if runOnce && containerSucceeded(&c, podStatus) {
+			// PodSandboxChanged also replaces a ready sandbox that lost its
+			// IP or changed network namespace, so a container can still be
+			// running here, and it has to come back up in the new sandbox.
+			if cStatus := podStatus.FindContainerStatusByName(c.Name); cStatus != nil && cStatus.State == kubecontainer.ContainerStateRunning {
+				containersToStart = append(containersToStart, idx)
 				continue
 			}
-			if utilfeature.DefaultFeatureGate.Enabled(features.ContainerRestartRules) {
-				if c.RestartPolicy != nil && *c.RestartPolicy == v1.ContainerRestartPolicyOnFailure && containerSucceeded(&c, podStatus) {
-					continue
-				}
+			// ShouldContainerBeRestarted covers the pod-level policy, the
+			// container-level policy and its restart rules, and the states
+			// that have not consumed a run yet.
+			if !kubecontainer.ShouldContainerBeRestarted(logger, &c, pod, podStatus) {
+				continue
 			}
 			containersToStart = append(containersToStart, idx)
 		}
@@ -1352,14 +1370,26 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 			}
 		}
 
-		// If we are creating a pod sandbox, we should restart from the initial
-		// state.
-		if len(pod.Spec.InitContainers) != 0 {
-			// Pod has init containers, return the first one.
-			changes.InitContainersToStart = []int{0}
-
+		// Resume the init sequence at the first container that has not already
+		// completed successfully. Pods that restart, and restartable init
+		// containers, always run the whole sequence again in the new sandbox.
+		for i := range pod.Spec.InitContainers {
+			c := &pod.Spec.InitContainers[i]
+			mustRerun := shouldRestartOnFailure(pod) || podutil.IsRestartableInitContainer(c)
+			if !mustRerun && containerSucceeded(c, podStatus) {
+				continue
+			}
+			// Start it only if it never ran. If it ran and failed, a pod that
+			// does not restart is done and needs no new sandbox.
+			status := podStatus.FindContainerStatusByName(c.Name)
+			if mustRerun || status == nil || status.State == kubecontainer.ContainerStateCreated {
+				changes.InitContainersToStart = []int{i}
+			} else {
+				changes.CreateSandbox = false
+			}
 			return changes
 		}
+		// The pod has no init containers, or all of them already completed.
 		changes.ContainersToStart = containersToStart
 		return changes
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -1480,6 +1480,83 @@ func TestComputePodActions(t *testing.T) {
 				ContainersToStart: []int{1},
 			},
 		},
+		"Restart running containers when a ready sandbox has to be replaced": {
+			mutateStatusFn: func(status *kubecontainer.PodStatus) {
+				// PodSandboxChanged also asks for a new sandbox for a ready one
+				// that lost its IP, so containers still reported as running
+				// have to come back up in the replacement.
+				status.SandboxStatuses[0].Network.Ip = ""
+			},
+			actions: podActions{
+				SandboxID:         baseStatus.SandboxStatuses[0].Id,
+				Attempt:           uint32(1),
+				CreateSandbox:     true,
+				KillPod:           true,
+				ContainersToStart: []int{0, 1, 2},
+				ContainersToKill:  map[kubecontainer.ContainerID]containerToKillInfo{},
+			},
+		},
+		"Recreate the sandbox for a pod with RestartPolicy=Never whose container was created but never started": {
+			mutatePodFn: func(pod *v1.Pod) { pod.Spec.RestartPolicy = v1.RestartPolicyNever },
+			mutateStatusFn: func(status *kubecontainer.PodStatus) {
+				// The node restarted between CreateContainer and
+				// StartContainer, so the sandbox is dead and the only
+				// container that exists never ran.
+				status.SandboxStatuses[0].State = runtimeapi.PodSandboxState_SANDBOX_NOTREADY
+				status.SandboxStatuses[0].Metadata.Attempt = uint32(2)
+				status.ContainerStatuses = status.ContainerStatuses[:1]
+				status.ContainerStatuses[0].State = kubecontainer.ContainerStateCreated
+			},
+			actions: podActions{
+				SandboxID:         baseStatus.SandboxStatuses[0].Id,
+				Attempt:           uint32(3),
+				CreateSandbox:     true,
+				KillPod:           true,
+				ContainersToStart: []int{0, 1, 2},
+				ContainersToKill:  map[kubecontainer.ContainerID]containerToKillInfo{},
+			},
+		},
+		"Recreate the sandbox but don't rerun exited containers for a pod with RestartPolicy=Never": {
+			mutatePodFn: func(pod *v1.Pod) { pod.Spec.RestartPolicy = v1.RestartPolicyNever },
+			mutateStatusFn: func(status *kubecontainer.PodStatus) {
+				status.SandboxStatuses[0].State = runtimeapi.PodSandboxState_SANDBOX_NOTREADY
+				status.SandboxStatuses[0].Metadata.Attempt = uint32(2)
+				// foo1 succeeded and foo3 failed, so neither may run again.
+				// foo2 was created but never started, so it still owes a run.
+				status.ContainerStatuses[0].State = kubecontainer.ContainerStateExited
+				status.ContainerStatuses[0].ExitCode = 0
+				status.ContainerStatuses[1].State = kubecontainer.ContainerStateCreated
+				status.ContainerStatuses[2].State = kubecontainer.ContainerStateExited
+				status.ContainerStatuses[2].ExitCode = 111
+			},
+			actions: podActions{
+				SandboxID:         baseStatus.SandboxStatuses[0].Id,
+				Attempt:           uint32(3),
+				CreateSandbox:     true,
+				KillPod:           true,
+				ContainersToStart: []int{1},
+				ContainersToKill:  map[kubecontainer.ContainerID]containerToKillInfo{},
+			},
+		},
+		"Don't recreate the sandbox for a pod with RestartPolicy=Never whose containers have all exited": {
+			mutatePodFn: func(pod *v1.Pod) { pod.Spec.RestartPolicy = v1.RestartPolicyNever },
+			mutateStatusFn: func(status *kubecontainer.PodStatus) {
+				status.SandboxStatuses[0].State = runtimeapi.PodSandboxState_SANDBOX_NOTREADY
+				status.SandboxStatuses[0].Metadata.Attempt = uint32(2)
+				for _, cs := range status.ContainerStatuses {
+					cs.State = kubecontainer.ContainerStateExited
+					cs.ExitCode = 0
+				}
+			},
+			actions: podActions{
+				SandboxID:         baseStatus.SandboxStatuses[0].Id,
+				Attempt:           uint32(3),
+				CreateSandbox:     false,
+				KillPod:           true,
+				ContainersToStart: []int{},
+				ContainersToKill:  map[kubecontainer.ContainerID]containerToKillInfo{},
+			},
+		},
 	} {
 		pod, status := makeBasePodAndStatus()
 		if test.mutatePodFn != nil {
@@ -2209,6 +2286,25 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 			},
 			skipWindows:          true, // Windows does not support resize.
 			disableIPPRInitCtrFG: true,
+		},
+		"Recreate the sandbox for a pod with RestartPolicy=Never without rerunning a completed init container": {
+			mutatePodFn: func(pod *v1.Pod) { pod.Spec.RestartPolicy = v1.RestartPolicyNever },
+			mutateStatusFn: func(status *kubecontainer.PodStatus) {
+				// The node restarted between CreateContainer and StartContainer
+				// for init2. init1 and init3 exited with code 0 in the base
+				// status, and init1 must not run a second time.
+				status.SandboxStatuses[0].State = runtimeapi.PodSandboxState_SANDBOX_NOTREADY
+				status.ContainerStatuses[1].State = kubecontainer.ContainerStateCreated
+			},
+			actions: podActions{
+				KillPod:               true,
+				CreateSandbox:         true,
+				SandboxID:             baseStatus.SandboxStatuses[0].Id,
+				Attempt:               uint32(1),
+				InitContainersToStart: []int{1},
+				ContainersToStart:     []int{},
+				ContainersToKill:      map[kubecontainer.ContainerID]containerToKillInfo{},
+			},
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
@@ -2998,6 +3094,48 @@ func TestComputePodActionsWithContainerRestartRules(t *testing.T) {
 				status.ContainerStatuses[1].ExitCode = 111
 			},
 			actions: noAction,
+		},
+		"Restart a container with RestartPolicy=Never whose restart rules match its exit code when the sandbox is dead": {
+			mutatePodFn: func(pod *v1.Pod) {
+				pod.Spec.RestartPolicy = v1.RestartPolicyAlways
+				// foo1 opts out of restarts, but a rule asks for one on exit code 42.
+				pod.Spec.Containers[0].RestartPolicy = &containerRestartPolicyNever
+				pod.Spec.Containers[0].RestartPolicyRules = []v1.ContainerRestartRule{{
+					Action: v1.ContainerRestartRuleActionRestart,
+					ExitCodes: &v1.ContainerRestartRuleOnExitCodes{
+						Operator: v1.ContainerRestartRuleOnExitCodesOpIn,
+						Values:   []int32{42},
+					},
+				}}
+				// foo2 opts out and has no rules at all.
+				pod.Spec.Containers[1].RestartPolicy = &containerRestartPolicyNever
+				// foo3 opts out and its rule does not match the code it exited with.
+				pod.Spec.Containers[2].RestartPolicy = &containerRestartPolicyNever
+				pod.Spec.Containers[2].RestartPolicyRules = []v1.ContainerRestartRule{{
+					Action: v1.ContainerRestartRuleActionRestart,
+					ExitCodes: &v1.ContainerRestartRuleOnExitCodes{
+						Operator: v1.ContainerRestartRuleOnExitCodesOpIn,
+						Values:   []int32{7},
+					},
+				}}
+			},
+			mutateStatusFn: func(status *kubecontainer.PodStatus) {
+				status.SandboxStatuses[0].State = runtimeapi.PodSandboxState_SANDBOX_NOTREADY
+				status.ContainerStatuses[0].State = kubecontainer.ContainerStateExited
+				status.ContainerStatuses[0].ExitCode = 42
+				status.ContainerStatuses[1].State = kubecontainer.ContainerStateExited
+				status.ContainerStatuses[1].ExitCode = 0
+				status.ContainerStatuses[2].State = kubecontainer.ContainerStateExited
+				status.ContainerStatuses[2].ExitCode = 42
+			},
+			actions: podActions{
+				KillPod:           true,
+				CreateSandbox:     true,
+				SandboxID:         baseStatus.SandboxStatuses[0].Id,
+				Attempt:           uint32(1),
+				ContainersToStart: []int{0},
+				ContainersToKill:  map[kubecontainer.ContainerID]containerToKillInfo{},
+			},
 		},
 		"Kill pod and recreate all containers (except for the succeeded one) if the pod sandbox is dead": {
 			mutatePodFn: func(pod *v1.Pod) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node

#### What this PR does / why we need it:

A pod with `restartPolicy: Never` can remain `Pending` indefinitely if its sandbox is lost between `CreateContainer` and `StartContainer`. Kubelet treats the existing container status as a reason not to recreate the sandbox, even though the container never ran.

Retry sandbox creation when an init or regular container is still `Created`. Respect restart policies when selecting replacement containers, and preserve completed init progress across recovery retries.

Regression tests cover mixed container states, restart rules, and init recovery after sandbox or container creation failures.

#### Which issue(s) this PR is related to:

- #118321 — pod (restartPolicy == Never) stuck pending when vm reboot
- #77544 — asks for phase: Failed when restartPolicy is Never and the sandbox is exited
- #79398
- #123839 — restartPolicy: OnFailure static-pod variant; triage/accepted, then rotted

#### Does this PR introduce a user-facing change?

```release-note
Fixed pods with restartPolicy Never remaining Pending after sandbox loss while a container was created but not yet started.
```

#### Additional documentation:

```docs
NONE
```

#### AI usage disclosure:

AI was used to diagnose the root cause from node journals and pod status, to review the initial patch, for the ShouldContainerBeRestarted refactor, and to write the tests.
