### PR TITLE
InterPodAffinity: handle namespaceSelector in assigned-pod queueing hints

### DIFF
--- a/pkg/scheduler/framework/plugins/interpodaffinity/plugin.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/plugin.go
@@ -185,6 +185,20 @@ func (pl *InterPodAffinity) isSchedulableAfterAssignedPodChange(logger klog.Logg
 		return fwk.Queue, err
 	}
 
+	// The matching helpers below assume namespaceSelector was already unrolled into
+	// Namespaces, as done in the Filter and Scoring paths, so unroll the queued
+	// pod terms here before matching them against the event pod.
+	for i := range terms {
+		if err := pl.mergeAffinityTermNamespacesIfNotEmpty(&terms[i]); err != nil {
+			return fwk.Queue, err
+		}
+	}
+	for i := range antiTerms {
+		if err := pl.mergeAffinityTermNamespacesIfNotEmpty(&antiTerms[i]); err != nil {
+			return fwk.Queue, err
+		}
+	}
+
 	// Pod is updated. Return Queue when the updated pod matching the target pod's affinity or not matching anti-affinity.
 	// Note that, we don't need to check each affinity individually when the Pod has more than one affinity
 	// because the current PodAffinity looks for a **single** existing pod that can satisfy **all** the terms of inter-pod affinity of an incoming pod.
@@ -227,6 +241,12 @@ func (pl *InterPodAffinity) isSchedulableAfterAssignedPodChange(logger klog.Logg
 	originalPodAntiTerms, err := fwk.GetAffinityTerms(originalPod, fwk.GetPodAntiAffinityTerms(originalPod.Spec.Affinity))
 	if err != nil {
 		return fwk.Queue, err
+	}
+	// The deleted pod's anti-affinity terms are matched against the queued pod, so unroll them here too.
+	for i := range originalPodAntiTerms {
+		if err := pl.mergeAffinityTermNamespacesIfNotEmpty(&originalPodAntiTerms[i]); err != nil {
+			return fwk.Queue, err
+		}
 	}
 	if podMatchesAnyAffinityTerms(originalPodAntiTerms, pod) {
 		logger.V(5).Info("a scheduled pod was deleted and the target pod matches the deleted pod's anti-affinity. The pod may be schedulable now",

--- a/pkg/scheduler/framework/plugins/interpodaffinity/plugin_test.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/plugin_test.go
@@ -35,6 +35,20 @@ import (
 )
 
 func Test_isSchedulableAfterAssignedPodChange(t *testing.T) {
+	nsPod := func(p *v1.Pod, ns string) *v1.Pod {
+		p.Namespace = ns
+		return p
+	}
+	withAffinityNamespaceSelector := func(p *v1.Pod) *v1.Pod {
+		term := &p.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0]
+		term.NamespaceSelector = &metav1.LabelSelector{MatchLabels: map[string]string{"team": "team1"}}
+		return p
+	}
+	withAntiAffinityNamespaceSelector := func(p *v1.Pod) *v1.Pod {
+		term := &p.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0]
+		term.NamespaceSelector = &metav1.LabelSelector{MatchLabels: map[string]string{"team": "team1"}}
+		return p
+	}
 	tests := []struct {
 		name           string
 		pod            *v1.Pod
@@ -191,6 +205,64 @@ func Test_isSchedulableAfterAssignedPodChange(t *testing.T) {
 			oldPod: st.MakePod().Node("fake-node").UID("other").
 				PodAntiAffinityIn("service", "region", []string{"securityscan"}, st.PodAntiAffinityWithRequiredReq).
 				PodAntiAffinityIn("app", "region", []string{"web"}, st.PodAntiAffinityWithRequiredReq).Obj(),
+			expectedHint: fwk.Queue,
+		},
+		{
+			name:         "add a pod matching the pod affinity with namespaceSelector",
+			pod:          withAffinityNamespaceSelector(st.MakePod().UID("p").Name("p").PodAffinityIn("service", "hostname", []string{"securityscan"}, st.PodAffinityWithRequiredReq).Obj()),
+			newPod:       nsPod(st.MakePod().UID("other").Node("fake-node").Label("service", "securityscan").Obj(), "subteam1.team1"),
+			expectedHint: fwk.Queue,
+		},
+		{
+			name:         "add a pod in a namespace not matching the namespaceSelector of the pod affinity",
+			pod:          withAffinityNamespaceSelector(st.MakePod().UID("p").Name("p").PodAffinityIn("service", "hostname", []string{"securityscan"}, st.PodAffinityWithRequiredReq).Obj()),
+			newPod:       nsPod(st.MakePod().UID("other").Node("fake-node").Label("service", "securityscan").Obj(), "subteam1.team2"),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:         "add a pod matching the namespaceSelector but not the labelSelector of the pod affinity",
+			pod:          withAffinityNamespaceSelector(st.MakePod().UID("p").Name("p").PodAffinityIn("service", "hostname", []string{"securityscan"}, st.PodAffinityWithRequiredReq).Obj()),
+			newPod:       nsPod(st.MakePod().UID("other").Node("fake-node").Label("aaa", "a").Obj(), "subteam1.team1"),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:         "update a pod to match the pod affinity with namespaceSelector",
+			pod:          withAffinityNamespaceSelector(st.MakePod().UID("p").Name("p").PodAffinityIn("service", "hostname", []string{"securityscan"}, st.PodAffinityWithRequiredReq).Obj()),
+			oldPod:       nsPod(st.MakePod().UID("other").Node("fake-node").Label("aaa", "a").Obj(), "subteam1.team2"),
+			newPod:       nsPod(st.MakePod().UID("other").Node("fake-node").Label("service", "securityscan").Obj(), "subteam1.team1"),
+			expectedHint: fwk.Queue,
+		},
+		{
+			name:         "update a pod to not match the pod anti-affinity with namespaceSelector",
+			pod:          withAntiAffinityNamespaceSelector(st.MakePod().UID("p").Name("p").PodAntiAffinityIn("service", "hostname", []string{"securityscan"}, st.PodAntiAffinityWithRequiredReq).Obj()),
+			oldPod:       nsPod(st.MakePod().UID("other").Node("fake-node").Label("service", "securityscan").Obj(), "subteam1.team1"),
+			newPod:       nsPod(st.MakePod().UID("other").Node("fake-node").Label("aaa", "a").Obj(), "subteam1.team1"),
+			expectedHint: fwk.Queue,
+		},
+		{
+			name:         "update a pod to match the pod anti-affinity with namespaceSelector",
+			pod:          withAntiAffinityNamespaceSelector(st.MakePod().UID("p").Name("p").PodAntiAffinityIn("service", "hostname", []string{"securityscan"}, st.PodAntiAffinityWithRequiredReq).Obj()),
+			oldPod:       nsPod(st.MakePod().UID("other").Node("fake-node").Label("aaa", "a").Obj(), "subteam1.team1"),
+			newPod:       nsPod(st.MakePod().UID("other").Node("fake-node").Label("service", "securityscan").Obj(), "subteam1.team1"),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:         "delete a pod matching the namespaceSelector but not the labelSelector of the pod anti-affinity",
+			pod:          withAntiAffinityNamespaceSelector(st.MakePod().UID("p").Name("p").PodAntiAffinityIn("service", "hostname", []string{"securityscan"}, st.PodAntiAffinityWithRequiredReq).Obj()),
+			oldPod:       nsPod(st.MakePod().UID("other").Node("fake-node").Label("aaa", "a").Obj(), "subteam1.team1"),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:         "delete a pod matching the anti-affinity with namespaceSelector of the pending pod",
+			pod:          withAntiAffinityNamespaceSelector(st.MakePod().Name("p").PodAntiAffinityIn("service", "hostname", []string{"securityscan"}, st.PodAntiAffinityWithRequiredReq).Obj()),
+			oldPod:       nsPod(st.MakePod().UID("other").Node("fake-node").Label("service", "securityscan").Obj(), "subteam1.team1"),
+			expectedHint: fwk.Queue,
+		},
+		{
+			name: "delete a pod whose anti-affinity with namespaceSelector matches the pending pod",
+			pod:  nsPod(st.MakePod().Name("p").Label("service", "securityscan").Obj(), "subteam1.team1"),
+			oldPod: withAntiAffinityNamespaceSelector(st.MakePod().Node("fake-node").UID("other").
+				PodAntiAffinityIn("service", "hostname", []string{"securityscan"}, st.PodAntiAffinityWithRequiredReq).Obj()),
 			expectedHint: fwk.Queue,
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

A pod whose only scheduling blocker is a required podAffinity term with a namespaceSelector is not requeued when an assigned pod that satisfies the term is added or updated, and a pod blocked by a namespaceSelector-based anti-affinity term is not requeued when the blocking pod is deleted or updated away from the term. The pod is only retried by the periodic unschedulable pods sweep (`--pod-max-in-unschedulable-pods-duration`, default 5m, deprecated), on the first attempt after the sweep. See #141953 for the cluster reproduction: a control term without namespaceSelector is requeued and scheduled within about 10s of the matching pod being added, while the namespaceSelector term only schedules after the sweep (~5m).

Root cause: the assigned-pod queueing hint (isSchedulableAfterAssignedPodChange) matches terms with podMatchesAllAffinityTerms / podMatchesAnyAffinityTerms without first unrolling namespaceSelector into term.Namespaces. Those helpers assume the selector was already merged, as mergeAffinityTermNamespacesIfNotEmpty does in the Filter and Scoring paths; with the selector left unmerged, term.Namespaces is empty and the namespace half of the match never succeeds, so the hint returns QueueSkip even when the event pod fully satisfies the term.

This change unrolls the namespaceSelector of the pending pod's affinity and anti-affinity terms before matching them against the event pod, and of a deleted pod's anti-affinity terms before the reverse-direction match, mirroring the Filter/Scoring behavior. On a namespace lister error the hint conservatively returns Queue so the pod is retried.

Namespace label changes (the second trigger in #141953) are not covered here: waking pods on namespace label updates needs a Namespace cluster event resource, which the scheduler framework does not provide today (the available cluster event resources are listed in pkg/scheduler/framework/types.go). The issue body scopes that separately and the discussion can decide where it belongs.

#### Which issue(s) this PR is related to:

Fixes #141953

#### Special notes for your reviewer:

- Scope: assigned pod add/update (affinity and anti-affinity terms) and pod delete (anti-affinity, both directions), i.e. all namespace-matching paths reachable from the AssignedPod queueing hint. The Node and TargetPod hints do not match namespaces.
- Red/green: nine new unit tests in Test_isSchedulableAfterAssignedPodChange; five fail on master with QueueSkip where Queue is expected (pod add matching the term, an update into an affinity match, an update out of an anti-affinity match, and both delete directions) and pass with this change. The four negative controls (event pod namespace not matching the selector, or labels not matching the term labelSelector) stay QueueSkip with and without the change.
- The delete-direction tests also cover the anti-affinity gap called out in #141953 by code inspection.
- Terms without namespaceSelector are unaffected: the merge helper early-returns for empty selectors, so existing behavior is unchanged.
- gofmt and go vet are clean; the interpodaffinity package test suite passes.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where pods with required pod affinity or anti-affinity terms using namespaceSelector were not requeued on assigned-pod events that could make them schedulable, which delayed scheduling until the periodic unschedulable-pods flush.
```

This PR was written in part with the assistance of generative AI.