### PR TITLE
kubectl explain: fix missing validation for empty api-version flag

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go
@@ -143,6 +143,9 @@ func NewCmdExplain(parent string, f cmdutil.Factory, streams genericiooptions.IO
 		Run: func(cmd *cobra.Command, args []string) {
 			o, err := flags.ToOptions(f, parent, args)
 			cmdutil.CheckErr(err)
+			if cmd.Flags().Changed("api-version") && len(o.APIVersion) == 0 {
+				cmdutil.CheckErr(fmt.Errorf("--api-version cannot be empty"))
+			}
 			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.Run())
 		},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain_test.go
@@ -194,9 +194,10 @@ var explainV2Cases = []explainTestCase{
 		ExpectErrorPattern: `couldn't find resource for \"/v99, (Kind=Pod|Resource=pods)\"`,
 	},
 	{
-		Name:               "NonExistingResource",
-		Args:               []string{"foo"},
-		ExpectErrorPattern: `the server doesn't have a resource type "foo"`,
+		Name:               "EmptyAPIVersion",
+		Args:               []string{"pods"},
+		Flags:              map[string]string{"api-version": ""},
+		ExpectErrorPattern: `--api-version cannot be empty`,
 	},
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR adds validation to `kubectl explain` to return an error when `--api-version` is passed with an empty value (e.g. `--api-version=`).

Currently, passing an empty `--api-version` flag is silently treated the same as not passing the flag at all, falling back to the default version without informing the user. This can mask user mistakes, such as a broken shell variable substitution that results in an empty value being passed unintentionally.

Currently learning `Kubernetes `and would appreciate suggestions to improve my learning process.

#### Which issue(s) this PR is related to:
- Fixes kubernetes/kubectl#1882

#### Special notes for your reviewer:
The check is currently implemented directly in the `Run` function of the cobra command in `explain.go`. Open to moving this into `ExplainOptions.Complete()`/`Validate()` if that's preferred, to match the pattern used elsewhere in kubectl (e.g. `create namespace`, `wait`).

Added a new test case `EmptyAPIVersion` to `explainV2Cases`, which is exercised by both `TestExplainOpenAPIV2` and `TestExplainOpenAPIV3`.

#### Does this PR introduce a user-facing change?
```release-note
`kubectl explain` now returns an error when `--api-version` is passed with an empty value, instead of silently falling back to the default API version.
```

#### AI usage disclosure:
YES. I am currently learning kubernities, so used ai assitance 