### PR TITLE
Drop container-storage-interface replaces

### DIFF
--- a/staging/src/k8s.io/code-generator/examples/go.mod
+++ b/staging/src/k8s.io/code-generator/examples/go.mod
@@ -61,5 +61,3 @@ replace (
 	k8s.io/apimachinery => ../../apimachinery
 	k8s.io/client-go => ../../client-go
 )
-
-replace github.com/container-storage-interface/spec => github.com/gnufied/spec v1.7.1-0.20260718120346-8e06851c4133

--- a/staging/src/k8s.io/kms/internal/plugins/_mock/go.mod
+++ b/staging/src/k8s.io/kms/internal/plugins/_mock/go.mod
@@ -22,5 +22,3 @@ require (
 )
 
 replace k8s.io/kms => ../../../../kms
-
-replace github.com/container-storage-interface/spec => github.com/gnufied/spec v1.7.1-0.20260718120346-8e06851c4133


### PR DESCRIPTION
#### What type of PR is this?

/kind dependency
/kind cleanup

#### What this PR does / why we need it:

Two modules replace github.com/container-storage-interface/spec with github.com/gnufied/spec v1.7.1-0.20260718120346-8e06851c4133, but now that we use v1.13.0 of the spec, all the changes in the fork are included. Since the replacement no longer seems necessary or useful, this removes it.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

NO.