### PR TITLE
Fix CEL map-list concatenation to merge duplicate new keys

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
@@ -1385,6 +1385,10 @@ func TestListAdd(t *testing.T) {
 			expression: "(x.mapList + [{'key1': 'k1v9', 'key2': 'k2v9', 'value': 9}])[2].value == 9",
 		}, skipSchemaless: true},
 		{testCase: testCase{
+			name:       "map list + literal list merges duplicate new keys",
+			expression: "size(x.mapList + [{'key1': 'k1v9', 'key2': 'k2v9', 'value': 9}, {'key1': 'k1v9', 'key2': 'k2v9', 'value': 10}]) == 3 && (x.mapList + [{'key1': 'k1v9', 'key2': 'k2v9', 'value': 9}, {'key1': 'k1v9', 'key2': 'k2v9', 'value': 10}])[2].value == 10",
+		}, skipSchemaless: true},
+		{testCase: testCase{
 			name:       "chained map list merge",
 			expression: "(x.mapList + y.mapList + [{'key1': 'k1v3', 'key2': 'k2v3', 'value': 33}])[2].value == 33",
 		}, skipSchemaless: true},

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
@@ -531,6 +531,7 @@ func addToMapList(elements []ref.Val, other traits.Lister, escapedKeyProps []str
 			elements[overwritePosition] = v
 		} else {
 			elements = append(elements, v)
+			keyToIdx[k] = len(elements) - 1
 		}
 	}
 	return &refValMapList{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Schema-aware CEL map-list concatenation kept duplicate new keys from the right operand instead of merging them.

`addToMapList` builds an index for the left operand but did not add a key to that index when it appended the first new element from the right operand. A later element with the same key was therefore appended again, producing duplicate keys and wrong list size. This breaks the merge-by-key semantics implemented for `x-kubernetes-list-type: map`, so CEL policies could observe the wrong size/value, and mutation expressions could emit duplicate map keys (admission request rejected instead of applying the later value).

Index each appended element immediately so later elements with an intersecting key overwrite it in place.

#### Which issue(s) this PR fixes:

Fixes #140591

#### Special notes for your reviewer:

The regression test below fails before this change:
`size(x.mapList + [...]) == 3 && (x.mapList + [...])[2].value == 10`
produced `Expected true with typed values but got false` (it returned 4 entries).

Verified: `GOWORK=off go test ./pkg/cel/common -run TestListAdd -count=1` (fails on parent commit, passes after), full `go test ./pkg/cel/common/...` passes, `gofmt` clean, `golangci-lint run --new-from-rev=<base> ./pkg/cel/common/...` reports 0 issues.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where schema-aware CEL map-list concatenation (`x-kubernetes-list-type: map`) could preserve duplicate new keys from the right operand instead of merging them by key.
```