### PR TITLE
resource: clear the cached string when unmarshalling null

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -777,8 +777,7 @@ func (q Quantity) ToUnstructured() interface{} {
 func (q *Quantity) UnmarshalJSON(value []byte) error {
 	l := len(value)
 	if l == 4 && bytes.Equal(value, []byte("null")) {
-		q.d.Dec = nil
-		q.i = int64Amount{}
+		q.Set(0)
 		return nil
 	}
 	if l >= 2 && value[0] == '"' && value[l-1] == '"' {
@@ -802,8 +801,7 @@ func (q *Quantity) UnmarshalCBOR(value []byte) error {
 	}
 
 	if s == nil {
-		q.d.Dec = nil
-		q.i = int64Amount{}
+		q.Set(0)
 		return nil
 	}
 

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_null_cache_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_null_cache_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// TestQuantityNullDecodeClearsCachedSerialization verifies that decoding null invalidates
+// the cached string, which both null branches used to leave in place.
+func TestQuantityNullDecodeClearsCachedSerialization(t *testing.T) {
+	decoders := []struct {
+		name   string
+		decode func(*Quantity) error
+	}{
+		{"json", func(q *Quantity) error { return json.Unmarshal([]byte("null"), q) }},
+		{"cbor", func(q *Quantity) error { return q.UnmarshalCBOR([]byte{0xf6}) }},
+	}
+	for _, value := range []string{"1", "1Ki", "1.5Gi", "1e6", "0"} {
+		for _, decoder := range decoders {
+			for _, dec := range []bool{false, true} {
+				name := decoder.name + "/" + value
+				if dec {
+					name += "/dec"
+				}
+				t.Run(name, func(t *testing.T) {
+					q := MustParse(value)
+					if dec {
+						q.ToDec()
+					}
+					format := q.Format
+					_ = q.String() // populate the cache the decoder has to invalidate
+
+					if err := decoder.decode(&q); err != nil {
+						t.Fatal(err)
+					}
+					if !q.IsZero() || q.Sign() != 0 || q.Value() != 0 {
+						t.Errorf("null decode left %v, want zero", q.Value())
+					}
+					if q.Format != format {
+						t.Errorf("format = %q, want %q", q.Format, format)
+					}
+					// MarshalJSON copies q.s when it is set; the others go through
+					// String(), which only recomputes an empty cache, never a stale one.
+					if encoded, err := json.Marshal(q); err != nil {
+						t.Fatal(err)
+					} else if string(encoded) != `"0"` {
+						t.Errorf("json = %s, want \"0\"", encoded)
+					}
+					// The codec's own output for "0", so the encoding form is not pinned.
+					wantCBOR, err := MustParse("0").MarshalCBOR()
+					if err != nil {
+						t.Fatal(err)
+					}
+					if encoded, err := q.MarshalCBOR(); err != nil {
+						t.Fatal(err)
+					} else if !bytes.Equal(encoded, wantCBOR) {
+						t.Errorf("cbor = %x, want %x", encoded, wantCBOR)
+					}
+					if got := q.ToUnstructured(); got != "0" {
+						t.Errorf("unstructured = %#v, want \"0\"", got)
+					}
+					if got := q.String(); got != "0" {
+						t.Errorf("String = %q, want \"0\"", got)
+					}
+					if err := decoder.decode(&q); err != nil {
+						t.Fatal(err)
+					}
+					if got := q.String(); got != "0" {
+						t.Errorf("second null decode = %q, want \"0\"", got)
+					}
+				})
+			}
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig api-machinery

#### What this PR does / why we need it:

Both null branches of the `Quantity` decoders reset the numeric fields and leave the cached string alone:

```go
	if l == 4 && bytes.Equal(value, []byte("null")) {
		q.d.Dec = nil
		q.i = int64Amount{}
		return nil
	}
```

`q.s` is the cached result of `String()`. A receiver that has already been printed reads as zero after this and keeps serializing what it held before:

```go
q := resource.MustParse("1Ki")
_ = q.String()
json.Unmarshal([]byte("null"), &q)
// q.Value() is 0, q.String() is "1Ki"
```

`MarshalJSON` copies `q.s` straight out when it holds something, and `MarshalCBOR` and `ToUnstructured` call `String()`, so the old text comes back out of all three. Decoding `{"limit":"1Ki"}` and then `{"limit":null}` into the same struct marshals back to `{"limit":"1Ki"}`. `DeepCopy` carries the stale cache with it. `UnmarshalCBOR` has the same branch.

`Set(0)` does the same reset and clears the cache. It delegates to `SetScaled(0, 0)`, which leaves `Format` alone, so null still decodes to zero in the format the receiver already had.

The non-null path replaces the receiver wholesale with `*q = parsed`, so these two branches are the only ones that write the numeric fields and leave `q.s` holding a value that no longer matches. `ToDec` and `AsDec` also write those fields without touching `q.s`, but they change the representation rather than the value, and the canonical string comes out the same on both backends, so the cached text stays correct there.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

There is one null case in the package tests today, in `TestQuantityUnmarshalCBOR`, and it decodes into a fresh receiver that has no cache to invalidate. `TestJSONWhitespace` reuses one receiver across its table and calls `String()` each round, which is the shape that reaches this, but it has no null row. Adding a null row after its `10` row makes `String()` return `"10"` while `Value()` is 0. The new test prints the receiver before decoding for the same reason.

It reads all four outputs on that receiver. `String()` only recomputes when the cache is empty, so it does not repair a stale one, and the order the four are read in does not change what any of them returns.

`Value()`, `Sign()` and `IsZero()` already answer zero on master, so what null decodes to is unchanged. #139712 is about a different null, whether a `ResourceList` drops entries whose value is null.

I have left the parse path and the `String()` cache itself alone.

#### Does this PR introduce a user-facing change?

```release-note
Decoding a JSON or CBOR null into a `resource.Quantity` that had already been serialized left its cached text in place, so the quantity read as zero while `String`, JSON, CBOR and unstructured conversion kept returning the previous value. The cached text is now cleared with the rest of the value.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

YES. AI-assisted tools were used during implementation, test planning, and review; I reviewed and validated the final change.



