### PR TITLE
kubelet: reject unknown seccomp profile types

### DIFF
--- a/pkg/kubelet/kuberuntime/helpers.go
+++ b/pkg/kubelet/kuberuntime/helpers.go
@@ -280,25 +280,33 @@ func fieldSeccompProfile(scmp *v1.SeccompProfile, profileRootPath string, fallba
 			ProfileType: runtimeapi.SecurityProfile_Unconfined,
 		}, nil
 	}
-	if scmp.Type == v1.SeccompProfileTypeRuntimeDefault {
+	switch scmp.Type {
+	case v1.SeccompProfileTypeUnconfined:
+		return &runtimeapi.SecurityProfile{
+			ProfileType: runtimeapi.SecurityProfile_Unconfined,
+		}, nil
+	case v1.SeccompProfileTypeRuntimeDefault:
 		return &runtimeapi.SecurityProfile{
 			ProfileType: runtimeapi.SecurityProfile_RuntimeDefault,
 		}, nil
-	}
-	if scmp.Type == v1.SeccompProfileTypeLocalhost {
+	case v1.SeccompProfileTypeLocalhost:
 		if scmp.LocalhostProfile != nil && len(*scmp.LocalhostProfile) > 0 {
 			fname := filepath.Join(profileRootPath, *scmp.LocalhostProfile)
 			return &runtimeapi.SecurityProfile{
 				ProfileType:  runtimeapi.SecurityProfile_Localhost,
 				LocalhostRef: fname,
 			}, nil
-		} else {
-			return nil, fmt.Errorf("localhostProfile must be set if seccompProfile type is Localhost.")
 		}
+		return nil, fmt.Errorf("localhostProfile must be set if seccompProfile type is Localhost")
+	default:
+		return nil, fmt.Errorf(
+			"unsupported seccompProfile type %q (supported: %s, %s, %s)",
+			scmp.Type,
+			v1.SeccompProfileTypeUnconfined,
+			v1.SeccompProfileTypeRuntimeDefault,
+			v1.SeccompProfileTypeLocalhost,
+		)
 	}
-	return &runtimeapi.SecurityProfile{
-		ProfileType: runtimeapi.SecurityProfile_Unconfined,
-	}, nil
 }
 
 func (m *kubeGenericRuntimeManager) getSeccompProfile(annotations map[string]string, containerName string,

--- a/pkg/kubelet/kuberuntime/helpers_linux_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_linux_test.go
@@ -92,12 +92,12 @@ func TestGetSeccompProfile(t *testing.T) {
 		{
 			description:   "pod seccomp profile set to SeccompProfileTypeLocalhost with empty LocalhostProfile returns error",
 			podSc:         &v1.PodSecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeLocalhost}},
-			expectedError: "localhostProfile must be set if seccompProfile type is Localhost.",
+			expectedError: "localhostProfile must be set if seccompProfile type is Localhost",
 		},
 		{
 			description:   "container seccomp profile set to SeccompProfileTypeLocalhost with empty LocalhostProfile returns error",
 			containerSc:   &v1.SecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeLocalhost}},
-			expectedError: "localhostProfile must be set if seccompProfile type is Localhost.",
+			expectedError: "localhostProfile must be set if seccompProfile type is Localhost",
 		},
 		{
 			description: "container seccomp profile set to SeccompProfileTypeLocalhost returns 'localhost/' + LocalhostProfile",
@@ -122,6 +122,26 @@ func TestGetSeccompProfile(t *testing.T) {
 				ProfileType:  runtimeapi.SecurityProfile_Localhost,
 				LocalhostRef: seccompLocalhostRef("field-cont-profile.json"),
 			},
+		},
+		{
+			description:   "unknown pod seccomp profile type returns error",
+			podSc:         &v1.PodSecurityContext{SeccompProfile: &v1.SeccompProfile{Type: "Unknown"}},
+			expectedError: `unsupported seccompProfile type "Unknown" (supported: Unconfined, RuntimeDefault, Localhost)`,
+		},
+		{
+			description:   "unknown container seccomp profile type returns error",
+			containerSc:   &v1.SecurityContext{SeccompProfile: &v1.SeccompProfile{Type: "Unknown"}},
+			expectedError: `unsupported seccompProfile type "Unknown" (supported: Unconfined, RuntimeDefault, Localhost)`,
+		},
+		{
+			description:   "empty pod seccomp profile type returns error",
+			podSc:         &v1.PodSecurityContext{SeccompProfile: &v1.SeccompProfile{}},
+			expectedError: `unsupported seccompProfile type "" (supported: Unconfined, RuntimeDefault, Localhost)`,
+		},
+		{
+			description:   "empty container seccomp profile type returns error",
+			containerSc:   &v1.SecurityContext{SeccompProfile: &v1.SeccompProfile{}},
+			expectedError: `unsupported seccompProfile type "" (supported: Unconfined, RuntimeDefault, Localhost)`,
 		},
 	}
 
@@ -193,12 +213,12 @@ func TestGetSeccompProfileDefaultSeccomp(t *testing.T) {
 		{
 			description:   "pod seccomp profile set to SeccompProfileTypeLocalhost with empty LocalhostProfile returns error",
 			podSc:         &v1.PodSecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeLocalhost}},
-			expectedError: "localhostProfile must be set if seccompProfile type is Localhost.",
+			expectedError: "localhostProfile must be set if seccompProfile type is Localhost",
 		},
 		{
 			description:   "container seccomp profile set to SeccompProfileTypeLocalhost with empty LocalhostProfile returns error",
 			containerSc:   &v1.SecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeLocalhost}},
-			expectedError: "localhostProfile must be set if seccompProfile type is Localhost.",
+			expectedError: "localhostProfile must be set if seccompProfile type is Localhost",
 		},
 		{
 			description: "container seccomp profile set to SeccompProfileTypeLocalhost returns 'localhost/' + LocalhostProfile",
@@ -223,6 +243,26 @@ func TestGetSeccompProfileDefaultSeccomp(t *testing.T) {
 				ProfileType:  runtimeapi.SecurityProfile_Localhost,
 				LocalhostRef: seccompLocalhostRef("field-cont-profile.json"),
 			},
+		},
+		{
+			description:   "unknown pod seccomp profile type returns error",
+			podSc:         &v1.PodSecurityContext{SeccompProfile: &v1.SeccompProfile{Type: "Unknown"}},
+			expectedError: `unsupported seccompProfile type "Unknown" (supported: Unconfined, RuntimeDefault, Localhost)`,
+		},
+		{
+			description:   "unknown container seccomp profile type returns error",
+			containerSc:   &v1.SecurityContext{SeccompProfile: &v1.SeccompProfile{Type: "Unknown"}},
+			expectedError: `unsupported seccompProfile type "Unknown" (supported: Unconfined, RuntimeDefault, Localhost)`,
+		},
+		{
+			description:   "empty pod seccomp profile type returns error",
+			podSc:         &v1.PodSecurityContext{SeccompProfile: &v1.SeccompProfile{}},
+			expectedError: `unsupported seccompProfile type "" (supported: Unconfined, RuntimeDefault, Localhost)`,
+		},
+		{
+			description:   "empty container seccomp profile type returns error",
+			containerSc:   &v1.SecurityContext{SeccompProfile: &v1.SeccompProfile{}},
+			expectedError: `unsupported seccompProfile type "" (supported: Unconfined, RuntimeDefault, Localhost)`,
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The `fieldSeccompProfile` function used an if-chain that silently fell through to `Unconfined` for any unrecognized `SeccompProfileType`. This means an unknown type would run the container without seccomp protection and without any error.

This replaces the if-chain with a switch that explicitly handles all three valid types (`Unconfined`, `RuntimeDefault`, `Localhost`) and returns an error for anything else.

An empty `Type` is also rejected now, where it previously fell through to `Unconfined`. API validation requires the type, and the kubelet runs the same validation for static pods, so nothing valid reaches this code path with an empty type.

The error message for a `Localhost` profile without `localhostProfile` loses its trailing period, which is visible in the pod event text.

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/6061

#### Special notes for your reviewer:

This is a prerequisite for KEP-6061 (OCI Artifact Security Profiles). The version skew strategy in that KEP requires this fix so that older kubelets fail closed on new profile types (like the future `OCI` type) rather than silently falling through to `Unconfined`.

The API validation layer (`validateSeccompProfileType`) already rejects unknown types at admission, so this is defense-in-depth at the kubelet runtime level. The AppArmor handler already fails closed on unknown types; this brings seccomp in line with that behavior.

#### Does this PR introduce a user-facing change?
```release-note
kubelet: a Pod with an unknown or empty `seccompProfile.type` now fails closed, the container fails to start with `CreateContainerConfigError` instead of silently running as `Unconfined`. Both values are already rejected by API validation on Pod create and update, and by the kubelet's own validation for static Pods, so no Pod accepted by a supported API server is affected. This only changes behavior for Pods that reached the kubelet without passing API validation, or for a kubelet older than an API server that supports a seccomp profile type the kubelet does not know. The error message for a `Localhost` profile without `localhostProfile` no longer ends with a trailing period.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/6061-oci-artifact-security-profiles
```

#### AI usage disclosure:

Yes, for review.

