### PR TITLE
chore: update TestEmulatedStorageVersion to use newer emulation version

### DIFF
--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -3162,8 +3162,9 @@ func TestDedupOwnerReferences(t *testing.T) {
 }
 
 func TestEmulatedStorageVersion(t *testing.T) {
-	validVap := &admissionregistrationv1.ValidatingAdmissionPolicy{
-		Spec: admissionregistrationv1.ValidatingAdmissionPolicySpec{
+	fail := admissionregistrationv1.Fail
+	validMap := &admissionregistrationv1.MutatingAdmissionPolicy{
+		Spec: admissionregistrationv1.MutatingAdmissionPolicySpec{
 			MatchConstraints: &admissionregistrationv1.MatchResources{
 				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
 					{
@@ -3179,10 +3180,14 @@ func TestEmulatedStorageVersion(t *testing.T) {
 					},
 				},
 			},
-			Validations: []admissionregistrationv1.Validation{
+			FailurePolicy:      &fail,
+			ReinvocationPolicy: admissionregistrationv1.NeverReinvocationPolicy,
+			Mutations: []admissionregistrationv1.Mutation{
 				{
-					Expression: "true",
-					Message:    "always valid",
+					PatchType: admissionregistrationv1.PatchTypeApplyConfiguration,
+					ApplyConfiguration: &admissionregistrationv1.ApplyConfiguration{
+						Expression: `Object{metadata: Object.metadata{annotations: {"foo": "bar"}}}`,
+					},
 				},
 			},
 		},
@@ -3197,28 +3202,28 @@ func TestEmulatedStorageVersion(t *testing.T) {
 	}
 	cases := []testCase{
 		{
-			name:            "vap after ga release",
-			emulatedVersion: "1.31",
+			name:            "map after ga release",
+			emulatedVersion: "1.37",
 			gvr: schema.GroupVersionResource{
 				Group:    "admissionregistration.k8s.io",
 				Version:  "v1beta1",
-				Resource: "validatingadmissionpolicies",
+				Resource: "mutatingadmissionpolicies",
 			},
-			object: validVap,
+			object: validMap,
 			expectedStorageVersion: schema.GroupVersion{
 				Group:   "admissionregistration.k8s.io",
 				Version: "v1",
 			},
 		},
 		{
-			name:            "vap before ga release",
-			emulatedVersion: "1.30",
+			name:            "map before ga release",
+			emulatedVersion: "1.36",
 			gvr: schema.GroupVersionResource{
 				Group:    "admissionregistration.k8s.io",
 				Version:  "v1beta1",
-				Resource: "validatingadmissionpolicies",
+				Resource: "mutatingadmissionpolicies",
 			},
-			object: validVap,
+			object: validMap,
 			expectedStorageVersion: schema.GroupVersion{
 				Group:   "admissionregistration.k8s.io",
 				Version: "v1beta1",
@@ -3547,10 +3552,10 @@ func TestAllowedEmulationVersions(t *testing.T) {
 }
 
 func TestEnableEmulationVersion(t *testing.T) {
-	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.33"))
+	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.38"))
 	server := kubeapiservertesting.StartTestServerOrDie(t,
-		&kubeapiservertesting.TestServerInstanceOptions{BinaryVersion: "1.33"},
-		[]string{"--emulated-version=kube=1.31", "--runtime-config=api/beta=true"}, framework.SharedEtcd())
+		&kubeapiservertesting.TestServerInstanceOptions{BinaryVersion: "1.38"},
+		[]string{"--emulated-version=kube=1.35", "--runtime-config=api/beta=true"}, framework.SharedEtcd())
 	defer server.TearDownFn()
 
 	rt, err := restclient.TransportFor(server.ClientConfig)
@@ -3575,11 +3580,15 @@ func TestEnableEmulationVersion(t *testing.T) {
 			expectedStatusCode: 200,
 		},
 		{
-			path:               "/apis/networking.k8s.io/v1beta1/servicecidrs", // introduced at 1.31, removed at 1.34
+			path:               "/apis/admissionregistration.k8s.io/v1beta1/mutatingadmissionpolicies", // introduced at 1.34, removed at 1.40
 			expectedStatusCode: 200,
 		},
 		{
-			path:               "/apis/networking.k8s.io/v1/servicecidrs", // introduced at 1.33
+			path:               "/apis/admissionregistration.k8s.io/v1/mutatingadmissionpolicies", // introduced at 1.36
+			expectedStatusCode: 404,
+		},
+		{
+			path:               "/apis/admissionregistration.k8s.io/v1/mutatingadmissionpolicybindings", // introduced at 1.36
 			expectedStatusCode: 404,
 		},
 	}
@@ -3605,10 +3614,10 @@ func TestEnableEmulationVersion(t *testing.T) {
 }
 
 func TestEnableEmulationVersionForwardCompatible(t *testing.T) {
-	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.33"))
+	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.38"))
 	server := kubeapiservertesting.StartTestServerOrDie(t,
-		&kubeapiservertesting.TestServerInstanceOptions{BinaryVersion: "1.33"},
-		[]string{"--emulated-version=kube=1.31", "--runtime-config=api/beta=true", "--emulation-forward-compatible=true"}, framework.SharedEtcd())
+		&kubeapiservertesting.TestServerInstanceOptions{BinaryVersion: "1.38"},
+		[]string{"--emulated-version=kube=1.35", "--runtime-config=api/beta=true", "--emulation-forward-compatible=true"}, framework.SharedEtcd())
 	defer server.TearDownFn()
 
 	rt, err := restclient.TransportFor(server.ClientConfig)
@@ -3633,11 +3642,15 @@ func TestEnableEmulationVersionForwardCompatible(t *testing.T) {
 			expectedStatusCode: 200,
 		},
 		{
-			path:               "/apis/networking.k8s.io/v1beta1/servicecidrs", // introduced at 1.31, removed at 1.34
+			path:               "/apis/admissionregistration.k8s.io/v1beta1/mutatingadmissionpolicies", // introduced at 1.34, removed at 1.40
 			expectedStatusCode: 200,
 		},
 		{
-			path:               "/apis/networking.k8s.io/v1/servicecidrs", // introduced at 1.33
+			path:               "/apis/admissionregistration.k8s.io/v1/mutatingadmissionpolicies", // introduced at 1.36
+			expectedStatusCode: 200,
+		},
+		{
+			path:               "/apis/admissionregistration.k8s.io/v1/mutatingadmissionpolicybindings", // introduced at 1.36
 			expectedStatusCode: 200,
 		},
 	}
@@ -3663,10 +3676,10 @@ func TestEnableEmulationVersionForwardCompatible(t *testing.T) {
 }
 
 func TestEnableRuntimeConfigEmulationVersionForwardCompatible(t *testing.T) {
-	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.33"))
+	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.38"))
 	server := kubeapiservertesting.StartTestServerOrDie(t,
-		&kubeapiservertesting.TestServerInstanceOptions{BinaryVersion: "1.33"},
-		[]string{"--emulated-version=kube=1.31", "--runtime-config-emulation-forward-compatible=true", "--runtime-config=api/beta=true,networking.k8s.io/v1=true"}, framework.SharedEtcd())
+		&kubeapiservertesting.TestServerInstanceOptions{BinaryVersion: "1.38"},
+		[]string{"--emulated-version=kube=1.35", "--runtime-config-emulation-forward-compatible=true", "--runtime-config=api/beta=true,admissionregistration.k8s.io/v1/mutatingadmissionpolicies=true"}, framework.SharedEtcd())
 	defer server.TearDownFn()
 
 	rt, err := restclient.TransportFor(server.ClientConfig)
@@ -3691,12 +3704,16 @@ func TestEnableRuntimeConfigEmulationVersionForwardCompatible(t *testing.T) {
 			expectedStatusCode: 200,
 		},
 		{
-			path:               "/apis/networking.k8s.io/v1beta1/servicecidrs", // introduced at 1.31, removed at 1.34
+			path:               "/apis/admissionregistration.k8s.io/v1beta1/mutatingadmissionpolicies", // introduced at 1.34, removed at 1.40
 			expectedStatusCode: 200,
 		},
 		{
-			path:               "/apis/networking.k8s.io/v1/servicecidrs", // introduced at 1.33
+			path:               "/apis/admissionregistration.k8s.io/v1/mutatingadmissionpolicies", // introduced at 1.36
 			expectedStatusCode: 200,
+		},
+		{
+			path:               "/apis/admissionregistration.k8s.io/v1/mutatingadmissionpolicybindings", // introduced at 1.36, not in --runtime-config
+			expectedStatusCode: 404,
 		},
 	}
 
@@ -3721,10 +3738,10 @@ func TestEnableRuntimeConfigEmulationVersionForwardCompatible(t *testing.T) {
 }
 
 func TestDisableEmulationVersion(t *testing.T) {
-	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.34"))
+	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.40"))
 	server := kubeapiservertesting.StartTestServerOrDie(t,
-		&kubeapiservertesting.TestServerInstanceOptions{BinaryVersion: "1.34"},
-		[]string{}, framework.SharedEtcd())
+		&kubeapiservertesting.TestServerInstanceOptions{BinaryVersion: "1.40"},
+		[]string{"--runtime-config=api/beta=true"}, framework.SharedEtcd())
 	defer server.TearDownFn()
 
 	rt, err := restclient.TransportFor(server.ClientConfig)
@@ -3745,12 +3762,20 @@ func TestDisableEmulationVersion(t *testing.T) {
 			expectedStatusCode: 200,
 		},
 		{
-			path:               "/apis/networking.k8s.io/v1/servicecidrs",
+			path:               "/apis/flowcontrol.apiserver.k8s.io/v1/flowschemas",
 			expectedStatusCode: 200,
 		},
 		{
-			path:               "/apis/networking.k8s.io/v1beta1/servicecidrs", // introduced at 1.31, removed at 1.34
+			path:               "/apis/admissionregistration.k8s.io/v1beta1/mutatingadmissionpolicies", // introduced at 1.34, removed at 1.40
 			expectedStatusCode: 404,
+		},
+		{
+			path:               "/apis/admissionregistration.k8s.io/v1/mutatingadmissionpolicies", // introduced at 1.36
+			expectedStatusCode: 200,
+		},
+		{
+			path:               "/apis/admissionregistration.k8s.io/v1/mutatingadmissionpolicybindings", // introduced at 1.36
+			expectedStatusCode: 200,
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

`TestEmulatedStorageVersion` is testing a very old emulation version, and will break on some feature removals, like https://github.com/kubernetes/kubernetes/pull/141762

This PR is updating a test to use a newer api to test a newer emulation version.

Eventually we will need to add a test api to test emulation version with. 

#### Which issue(s) this PR is related to:
buys more time for https://github.com/kubernetes/kubernetes/issues/129311

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:
YES, AI is used to update and verify the test.

