### PR TITLE
Regenerate Pod Security test fixtures for v1.38

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/test/run.go
+++ b/staging/src/k8s.io/pod-security-admission/test/run.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	newestMinorVersionToTest            = 37
+	newestMinorVersionToTest            = 38
 	podOSBasedRestrictionEnabledVersion = 29
 )
 

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/capabilities_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/capabilities_baseline0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - NET_RAW
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/capabilities_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/capabilities_baseline1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities:
+        add:
+        - NET_RAW
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/capabilities_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/capabilities_baseline2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - chown
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/capabilities_baseline3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/capabilities_baseline3.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - CAP_CHOWN
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostpathvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostpathvolumes0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  volumes:
+  - emptyDir: {}
+    name: volume-emptydir
+  - hostPath:
+      path: /a
+    name: volume-hostpath

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostpathvolumes1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostpathvolumes1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  volumes:
+  - hostPath:
+      path: /a
+    name: volume-hostpath-a
+  - hostPath:
+      path: /b
+    name: volume-hostpath-b

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostprobesandhostlifecycle0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostprobesandhostlifecycle0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    livenessProbe:
+      httpGet:
+        host: bad.host
+        port: 8080
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostprobesandhostlifecycle1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostprobesandhostlifecycle1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    readinessProbe:
+      tcpSocket:
+        host: 8.8.8.8
+        port: 8080
+    restartPolicy: Always

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostprobesandhostlifecycle2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostprobesandhostlifecycle2.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    lifecycle:
+      postStart:
+        httpGet:
+          host: bad.host
+          port: 8080
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostprobesandhostlifecycle3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostprobesandhostlifecycle3.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    livenessProbe:
+      httpGet:
+        host: 127.0.0.1
+        port: 8080
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostprobesandhostlifecycle4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/hostprobesandhostlifecycle4.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle4
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    readinessProbe:
+      tcpSocket:
+        host: ::1
+        port: 8080
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/privileged0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      privileged: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/privileged1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/privileged1.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      privileged: true
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/procmount0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      procMount: Unmasked
+  hostUsers: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/procmount1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext: {}
+  hostUsers: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      procMount: Unmasked
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/seccompprofile_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/seccompprofile_baseline0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext:
+    seccompProfile:
+      type: Unconfined

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/seccompprofile_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/seccompprofile_baseline1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seccompProfile:
+        type: Unconfined
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/seccompprofile_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/seccompprofile_baseline2.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seccompProfile:
+        type: Unconfined
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/selinuxoptions0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions:
+      type: somevalue

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/selinuxoptions1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions:
+        type: somevalue
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/selinuxoptions2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/selinuxoptions2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions:
+        type: somevalue
+  securityContext:
+    seLinuxOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/selinuxoptions3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/selinuxoptions3.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions:
+      user: somevalue

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/selinuxoptions4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/selinuxoptions4.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions4
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions:
+      role: somevalue

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/sysctls0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  securityContext:
+    sysctls:
+    - name: othersysctl
+      value: other

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/windowshostprocess0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/windowshostprocess0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      windowsOptions: {}
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      windowsOptions: {}
+  securityContext:
+    windowsOptions:
+      hostProcess: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/windowshostprocess1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/fail/windowshostprocess1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      windowsOptions:
+        hostProcess: true
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      windowsOptions:
+        hostProcess: true
+  securityContext:
+    windowsOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/base.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/base.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/capabilities_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/capabilities_baseline0.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/hostprobesandhostlifecycle0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/hostprobesandhostlifecycle0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/hostprobesandhostlifecycle1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/hostprobesandhostlifecycle1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    livenessProbe:
+      httpGet:
+        port: 8080
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/hostprobesandhostlifecycle2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/hostprobesandhostlifecycle2.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/privileged0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      privileged: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      privileged: false
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/procmount0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      procMount: Default
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      procMount: Default
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/procmount1.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      procMount: Unmasked
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      procMount: Unmasked
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/seccompprofile_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/seccompprofile_baseline0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/selinuxoptions0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/selinuxoptions1.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions:
+        level: somevalue
+        type: container_init_t
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions:
+        type: container_kvm_t
+  securityContext:
+    seLinuxOptions:
+      type: container_t

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/sysctls0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.38/pass/sysctls1.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  securityContext:
+    sysctls:
+    - name: net.ipv4.tcp_slow_start_after_idle
+      value: "0"
+    - name: net.ipv4.tcp_notsent_lowat
+      value: "16384"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/allowprivilegeescalation0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/allowprivilegeescalation0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/allowprivilegeescalation1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/allowprivilegeescalation1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/allowprivilegeescalation2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/allowprivilegeescalation2.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/allowprivilegeescalation3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/allowprivilegeescalation3.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/apparmorprofile0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/apparmorprofile1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/capabilities_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/capabilities_baseline0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_RAW
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/capabilities_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/capabilities_baseline1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_RAW
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/capabilities_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/capabilities_baseline2.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - chown
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/capabilities_baseline3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/capabilities_baseline3.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - CAP_CHOWN
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/capabilities_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/capabilities_restricted0.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/capabilities_restricted1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/capabilities_restricted1.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities: {}
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/capabilities_restricted2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/capabilities_restricted2.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - SYS_TIME
+        - SYS_MODULE
+        - SYS_RAWIO
+        - SYS_PACCT
+        - SYS_ADMIN
+        - SYS_NICE
+        - SYS_RESOURCE
+        - SYS_TIME
+        - SYS_TTY_CONFIG
+        - MKNOD
+        - AUDIT_WRITE
+        - AUDIT_CONTROL
+        - MAC_OVERRIDE
+        - MAC_ADMIN
+        - NET_ADMIN
+        - SYSLOG
+        - CHOWN
+        - NET_RAW
+        - DAC_OVERRIDE
+        - FOWNER
+        - DAC_READ_SEARCH
+        - FSETID
+        - KILL
+        - SETGID
+        - SETUID
+        - LINUX_IMMUTABLE
+        - NET_BIND_SERVICE
+        - NET_BROADCAST
+        - IPC_LOCK
+        - IPC_OWNER
+        - SYS_CHROOT
+        - SYS_PTRACE
+        - SYS_BOOT
+        - LEASE
+        - SETFCAP
+        - WAKE_ALARM
+        - BLOCK_SUSPEND
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - SYS_TIME
+        - SYS_MODULE
+        - SYS_RAWIO
+        - SYS_PACCT
+        - SYS_ADMIN
+        - SYS_NICE
+        - SYS_RESOURCE
+        - SYS_TIME
+        - SYS_TTY_CONFIG
+        - MKNOD
+        - AUDIT_WRITE
+        - AUDIT_CONTROL
+        - MAC_OVERRIDE
+        - MAC_ADMIN
+        - NET_ADMIN
+        - SYSLOG
+        - CHOWN
+        - NET_RAW
+        - DAC_OVERRIDE
+        - FOWNER
+        - DAC_READ_SEARCH
+        - FSETID
+        - KILL
+        - SETGID
+        - SETUID
+        - LINUX_IMMUTABLE
+        - NET_BIND_SERVICE
+        - NET_BROADCAST
+        - IPC_LOCK
+        - IPC_OWNER
+        - SYS_CHROOT
+        - SYS_PTRACE
+        - SYS_BOOT
+        - LEASE
+        - SETFCAP
+        - WAKE_ALARM
+        - BLOCK_SUSPEND
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/capabilities_restricted3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/capabilities_restricted3.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostnamespaces0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostIPC: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostnamespaces1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostnamespaces2.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostPID: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostpathvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostpathvolumes0.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - emptyDir: {}
+    name: volume-emptydir
+  - hostPath:
+      path: /a
+    name: volume-hostpath

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostpathvolumes1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostpathvolumes1.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - hostPath:
+      path: /a
+    name: volume-hostpath-a
+  - hostPath:
+      path: /b
+    name: volume-hostpath-b

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostports0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostports1.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostports2.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostprobesandhostlifecycle0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostprobesandhostlifecycle0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    livenessProbe:
+      httpGet:
+        host: bad.host
+        port: 8080
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostprobesandhostlifecycle1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostprobesandhostlifecycle1.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    readinessProbe:
+      tcpSocket:
+        host: 8.8.8.8
+        port: 8080
+    restartPolicy: Always
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostprobesandhostlifecycle2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostprobesandhostlifecycle2.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    lifecycle:
+      postStart:
+        httpGet:
+          host: bad.host
+          port: 8080
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostprobesandhostlifecycle3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostprobesandhostlifecycle3.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    livenessProbe:
+      httpGet:
+        host: 127.0.0.1
+        port: 8080
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostprobesandhostlifecycle4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/hostprobesandhostlifecycle4.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle4
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    readinessProbe:
+      tcpSocket:
+        host: ::1
+        port: 8080
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/privileged0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+      privileged: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/privileged1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/privileged1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+      privileged: true
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/procmount0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Unmasked
+  hostUsers: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/procmount1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostUsers: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Unmasked
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/procmount_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/procmount_restricted0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount_restricted0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Unmasked
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/procmount_restricted1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/procmount_restricted1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount_restricted1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Unmasked
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - gcePersistentDisk:
+      pdName: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes1.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - awsElasticBlockStore:
+      volumeID: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes10.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes10.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes10
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - flocker:
+      datasetName: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes11.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes11.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes11
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - fc:
+      wwids:
+      - test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes12.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes12.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes12
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - azureFile:
+      secretName: test
+      shareName: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes13.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes13.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes13
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    vsphereVolume:
+      volumePath: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes14.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes14.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes14
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    quobyte:
+      registry: localhost:1234
+      volume: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes15.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes15.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes15
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - azureDisk:
+      diskName: test
+      diskURI: https://test.blob.core.windows.net/test/test.vhd
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes16.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes16.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes16
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    portworxVolume:
+      fsType: ext4
+      volumeID: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes17.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes17.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes17
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    scaleIO:
+      gateway: localhost
+      secretRef: null
+      system: test
+      volumeName: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes18.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes18.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes18
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    storageos:
+      volumeName: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes19.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes19.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes19
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - hostPath:
+      path: /dev/null
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes2.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - gitRepo:
+      repository: github.com/kubernetes/kubernetes
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes3.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    nfs:
+      path: /test
+      server: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes4.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes4
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - iscsi:
+      iqn: iqn.2001-04.com.example:storage.kube.sys1.xyz
+      lun: 0
+      targetPortal: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes5.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes5.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes5
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - glusterfs:
+      endpoints: test
+      path: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes6.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes6.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes6
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    rbd:
+      image: test
+      monitors:
+      - test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes7.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes7.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes7
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - flexVolume:
+      driver: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes8.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes8.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes8
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - cinder:
+      volumeID: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes9.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/restrictedvolumes9.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes9
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - cephfs:
+      monitors:
+      - test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/runasnonroot0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/runasnonroot0.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/runasnonroot1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/runasnonroot1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: false
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/runasnonroot2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/runasnonroot2.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/runasnonroot3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/runasnonroot3.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: false
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/runasuser0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/runasuser0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 0
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/runasuser1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/runasuser1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 0
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/runasuser2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/runasuser2.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 0
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/seccompprofile_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/seccompprofile_baseline0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: Unconfined

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/seccompprofile_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/seccompprofile_baseline1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: Unconfined
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/seccompprofile_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/seccompprofile_baseline2.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: Unconfined
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/seccompprofile_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/seccompprofile_restricted0.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/seccompprofile_restricted1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/seccompprofile_restricted1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: Unconfined

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/seccompprofile_restricted2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/seccompprofile_restricted2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/seccompprofile_restricted3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/seccompprofile_restricted3.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/seccompprofile_restricted4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/seccompprofile_restricted4.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted4
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: Unconfined
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/selinuxoptions0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      type: somevalue
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/selinuxoptions1.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        type: somevalue
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions: {}
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/selinuxoptions2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/selinuxoptions2.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        type: somevalue
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions: {}
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/selinuxoptions3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/selinuxoptions3.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      user: somevalue
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/selinuxoptions4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/selinuxoptions4.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions4
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      role: somevalue
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/sysctls0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    sysctls:
+    - name: othersysctl
+      value: other

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/windowshostprocess0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/windowshostprocess0.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions: {}
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    windowsOptions:
+      hostProcess: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/windowshostprocess1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/fail/windowshostprocess1.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions:
+        hostProcess: true
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions:
+        hostProcess: true
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    windowsOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/apparmorprofile0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/base.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/base.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/base_linux.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/base_linux.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base_linux
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  os:
+    name: linux
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/base_windows.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/base_windows.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base_windows
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  os:
+    name: windows
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/capabilities_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/capabilities_restricted0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_BIND_SERVICE
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_BIND_SERVICE
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/hostports0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/hostprobesandhostlifecycle0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/hostprobesandhostlifecycle0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/hostprobesandhostlifecycle1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/hostprobesandhostlifecycle1.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    livenessProbe:
+      httpGet:
+        port: 8080
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/hostprobesandhostlifecycle2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/hostprobesandhostlifecycle2.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/privileged0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/procmount0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Default
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Default
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/procmount_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/procmount_restricted0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount_restricted0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Default
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Default
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/restrictedvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/restrictedvolumes0.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume0
+  - emptyDir: {}
+    name: volume1
+  - name: volume2
+    secret:
+      secretName: test
+  - name: volume3
+    persistentVolumeClaim:
+      claimName: test
+  - downwardAPI:
+      items:
+      - fieldRef:
+          fieldPath: metadata.labels
+        path: labels
+    name: volume4
+  - configMap:
+      name: test
+    name: volume5
+  - name: volume6
+    projected:
+      sources: []

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/runasnonroot0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/runasnonroot0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/runasnonroot1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/runasnonroot1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/runasuser0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/runasuser0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 1000
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 1000
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/seccompprofile_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/seccompprofile_restricted0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/seccompprofile_restricted1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/seccompprofile_restricted1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      localhostProfile: testing
+      type: Localhost

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/seccompprofile_restricted2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/seccompprofile_restricted2.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        localhostProfile: testing
+        type: Localhost
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/selinuxoptions0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/selinuxoptions1.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        level: somevalue
+        type: container_init_t
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        type: container_kvm_t
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      type: container_t
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/sysctls0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.38/pass/sysctls1.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    sysctls:
+    - name: net.ipv4.tcp_slow_start_after_idle
+      value: "0"
+    - name: net.ipv4.tcp_notsent_lowat
+      value: "16384"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Extend Pod Security Admission fixture coverage to v1.38.

Bump `newestMinorVersionToTest` from 37 to 38, then regenerate fixtures from the repository root with:

```sh
UPDATE_POD_SECURITY_FIXTURE_DATA=true \
  go test k8s.io/pod-security-admission/test
```

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Verified with `go test k8s.io/pod-security-admission/test -count=1`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

YES. AI assisted with preparing and validating the change and drafting this description.

/sig auth