### PR TITLE
kubeadm: match the service and runlevel columns for OpenRC enablement

### DIFF
--- a/cmd/kubeadm/app/util/initsystem/initsystem_unix.go
+++ b/cmd/kubeadm/app/util/initsystem/initsystem_unix.go
@@ -21,6 +21,7 @@ package initsystem
 import (
 	"fmt"
 	"os/exec"
+	"slices"
 	"strings"
 
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/errors"
@@ -60,8 +61,28 @@ func (openrc OpenRCInitSystem) ServiceExists(service string) bool {
 // ServiceIsEnabled ensures the service is enabled to start on each boot.
 func (openrc OpenRCInitSystem) ServiceIsEnabled(service string) bool {
 	args := []string{"show", "default"}
-	outBytes, _ := exec.Command("rc-update", args...).Output()
-	return strings.Contains(string(outBytes), service)
+	outBytes, err := exec.Command("rc-update", args...).Output()
+	if err != nil {
+		return false
+	}
+	return openrcServiceIsEnabled(string(outBytes), service)
+}
+
+// openrcServiceIsEnabled reports whether the listing printed by "rc-update show default"
+// has the service in the default runlevel.
+func openrcServiceIsEnabled(listing, service string) bool {
+	// rc-update prints one "<service> | <runlevels>" line per listed service, and with
+	// verbose output on it lists services in no runlevel. Hence, we compare both columns.
+	for line := range strings.SplitSeq(listing, "\n") {
+		name, runlevels, found := strings.CutLast(line, "|")
+		if !found || strings.TrimSpace(name) != service {
+			continue
+		}
+		if slices.Contains(strings.Fields(runlevels), "default") {
+			return true
+		}
+	}
+	return false
 }
 
 // ServiceIsActive ensures the service is running, or attempting to run. (crash looping in the case of kubelet)

--- a/cmd/kubeadm/app/util/initsystem/initsystem_unix_test.go
+++ b/cmd/kubeadm/app/util/initsystem/initsystem_unix_test.go
@@ -1,0 +1,115 @@
+//go:build !windows
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initsystem
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// row renders one line the way rc-update does: the service in a padded column, then
+// " %s" per runlevel, blanked when it is not in one.
+func row(service string, runlevels ...string) string {
+	out := fmt.Sprintf(" %20s |", service)
+	for _, runlevel := range runlevels {
+		out += " " + runlevel
+	}
+	return out + "\n"
+}
+
+func TestOpenrcServiceIsEnabled(t *testing.T) {
+	// What verbose output prints for a service that is in no runlevel.
+	blank := strings.Repeat(" ", len("default"))
+
+	tests := []struct {
+		name    string
+		service string // what to ask about, "kubelet" when empty
+		listing string // what "rc-update show default" printed
+		want    bool
+	}{
+		{
+			name:    "listed in the default runlevel",
+			listing: row("kubelet", "default"),
+			want:    true,
+		},
+		{
+			name:    "another service whose name starts with the same text",
+			listing: row("kubelet-debug", "default"),
+		},
+		{
+			name:    "another service whose name ends with the same text",
+			listing: row("my-kubelet", "default"),
+		},
+		{
+			name:    "listed among other services",
+			listing: row("kubelet-debug", "default") + row("kubelet", "default"),
+			want:    true,
+		},
+		{
+			name:    "a service other than kubelet",
+			service: "containerd",
+			listing: row("containerd", "default"),
+			want:    true,
+		},
+		{
+			name:    "listed with the runlevel column blanked",
+			listing: row("kubelet", blank),
+		},
+		{
+			name:    "listed with a different runlevel",
+			listing: row("kubelet", "boot"),
+		},
+		{
+			name:    "a name containing the column separator",
+			listing: row("kubelet|debug", "default"),
+		},
+		{
+			// The reverse of the case above: kubelet|debug asking about itself.
+			name:    "the name asked about contains the separator",
+			service: "kubelet|debug",
+			listing: row("kubelet|debug", "default"),
+			want:    true,
+		},
+		{
+			name:    "test with a wider column",
+			listing: fmt.Sprintf(" %26s | default\n", "kubelet"),
+			want:    true,
+		},
+		{
+			name:    "a line without a separator",
+			listing: "kubelet\n",
+		},
+		{
+			name:    "nothing in the default runlevel",
+			listing: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			service := tc.service
+			if service == "" {
+				service = "kubelet"
+			}
+			if got := openrcServiceIsEnabled(tc.listing, service); got != tc.want {
+				t.Errorf("openrcServiceIsEnabled(%q) = %v, want %v", service, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

[`ServiceIsEnabled`](https://github.com/kubernetes/kubernetes/blob/b1856e29a9c992113d5db00096082ddcc3a55d8a/cmd/kubeadm/app/util/initsystem/initsystem_unix.go#L60-L65) searches the whole output of `rc-update show default` for the service name, so another listed service whose name contains it answers for it.

```go
outBytes, _ := exec.Command("rc-update", args...).Output()
return strings.Contains(string(outBytes), service)
```

With `kubelet-debug` or `my-kubelet` in the default runlevel and `kubelet` not added to it, the call returns true for `kubelet`. Preflight [checks that service](https://github.com/kubernetes/kubernetes/blob/b1856e29a9c992113d5db00096082ddcc3a55d8a/cmd/kubeadm/app/preflight/checks.go#L1160), so the operator never gets the `kubelet service is not enabled, please run 'rc-update add kubelet default'` warning.

A name collision is not the only way to reach that answer. Whether `rc-update` lists a service that is in none of the requested runlevels comes from the environment rather than from its arguments:

```c
verbose = rc_yesno(getenv ("EINFO_VERBOSE"));
```

and that flag is what decides whether the row is printed at all:

```c
if (inone || verbose) {
	printf(" %26s |", service->value);
```

OpenRC exports `EINFO_VERBOSE=yes` when `rc_verbose` is enabled in `/etc/rc.conf`, so a kubeadm run that inherits it gets every known service listed, with the runlevel column blanked for the ones outside default. The substring search then answers true for anything installed.

The call drops the error as well, so if `rc-update` fails partway through, whatever it printed first is still searched.

`rc-update` prints `<service> | <runlevels>` per line, and this compares the two columns instead of the whole listing. It cuts at the last `|` so a service name containing one is not cut short, then looks for `default` among the fields on the right. `rc-update show` always exits 0, so a non-zero status means the command itself failed and there is nothing worth reading.

The parsing lives in `openrcServiceIsEnabled`, which takes the listing as a string, so the test drives it directly rather than putting a fake `rc-update` on `PATH`. The package had no test file. This adds one with twelve cases: the plain enabled service, the two name collisions above, a listing holding more than one service, a service other than `kubelet`, a blanked runlevel column, a different runlevel, a listed name containing the separator, the same name being the one asked about, the wider column, a line with no separator, and an empty listing. The fixtures come from a helper that reproduces the `printf` above rather than hand-counted padding, which I checked by diffing its output against the C. The padding width is not fixed, so the helper prints one width and one case carries a wider one.

Putting each piece of the old behavior back makes named cases fail. `strings.Contains` fails six of the twelve, cutting at the first `|` fails the two separator cases, skipping the runlevel column fails the two runlevel cases, dropping `TrimSpace` fails five, and comparing against a hard-coded `kubelet` rather than the argument fails the two cases that ask about something else.

The three lines that run `rc-update` and drop out on a non-zero status are not covered, since driving them would need the fake binary this test deliberately does not use.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Only `ServiceIsEnabled` changes. `ServiceExists` and `ServiceIsActive` ignore their exit status on purpose, since `rc-service status` reports a stopped or missing service that way and writes it to stderr, which is what the comment above `ServiceExists` is about; #86508 is why `ServiceIsActive` reads the combined output. systemd and Windows are untouched.

A node where `kubelet` really is in the default runlevel keeps getting true. What changes is the node that was getting a false positive and now sees the warning it should have been seeing.

I do not have an OpenRC machine to hand, so the output shapes come from [`show()`](https://github.com/OpenRC/openrc/blob/e877fe9f5d6ce238862516ce84a405a12fd721a2/src/rc-update/rc-update.c#L161-L205) rather than from a capture. The `boot` case is there to pin the column comparison; `show default` itself only ever prints `default` or blanks in that column.

#### Does this PR introduce a user-facing change?

```release-note
kubeadm: fixed a preflight check on OpenRC systems that reported a service as enabled whenever `rc-update show default` mentioned its name anywhere, including as part of another service's name.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

YES. Drafted with an AI coding assistant, measured and reviewed by the author.

/sig cluster-lifecycle
/area kubeadm
/cc @neolit123



