### PR TITLE
DRA: clarify PrepareResourceClaims guarantees

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
@@ -123,6 +123,9 @@ type DRAPlugin interface {
 	//
 	// This call must be idempotent because the kubelet might have to ask
 	// for preparation multiple times, for example if it gets restarted.
+	// DRA drivers can rely on it being called after a node reboot
+	// and before the kubelet restarts application pods, so this call is
+	// a good place to verify that everything is really ready.
 	//
 	// A DRA driver should verify that all devices listed in a
 	// [resourceapi.DeviceRequestAllocationResult] are not already in use


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

It's useful that the kubelet calls NodePrepareResources after a reboot because DRA drivers then can fix things that might have been lost because of a reboot.

We didn't actually specify this in the KEP, but have implemented it so that kubelet does not cache the "is prepared" flag in its checkpoint file and thus does call NodePrepareResources again. We can't change that anymore (and shouldn't anyway), so we might as well document it.

#### Which issue(s) this PR is related to:

Fixes: https://github.com/kubernetes/kubernetes/issues/141433#issuecomment-5572182659

/assign @bart0sh 
/cc @gaurav1086 @yogeshbendre

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### AI usage disclosure:

NO