### PR TITLE
scheduler: support CompositePodGroup in workload preemption metrics

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -6943,20 +6943,24 @@
     endpoint: /metrics
 - name: workload_preemption_attempts_total
   subsystem: scheduler
-  help: Total preemption attempts initiated by workload (including pod groups) in
-    the cluster till now.
+  help: Total preemption attempts initiated by workload (including pod groups and
+    composite pod groups) in the cluster till now.
   type: Counter
   stabilityLevel: ALPHA
   labels:
+  - preemptor
   - result
   componentEndpoints:
   - component: kube-scheduler
     endpoint: /metrics
 - name: workload_preemption_victims
   subsystem: scheduler
-  help: Number of pod preemption victims caused by workload preemption.
+  help: Number of pod preemption victims caused by workload preemption (including
+    pod groups and composite pod groups).
   type: Histogram
   stabilityLevel: ALPHA
+  labels:
+  - preemptor
   buckets:
   - 1
   - 2

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -504,7 +504,7 @@ func (pl *DefaultPreemption) isPreemptionAllowedAcrossAllVictimNodes(victim *pre
 // PodGroupPostFilter runs a default preemption for the pod group.
 func (pl *DefaultPreemption) PodGroupPostFilter(ctx context.Context, state fwk.PodGroupCycleState, pgInfo fwk.PodGroupInfo, pgSchedulingFunc fwk.PodGroupSchedulingFunc) (postFilterResult *fwk.PodGroupPostFilterResult, status *fwk.Status) {
 	defer func() {
-		metrics.WorkloadPreemptionAttempts.WithLabelValues(status.Code().String()).Inc()
+		metrics.WorkloadPreemptionAttempts.WithLabelValues(status.Code().String(), string(pgInfo.GetType())).Inc()
 	}()
 
 	mutableLister := pl.fh.MutableSnapshotSharedLister()

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -4187,20 +4187,46 @@ func (m *mockHandle) MutableSnapshotSharedLister() fwk.MutableSnapshotSharedList
 
 func TestDefaultPreemption_PodGroupPostFilter_WorkloadPreemptionAttempts(t *testing.T) {
 	tests := []struct {
-		name   string
-		status *fwk.Status
+		name          string
+		status        *fwk.Status
+		isCPG         bool
+		wantPreemptor string
 	}{
 		{
-			name:   "preemption success",
-			status: fwk.NewStatus(fwk.Success),
+			name:          "podgroup preemption success",
+			status:        fwk.NewStatus(fwk.Success),
+			isCPG:         false,
+			wantPreemptor: metrics.PodGroup,
 		},
 		{
-			name:   "preemption unschedulable",
-			status: fwk.NewStatus(fwk.Unschedulable),
+			name:          "compositepodgroup preemption success",
+			status:        fwk.NewStatus(fwk.Success),
+			isCPG:         true,
+			wantPreemptor: metrics.CompositePodGroup,
 		},
 		{
-			name:   "preemption error",
-			status: fwk.NewStatus(fwk.Error),
+			name:          "podgroup preemption unschedulable",
+			status:        fwk.NewStatus(fwk.Unschedulable),
+			isCPG:         false,
+			wantPreemptor: metrics.PodGroup,
+		},
+		{
+			name:          "compositepodgroup preemption unschedulable",
+			status:        fwk.NewStatus(fwk.Unschedulable),
+			isCPG:         true,
+			wantPreemptor: metrics.CompositePodGroup,
+		},
+		{
+			name:          "podgroup preemption error",
+			status:        fwk.NewStatus(fwk.Error),
+			isCPG:         false,
+			wantPreemptor: metrics.PodGroup,
+		},
+		{
+			name:          "compositepodgroup preemption error",
+			status:        fwk.NewStatus(fwk.Error),
+			isCPG:         true,
+			wantPreemptor: metrics.CompositePodGroup,
 		},
 	}
 
@@ -4216,16 +4242,21 @@ func TestDefaultPreemption_PodGroupPostFilter_WorkloadPreemptionAttempts(t *test
 			}
 
 			expectedStatus := tt.status.Code().String()
-			stateBefore := captureWorkloadPreemptionAttempts(testRegistry, expectedStatus)
+			stateBefore := captureWorkloadPreemptionAttempts(testRegistry, expectedStatus, tt.wantPreemptor)
 
-			pgInfo := &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericPodGroup(st.MakePodGroup().Obj())}
+			var pgInfo *framework.PodGroupInfo
+			if tt.isCPG {
+				pgInfo = &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericCompositePodGroup(st.MakeCompositePodGroup().Obj())}
+			} else {
+				pgInfo = &framework.PodGroupInfo{GenericPodGroup: fwk.NewGenericPodGroup(st.MakePodGroup().Obj())}
+			}
 			pl.PodGroupPostFilter(ctx, nil, pgInfo, nil)
 
-			stateAfter := captureWorkloadPreemptionAttempts(testRegistry, expectedStatus)
+			stateAfter := captureWorkloadPreemptionAttempts(testRegistry, expectedStatus, tt.wantPreemptor)
 
 			diff := stateAfter.count - stateBefore.count
 			if diff != 1 {
-				t.Errorf("Expected %s count delta to be 1, got %d", expectedStatus, diff)
+				t.Errorf("Expected %s count delta for %s to be 1, got %d", expectedStatus, tt.wantPreemptor, diff)
 			}
 		})
 	}
@@ -4235,16 +4266,16 @@ type workloadPreemptionAttemptsState struct {
 	count uint64
 }
 
-func captureWorkloadPreemptionAttempts(g componentmetrics.Gatherer, status string) workloadPreemptionAttemptsState {
+func captureWorkloadPreemptionAttempts(g componentmetrics.Gatherer, status, preemptorType string) workloadPreemptionAttemptsState {
 	state := workloadPreemptionAttemptsState{}
-	if count, err := getCounterFromGatherer(g, "scheduler_workload_preemption_attempts_total", status); err == nil {
+	if count, err := getCounterFromGatherer(g, "scheduler_workload_preemption_attempts_total", status, preemptorType); err == nil {
 		state.count = count
 	}
 	return state
 }
 
-func getCounterFromGatherer(g componentmetrics.Gatherer, name string, resultLabelValue string) (uint64, error) {
-	vals, err := testutil.GetCounterValuesFromGatherer(g, name, nil, "result")
+func getCounterFromGatherer(g componentmetrics.Gatherer, name string, resultLabelValue, preemptorType string) (uint64, error) {
+	vals, err := testutil.GetCounterValuesFromGatherer(g, name, map[string]string{"preemptor": preemptorType}, "result")
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/scheduler/framework/preemption/executor.go
+++ b/pkg/scheduler/framework/preemption/executor.go
@@ -363,7 +363,7 @@ func (e *Executor) prepareCandidate(ctx context.Context, c Candidate, preemptor 
 func observeVictims(preemptor ExecutorPreemptor, candidate Candidate) {
 	numVictims := float64(len(candidate.Victims().Pods))
 	if preemptor.Type() == string(fwk.PodGroupKeyType) || preemptor.Type() == string(fwk.CompositePodGroupKeyType) {
-		metrics.WorkloadPreemptionVictims.Observe(numVictims)
+		metrics.WorkloadPreemptionVictims.WithLabelValues(preemptor.Type()).Observe(numVictims)
 	} else {
 		metrics.PreemptionVictims.Observe(numVictims)
 	}

--- a/pkg/scheduler/framework/preemption/executor_test.go
+++ b/pkg/scheduler/framework/preemption/executor_test.go
@@ -303,7 +303,8 @@ func TestPrepareCandidate(t *testing.T) {
 				Containers([]v1.Container{st.MakeContainer().Name("container1").Obj()}).
 				Obj()
 
-		podGroupPreemptor = &schedulingv1beta1.PodGroup{ObjectMeta: metav1.ObjectMeta{Name: "pg1", Namespace: "default", UID: "pg1"}}
+		podGroupPreemptor          = &schedulingv1beta1.PodGroup{ObjectMeta: metav1.ObjectMeta{Name: "pg1", Namespace: "default", UID: "pg1"}}
+		compositePodGroupPreemptor = &schedulingv1alpha3.CompositePodGroup{ObjectMeta: metav1.ObjectMeta{Name: "cpg1", Namespace: "default", UID: "cpg1"}}
 
 		errDeletePodFailed   = errors.New("delete pod failed")
 		errPatchStatusFailed = errors.New("patch pod status failed")
@@ -401,7 +402,7 @@ func TestPrepareCandidate(t *testing.T) {
 				},
 			},
 			preemptor:                  preemptor,
-			preemptorCompositePodGroup: &schedulingv1alpha3.CompositePodGroup{ObjectMeta: metav1.ObjectMeta{Name: "cpg1", Namespace: "default", UID: "cpg1"}},
+			preemptorCompositePodGroup: compositePodGroupPreemptor,
 			testPods: []*v1.Pod{
 				victim1,
 			},
@@ -649,6 +650,28 @@ func TestPrepareCandidate(t *testing.T) {
 			expectedDeletedPod:    []string{"victim1"},
 			expectedStatus:        nil,
 			expectedPreemptingMap: sets.New(types.UID("pg1")),
+		},
+		{
+			name: "metrics: compositepodgroup preemptor with PDB violations and disruptions",
+			candidate: &candidate{
+				name: node1Name,
+				victims: &extenderv1.Victims{
+					Pods: []*v1.Pod{
+						victim1,
+					},
+					NumPDBViolations: 1,
+				},
+				numPodGroupDisruptions: 1,
+			},
+			preemptor:                  preemptor,
+			preemptorCompositePodGroup: compositePodGroupPreemptor,
+			testPods: []*v1.Pod{
+				victim1,
+			},
+			nodeNames:             []string{node1Name},
+			expectedDeletedPod:    []string{"victim1"},
+			expectedStatus:        nil,
+			expectedPreemptingMap: sets.New(types.UID("cpg1")),
 		},
 	}
 
@@ -1988,7 +2011,7 @@ type preemptionMetricsState struct {
 
 func capturePreemptionMetricsState(g componentmetrics.Gatherer, preemptorType string) preemptionMetricsState {
 	return preemptionMetricsState{
-		workloadPreemptionVictims: newHistogramState(g, "scheduler_workload_preemption_victims", map[string]string{}),
+		workloadPreemptionVictims: newHistogramState(g, "scheduler_workload_preemption_victims", map[string]string{"preemptor": preemptorType}),
 		preemptionVictims:         newHistogramState(g, "scheduler_preemption_victims", map[string]string{}),
 		workloadDisruptions:       newHistogramState(g, "scheduler_preemption_workload_disruptions", map[string]string{"preemptor": preemptorType}),
 		pdbViolations:             newCounterState(g, "scheduler_preemption_pdb_violations_total", map[string]string{}, "preemptor", preemptorType),

--- a/pkg/scheduler/framework/preemption/podgrouppreemption.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption.go
@@ -69,7 +69,7 @@ func NewPodGroupEvaluator(fh fwk.Handle, executor *Executor, fts feature.Feature
 func (ev *PodGroupEvaluator) evaluate(ctx context.Context, preemptor *podGroupPreemptor, domain *domain, podGroupSchedulingFunc fwk.PodGroupSchedulingFunc) (res *selectVictimsResult, status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.PreemptionEvaluationDuration.WithLabelValues("podgroup", status.Code().String()).Observe(metrics.SinceInSeconds(startTime))
+		metrics.PreemptionEvaluationDuration.WithLabelValues(preemptor.getType(), status.Code().String()).Observe(metrics.SinceInSeconds(startTime))
 	}()
 
 	pdbs, err := getPodDisruptionBudgets(ev.pdbLister)

--- a/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
@@ -1651,21 +1651,35 @@ func (pa *mockProposedAssignment) GetCycleState() fwk.CycleState {
 func TestPodGroupPreemptionEvaluationDurationMetric(t *testing.T) {
 	nodeName := "node1"
 	preemptorPod := st.MakePod().Name("p1").UID("p1").Obj()
-	preemptor := newPodGroupPreemptor(
-		newTestPodGroupInfo(st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(), nil, []*v1.Pod{preemptorPod}),
-		false,
-	)
 
 	tests := []struct {
 		name             string
+		isCPG            bool
+		wantPreemptor    string
 		evaluationStatus *fwk.Status
 	}{
 		{
-			name:             "scheduling success",
+			name:             "podgroup scheduling success",
+			isCPG:            false,
+			wantPreemptor:    "podgroup",
 			evaluationStatus: fwk.NewStatus(fwk.Success),
 		},
 		{
-			name:             "scheduling error",
+			name:             "compositepodgroup scheduling success",
+			isCPG:            true,
+			wantPreemptor:    "compositepodgroup",
+			evaluationStatus: fwk.NewStatus(fwk.Success),
+		},
+		{
+			name:             "podgroup scheduling error",
+			isCPG:            false,
+			wantPreemptor:    "podgroup",
+			evaluationStatus: fwk.NewStatus(fwk.Error, "failed to schedule"),
+		},
+		{
+			name:             "compositepodgroup scheduling error",
+			isCPG:            true,
+			wantPreemptor:    "compositepodgroup",
 			evaluationStatus: fwk.NewStatus(fwk.Error, "failed to schedule"),
 		},
 	}
@@ -1678,6 +1692,19 @@ func TestPodGroupPreemptionEvaluationDurationMetric(t *testing.T) {
 			logger, ctx := ktesting.NewTestContext(t)
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
+
+			var preemptor *podGroupPreemptor
+			if tt.isCPG {
+				preemptor = newPodGroupPreemptor(
+					newTestPodGroupInfo(nil, st.MakeCompositePodGroup().Name("preemptor-cpg").Priority(highPriority).Obj(), []*v1.Pod{preemptorPod}),
+					false,
+				)
+			} else {
+				preemptor = newPodGroupPreemptor(
+					newTestPodGroupInfo(st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(), nil, []*v1.Pod{preemptorPod}),
+					false,
+				)
+			}
 
 			node := st.MakeNode().Name(nodeName).Obj()
 			victimPod := st.MakePod().Name("p2").UID("p2").Node(nodeName).Priority(lowPriority).Obj()
@@ -1728,8 +1755,9 @@ func TestPodGroupPreemptionEvaluationDurationMetric(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
+
 			expectedStatus := tt.evaluationStatus.Code().String()
-			stateBefore := captureEvaluationDurationMetric(testRegistry, "podgroup", expectedStatus)
+			stateBefore := captureEvaluationDurationMetric(testRegistry, tt.wantPreemptor, expectedStatus)
 
 			if err := pl.Handle.MutableSnapshotSharedLister().StartMutations(); err != nil {
 				t.Fatalf("Unexpected error: %v", err)
@@ -1739,11 +1767,11 @@ func TestPodGroupPreemptionEvaluationDurationMetric(t *testing.T) {
 				t.Errorf("Unexpected error: %v", err)
 			}
 
-			stateAfter := captureEvaluationDurationMetric(testRegistry, "podgroup", expectedStatus)
+			stateAfter := captureEvaluationDurationMetric(testRegistry, tt.wantPreemptor, expectedStatus)
 
 			diff := stateAfter.count - stateBefore.count
 			if diff != 1 {
-				t.Errorf("Expected %s count delta to be 1, got %d", expectedStatus, diff)
+				t.Errorf("Expected %s count delta for %s to be 1, got %d", expectedStatus, tt.wantPreemptor, diff)
 			}
 		})
 	}

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -99,7 +99,7 @@ const (
 	QueueingHintResultError     = "Error"
 )
 
-// Entity label values used for queued_entities and queue_incoming_entities metrics.
+// Entity label values used for queued_entities, queue_incoming_entities, and preemption metrics.
 const (
 	Pod               = "pod"
 	PodGroup          = "podgroup"
@@ -203,7 +203,7 @@ var (
 	DRABindingConditionsPreBindDuration  *metrics.HistogramVec
 
 	WorkloadPreemptionAttempts    *metrics.CounterVec
-	WorkloadPreemptionVictims     *metrics.Histogram
+	WorkloadPreemptionVictims     *metrics.HistogramVec
 	PreemptionWorkloadDisruptions *metrics.HistogramVec
 	PreemptionEvaluationDuration  *metrics.HistogramVec
 	PreemptionExecutionDuration   *metrics.HistogramVec
@@ -622,18 +622,18 @@ func InitMetrics() {
 		&metrics.CounterOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "workload_preemption_attempts_total",
-			Help:           "Total preemption attempts initiated by workload (including pod groups) in the cluster till now.",
+			Help:           "Total preemption attempts initiated by workload (including pod groups and composite pod groups) in the cluster till now.",
 			StabilityLevel: metrics.ALPHA,
-		}, []string{"result"})
-	WorkloadPreemptionVictims = metrics.NewHistogram(
+		}, []string{"result", "preemptor"})
+	WorkloadPreemptionVictims = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
 			Subsystem: SchedulerSubsystem,
 			Name:      "workload_preemption_victims",
-			Help:      "Number of pod preemption victims caused by workload preemption.",
+			Help:      "Number of pod preemption victims caused by workload preemption (including pod groups and composite pod groups).",
 			// Start with 1 with the last bucket being [1024, Inf)
 			Buckets:        metrics.ExponentialBuckets(1, 2, 11),
 			StabilityLevel: metrics.ALPHA,
-		})
+		}, []string{"preemptor"})
 	PreemptionWorkloadDisruptions = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
 			Subsystem: SchedulerSubsystem,


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds `compositepodgroup` label support to workload preemption metrics in the scheduler so that preemption behavior can be observed separately for `PodGroup` and `CompositePodGroup` workloads.

#### Which issue(s) this PR is related to:

KEP: [KEP-6012](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/6012-composite-podgroup-api#readme)

#### Special notes for your reviewer:

Summary of changes by preemption metric
| Metric | Labels | Pre-PR Behavior | Changes in this PR |
| :--- | :--- | :--- | :--- |
| `workload_preemption_attempts_total` | `preemptor`, `result` | Only had `result` label | Added `preemptor` label (`podgroup` / `compositepodgroup`); recorded in `DefaultPreemption.PodGroupPostFilter` via `string(pgInfo.GetType())` |
| `workload_preemption_victims` | `preemptor` | Unlabeled `*metrics.Histogram` | Changed to `*metrics.HistogramVec` with `preemptor` label (`podgroup` / `compositepodgroup`); recorded in `PreemptionExecutor.PrepareCandidate` via `preemptor.Type()` |
| `preemption_evaluation_duration_seconds` | `preemptor`, `result` | Hardcoded `"podgroup"` in `PodGroupEvaluator.evaluate` | Updated `PodGroupEvaluator.evaluate` to record `preemptor.getType()` (`podgroup` / `compositepodgroup`) |
| `preemption_workload_disruptions` | `preemptor` | Already used `preemptor.Type()` | Verified existing dynamic recording; added unit test coverage for `compositepodgroup` preemptor in `TestPrepareCandidate` |
| `preemption_pdb_violations_total` | `preemptor` | Already used `preemptor.Type()` | Verified existing dynamic recording; added unit test coverage for `compositepodgroup` preemptor in `TestPrepareCandidate` |
| `preemption_execution_duration_seconds` | `preemptor`, `result` | Already used `preemptor.Type()` | Verified existing dynamic recording for `podgroup` and `compositepodgroup` |

/sig scheduling
/wg workload-aware-scheduling

#### Does this PR introduce a user-facing change?
```release-note
Added support to CompositePodGroup to preemption metrics. Changed alpha metric by adding `preemptor` label (`podgroup` or `compositepodgroup`) to `scheduler_workload_preemption_attempts_total` and `scheduler_workload_preemption_victims`, and updated `scheduler_preemption_evaluation_duration_seconds` to distinguish `compositepodgroup` preemptors.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

#### AI usage disclosure:

YES, AI assistance was used to update metric definitions, call sites, and unit tests.