### PR TITLE
[PodLevelResources] Fix Pod resize CPU/memory keys drops from PodStatus.Resources depending on resize dimension

### DIFF
--- a/pkg/kubelet/kubelet_pod_level_resources_status_test.go
+++ b/pkg/kubelet/kubelet_pod_level_resources_status_test.go
@@ -107,3 +107,113 @@ func TestConvertToAPIPodLevelResourcesStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertToAPIPodLevelResourcesStatus_ResourceKeysPresent(t *testing.T) {
+	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+		features.PodLevelResources:                       true,
+		features.InPlacePodLevelResourcesVerticalScaling: true,
+	})
+
+	// This test verifies that PodStatus.Resources always contains CPU and memory
+	// for both requests and limits after an in-place resize, even when the
+	// cgroup readback is unavailable and old status was truncated. This
+	// reproduces the disappearing-keys bug where a CPU-only resize left
+	// limits.cpu missing, and a memory-only resize left cpu missing entirely.
+	testCases := []struct {
+		name         string
+		allocatedPod *v1.Pod
+		oldStatus    v1.PodStatus
+		expectCPUReq string
+		expectMemReq string
+		expectCPULim string
+		expectMemLim string
+	}{
+		{
+			name: "CPU-only resize retains memory and CPU limits",
+			allocatedPod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name: "c1",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("20m"), v1.ResourceMemory: resource.MustParse("100Mi")},
+							Limits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("20m"), v1.ResourceMemory: resource.MustParse("100Mi")},
+						},
+					}},
+				},
+				Status: v1.PodStatus{Phase: v1.PodRunning},
+			},
+			oldStatus: v1.PodStatus{
+				Phase: v1.PodRunning,
+				Resources: &v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("10m"), v1.ResourceMemory: resource.MustParse("100Mi")},
+					Limits:   v1.ResourceList{v1.ResourceMemory: resource.MustParse("100Mi")}, // missing cpu limit (previous bug)
+				},
+			},
+			expectCPUReq: "20m", expectMemReq: "100Mi", expectCPULim: "20m", expectMemLim: "100Mi",
+		},
+		{
+			name: "Memory-only resize retains CPU in requests and limits",
+			allocatedPod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name: "c1",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("10m"), v1.ResourceMemory: resource.MustParse("200Mi")},
+							Limits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("10m"), v1.ResourceMemory: resource.MustParse("200Mi")},
+						},
+					}},
+				},
+				Status: v1.PodStatus{Phase: v1.PodRunning},
+			},
+			oldStatus: v1.PodStatus{
+				Phase: v1.PodRunning,
+				Resources: &v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceMemory: resource.MustParse("100Mi")}, // missing cpu
+					Limits:   v1.ResourceList{v1.ResourceMemory: resource.MustParse("100Mi")},
+				},
+			},
+			expectCPUReq: "10m", expectMemReq: "200Mi", expectCPULim: "10m", expectMemLim: "200Mi",
+		},
+		{
+			name: "Pod-level resources present after CPU resize",
+			allocatedPod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("300m"), v1.ResourceMemory: resource.MustParse("300Mi")},
+						Limits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("500m"), v1.ResourceMemory: resource.MustParse("500Mi")},
+					},
+					Containers: []v1.Container{{
+						Name: "c1",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("50m"), v1.ResourceMemory: resource.MustParse("50Mi")},
+							Limits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("50m"), v1.ResourceMemory: resource.MustParse("50Mi")},
+						},
+					}},
+				},
+				Status: v1.PodStatus{Phase: v1.PodRunning},
+			},
+			oldStatus:    v1.PodStatus{Phase: v1.PodRunning, Resources: &v1.ResourceRequirements{}},
+			expectCPUReq: "300m", expectMemReq: "300Mi", expectCPULim: "500m", expectMemLim: "500Mi",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+			// Simulate cgroup not yet updated: both CPU and memory return nil,
+			// forcing the fallback/preserve path that previously dropped keys.
+			mockPCM := cmtesting.NewMockPodContainerManager(t)
+			mockPCM.EXPECT().GetPodCgroupConfig(tc.allocatedPod, v1.ResourceMemory).Return(nil, nil)
+			mockPCM.EXPECT().GetPodCgroupConfig(tc.allocatedPod, v1.ResourceCPU).Return(nil, nil)
+			mockCM := cmtesting.NewMockContainerManager(t)
+			mockCM.EXPECT().NewPodContainerManager().Return(mockPCM)
+			kl := &Kubelet{containerManager: mockCM}
+			got := kl.convertToAPIPodLevelResourcesStatus(logger, tc.allocatedPod, tc.oldStatus)
+			require.NotNil(t, got)
+			require.Equal(t, tc.expectCPUReq, got.Requests.Cpu().String())
+			require.Equal(t, tc.expectMemReq, got.Requests.Memory().String())
+			require.Equal(t, tc.expectCPULim, got.Limits.Cpu().String())
+			require.Equal(t, tc.expectMemLim, got.Limits.Memory().String())
+		})
+	}
+}

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2301,22 +2301,65 @@ func (kl *Kubelet) convertToAPIPodLevelResourcesStatus(logger klog.Logger, alloc
 		}
 	}
 
+	// Ensure CPU request is not lost when cgroup value is unavailable and old
+	// status was already truncated. This mirrors the memory request fallback
+	// above and prevents state-dependent propagation of missing keys when only
+	// memory is resized.
+	if _, found := resources.Requests[v1.ResourceCPU]; !found {
+		opts := resourcehelper.PodResourcesOptions{
+			SkipPodLevelResources:                    !utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources),
+			UseDRANodeAllocatableResourceClaimStatus: utilfeature.DefaultFeatureGate.Enabled(features.DRANodeAllocatableResources),
+		}
+		aggregatedResources := resourcehelper.PodRequests(allocatedPod, opts)
+		if val, ok := aggregatedResources[v1.ResourceCPU]; ok {
+			resources.Requests[v1.ResourceCPU] = val
+		}
+	}
+
 	if cpuLimit != nil {
 		// If both the allocated & actual resources are at
 		// or below the minimum effective limit, preserve the
 		// allocated value in the API to avoid confusion and simplify comparisons.
 		if cpuLimit.MilliValue() > cm.MinMilliCPULimit || resources.Limits.Cpu().MilliValue() > cm.MinMilliCPULimit {
 			resources.Limits[v1.ResourceCPU] = cpuLimit.DeepCopy()
+		} else {
+			preserveOldResourcesValue(v1.ResourceCPU, oldPodStatus.Resources.Limits, resources.Limits)
 		}
 	} else {
 		preserveOldResourcesValue(v1.ResourceCPU, oldPodStatus.Resources.Limits, resources.Limits)
 
 	}
 
+	// Fallback for CPU limit when cgroup and old status are both missing.
+	// Without this, a CPU-only resize can leave limits.cpu empty, and the
+	// missing key then propagates via preserveOld on the next resize.
+	if _, found := resources.Limits[v1.ResourceCPU]; !found {
+		opts := resourcehelper.PodResourcesOptions{
+			SkipPodLevelResources:                    !utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources),
+			UseDRANodeAllocatableResourceClaimStatus: utilfeature.DefaultFeatureGate.Enabled(features.DRANodeAllocatableResources),
+		}
+		aggregatedLimits := resourcehelper.PodLimits(allocatedPod, opts)
+		if val, ok := aggregatedLimits[v1.ResourceCPU]; ok {
+			resources.Limits[v1.ResourceCPU] = val
+		}
+	}
+
 	if memoryLimit != nil {
 		resources.Limits[v1.ResourceMemory] = memoryLimit.DeepCopy()
 	} else {
 		preserveOldResourcesValue(v1.ResourceMemory, oldPodStatus.Resources.Limits, resources.Limits)
+	}
+
+	// Ensure memory limit is not lost when cgroup is unavailable.
+	if _, found := resources.Limits[v1.ResourceMemory]; !found {
+		opts := resourcehelper.PodResourcesOptions{
+			SkipPodLevelResources:                    !utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources),
+			UseDRANodeAllocatableResourceClaimStatus: utilfeature.DefaultFeatureGate.Enabled(features.DRANodeAllocatableResources),
+		}
+		aggregatedLimits := resourcehelper.PodLimits(allocatedPod, opts)
+		if val, ok := aggregatedLimits[v1.ResourceMemory]; ok {
+			resources.Limits[v1.ResourceMemory] = val
+		}
 	}
 
 	return resources


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig node
/area kubelet

**What this PR does / why we need it:**

When you resize a running pod in-place (e.g., `kubectl patch pod --subresource resize`), Kubernetes updates the cgroup and reports the new resources in `status.allocatedResources` and `status.containerStatuses` correctly. 

However, `status.resources` (the pod-level summary) was sometimes **missing keys** depending on *what* you resized:

* If you changed **only CPU** (`10m/100Mi → 20m/100Mi`), `status.resources.limits` lost `cpu` and showed only `memory`.
* If you changed **only memory** (`100Mi → 200Mi`), `status.resources` lost `cpu` entirely.

This was confusing — the resize actually worked, but `kubectl get pod -o yaml` showed incomplete pod-level resources. The bug was also **stateful**: once `cpu` disappeared, it stayed missing until you resized both CPU and memory together, which made it hard to debug.

**Which issue(s) this PR is related to:**

Fixes #141814

**Does this PR introduce a user-facing change?:**
```release-note
Fixed kubelet PodStatus.Resources to always report CPU and memory for both requests and limits after in-place pod resize, instead of dropping keys depending on which dimension was resized.
```