### PR TITLE
Add missing tests in scheduler_perf for podgroups scheduling

### DIFF
--- a/test/integration/scheduler_perf/podgroup/tas/performance-config.yaml
+++ b/test/integration/scheduler_perf/podgroup/tas/performance-config.yaml
@@ -139,4 +139,135 @@
     featureGates:
       CompositePodGroup: true
 
-
+- name: BasicTopologyAwareScheduling
+  featureGates:
+    GenericWorkload: true
+    TopologyAwareWorkloadScheduling: true
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+    nodeTemplatePath: templates/node.yaml
+  - opcode: createNamespaces
+    prefix: tas-ns
+    count: 1
+  - opcode: createPodGroups
+    # Create pod groups, and wait for the scheduler's informer cache to reflect the newly created pod group objects.
+    # Each pod group is named basic-group-0, basic-group-1, ..., basic-group-(n-1), where n is the number of pod groups.
+    # Each group has basic policy and topology constraints specified in the pod group template.
+    countParam: $initPodGroups
+    namespace: tas-ns-0
+    templatePath: templates/basic-podgroup.yaml
+  - opcode: createPods
+    # Create pods with reference to the pod groups according to their indices (e.g., pods 0-2 → basic-group-0, pods 3-5 → basic-group-1, etc.).
+    countParam: $initPodGroups
+    countMultiplierParam: $podsPerGroup
+    namespace: tas-ns-0
+    podTemplatePath: templates/basic-pod.yaml
+    collectMetrics: true
+    templateParams:
+      podsPerGroup: $podsPerGroup
+  workloads:
+  - name: 10Nodes_3Groups
+    labels: [integration-test, short]
+    params:
+      initNodes: 10
+      initPodGroups: 3
+      podsPerGroup: 3
+  - name: 100Nodes_10Groups
+    labels: [integration-test]
+    params:
+      initNodes: 100
+      initPodGroups: 10
+      podsPerGroup: 3
+  - name: 100Nodes_10Groups_CompositePodGroupEnabled
+    labels: [integration-test]
+    params:
+      initNodes: 100
+      initPodGroups: 10
+      podsPerGroup: 3
+    featureGates:
+      CompositePodGroup: true
+  - name: 5000Nodes_750Groups_3000Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initPodGroups: 750
+      podsPerGroup: 4
+  - name: 5000Nodes_750Groups_3000Pods_CompositePodGroupEnabled
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initPodGroups: 750
+      podsPerGroup: 4
+    featureGates:
+      CompositePodGroup: true
+  - name: 5000Nodes_1500Groups_6000Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initPodGroups: 1500
+      podsPerGroup: 4
+  - name: 5000Nodes_1500Groups_6000Pods_CompositePodGroupEnabled
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initPodGroups: 1500
+      podsPerGroup: 4
+    featureGates:
+      CompositePodGroup: true
+  - name: 5000Nodes_2250Groups_9000Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initPodGroups: 2250
+      podsPerGroup: 4
+  - name: 5000Nodes_2250Groups_9000Pods_CompositePodGroupEnabled
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initPodGroups: 2250
+      podsPerGroup: 4
+    featureGates:
+      CompositePodGroup: true
+  - name: 5000Nodes_3Groups_3000Pods_1000PerGroup
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initPodGroups: 3
+      podsPerGroup: 1000
+  - name: 5000Nodes_3Groups_3000Pods_1000PerGroup_CompositePodGroupEnabled
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initPodGroups: 3
+      podsPerGroup: 1000
+    featureGates:
+      CompositePodGroup: true
+  - name: 5000Nodes_6Groups_6000Pods_1000PerGroup
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initPodGroups: 6
+      podsPerGroup: 1000
+  - name: 5000Nodes_6Groups_6000Pods_1000PerGroup_CompositePodGroupEnabled
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initPodGroups: 6
+      podsPerGroup: 1000
+    featureGates:
+      CompositePodGroup: true
+  - name: 5000Nodes_9Groups_9000Pods_1000PerGroup
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initPodGroups: 9
+      podsPerGroup: 1000
+  - name: 5000Nodes_9Groups_9000Pods_1000PerGroup_CompositePodGroupEnabled
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initPodGroups: 9
+      podsPerGroup: 1000
+    featureGates:
+      CompositePodGroup: true

--- a/test/integration/scheduler_perf/podgroup/tas/templates/basic-pod.yaml
+++ b/test/integration/scheduler_perf/podgroup/tas/templates/basic-pod.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-tas-basic-{{.Index}}
+spec:
+  schedulingGroup:
+    podGroupName: basic-group-{{DivideInt .Index .podsPerGroup}}
+  containers:
+  - image: registry.k8s.io/pause:3.10.1
+    name: pause
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi

--- a/test/integration/scheduler_perf/podgroup/tas/templates/basic-podgroup.yaml
+++ b/test/integration/scheduler_perf/podgroup/tas/templates/basic-podgroup.yaml
@@ -1,0 +1,10 @@
+apiVersion: scheduling.k8s.io/v1beta1
+kind: PodGroup
+metadata:
+  name: basic-group-{{.Index}}
+spec:
+  schedulingPolicy:
+    basic: {}
+  schedulingConstraints:
+    topology:
+    - key: topology.kubernetes.io/rack


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig scheduling

#### What this PR does / why we need it:
We are adding missing tests when it comes to podgroups scheduling in scheduler_perf.

#### What are missing tests?
- scheduling podgroups with basic policy and TAS enabled.

#### Special notes for your reviewer:
Test cases provided are basically the same as scheduling podgroups with gang policy and TAS enabled.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```