### PR TITLE
kubeadm: warn when getent is missing from PATH

### DIFF
--- a/cmd/kubeadm/app/preflight/checks_linux.go
+++ b/cmd/kubeadm/app/preflight/checks_linux.go
@@ -91,6 +91,13 @@ func addExecChecks(checks []Checker, execer utilsexec.Interface, k8sVersion stri
 	// kubelet requires mount to be present in PATH for in-tree volume plugins.
 	checks = append(checks, InPathCheck{executable: "mount", mandatory: true, exec: execer})
 
+	// kubelet uses getent to resolve the "kubelet" account before it consults getsubids
+	// for user namespace ID mappings. Without it the account looks absent and kubelet
+	// falls back to the default ID range without reporting anything.
+	// (ref: https://github.com/kubernetes/kubernetes/pull/135870)
+	checks = append(checks, InPathCheck{executable: "getent", mandatory: false, exec: execer,
+		suggestion: "install the package that provides getent, usually glibc or libc-bin"})
+
 	// kubeadm requires cp to be present in PATH for copying etcd directories.
 	checks = append(checks, InPathCheck{executable: "cp", mandatory: true, exec: execer})
 	return checks


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This adds `getent` to the kubeadm preflight tool inventory as a warning, so a node missing it gets flagged before kubelet quietly picks the wrong user namespace ID range.

It should almost never fire in practice. `getent` ships in libc-bin, so on the distros kubeadm targets it is already there; musl or a minimal image is where this would show up.

##### What happens without it

kubelet runs `getent passwd kubelet` to decide whether the account exists, and only consults `getsubids` if it does. With `getent` off PATH the account looks absent, so the built-in default range gets used instead of the delegated one, and nothing is logged above `V(5)`:

```
firstID=1048576  rangeLen=8388608     # getent present, /etc/subuid honored
firstID=65536    rangeLen=4294901760  # getent missing, default range
```

##### Why getsubids is not checked too

That one fails loudly. When `getsubids` is missing and the account does resolve, kubelet stops with the binary named:

```
create user namespace manager: kubelet mappings: exec: "getsubids": executable file not found in $PATH
```

Which is the `os.IsNotExist` versus `exec.ErrNotFound` mismatch that #141345 is already fixing, so it wants a code fix, not a preflight entry.

##### Ordering against #135870

The `getent` call arrives with #135870, which is still open. On current master kubelet uses `os/user`, so this check describes a dependency that doesn't exist yet and should land after that one.

Requested in https://github.com/kubernetes/kubernetes/pull/135870#discussion_r3966842437

#### Which issue(s) this PR is related to:

Related to #135870

#### Does this PR introduce a user-facing change?

```release-note
kubeadm: added a preflight warning when `getent` is not found in PATH. kubelet uses it to resolve the `kubelet` account when setting up user namespace ID mappings.
```

/sig cluster-lifecycle
/area kubeadm
/cc @neolit123 @carlory
