### PR TITLE
Migrate LeaseCandidate.Spec.BinaryVersion to declarative validation

### DIFF
--- a/pkg/apis/coordination/v1alpha2/zz_generated.validations.go
+++ b/pkg/apis/coordination/v1alpha2/zz_generated.validations.go
@@ -88,6 +88,71 @@ func Validate_LeaseCandidate(
 		errs = append(errs, fn(fldPath.Child("metadata"), &obj.ObjectMeta, oldVal, oldObj != nil)...)
 	}
 
-	// field coordinationv1alpha2.LeaseCandidate.Spec has no validation
+	{ // field coordinationv1alpha2.LeaseCandidate.Spec
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *coordinationv1alpha2.LeaseCandidateSpec,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if validate.SemanticDeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_LeaseCandidateSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *coordinationv1alpha2.LeaseCandidate) *coordinationv1alpha2.LeaseCandidateSpec {
+				return &oldObj.Spec
+			})
+		errs = append(errs, fn(fldPath.Child("spec"), &obj.Spec, oldVal, oldObj != nil)...)
+	}
+
+	return errs
+}
+
+// Validate_LeaseCandidateSpec validates an instance of LeaseCandidateSpec according
+// to declarative validation rules in the API schema.
+func Validate_LeaseCandidateSpec(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *coordinationv1alpha2.LeaseCandidateSpec) (errs field.ErrorList) {
+
+	// field coordinationv1alpha2.LeaseCandidateSpec.LeaseName has no validation
+	// field coordinationv1alpha2.LeaseCandidateSpec.PingTime has no validation
+	// field coordinationv1alpha2.LeaseCandidateSpec.RenewTime has no validation
+
+	{ // field coordinationv1alpha2.LeaseCandidateSpec.BinaryVersion
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *coordinationv1alpha2.LeaseCandidateSpec) *string {
+				return &oldObj.BinaryVersion
+			})
+		errs = append(errs, fn(fldPath.Child("binaryVersion"), &obj.BinaryVersion, oldVal, oldObj != nil)...)
+	}
+
+	// field coordinationv1alpha2.LeaseCandidateSpec.EmulationVersion has no validation
+	// field coordinationv1alpha2.LeaseCandidateSpec.Strategy has no validation
 	return errs
 }

--- a/pkg/apis/coordination/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/coordination/v1beta1/zz_generated.validations.go
@@ -137,6 +137,71 @@ func Validate_LeaseCandidate(
 		errs = append(errs, fn(fldPath.Child("metadata"), &obj.ObjectMeta, oldVal, oldObj != nil)...)
 	}
 
-	// field coordinationv1beta1.LeaseCandidate.Spec has no validation
+	{ // field coordinationv1beta1.LeaseCandidate.Spec
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *coordinationv1beta1.LeaseCandidateSpec,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if validate.SemanticDeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_LeaseCandidateSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *coordinationv1beta1.LeaseCandidate) *coordinationv1beta1.LeaseCandidateSpec {
+				return &oldObj.Spec
+			})
+		errs = append(errs, fn(fldPath.Child("spec"), &obj.Spec, oldVal, oldObj != nil)...)
+	}
+
+	return errs
+}
+
+// Validate_LeaseCandidateSpec validates an instance of LeaseCandidateSpec according
+// to declarative validation rules in the API schema.
+func Validate_LeaseCandidateSpec(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *coordinationv1beta1.LeaseCandidateSpec) (errs field.ErrorList) {
+
+	// field coordinationv1beta1.LeaseCandidateSpec.LeaseName has no validation
+	// field coordinationv1beta1.LeaseCandidateSpec.PingTime has no validation
+	// field coordinationv1beta1.LeaseCandidateSpec.RenewTime has no validation
+
+	{ // field coordinationv1beta1.LeaseCandidateSpec.BinaryVersion
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *coordinationv1beta1.LeaseCandidateSpec) *string {
+				return &oldObj.BinaryVersion
+			})
+		errs = append(errs, fn(fldPath.Child("binaryVersion"), &obj.BinaryVersion, oldVal, oldObj != nil)...)
+	}
+
+	// field coordinationv1beta1.LeaseCandidateSpec.EmulationVersion has no validation
+	// field coordinationv1beta1.LeaseCandidateSpec.Strategy has no validation
 	return errs
 }

--- a/pkg/apis/coordination/validation/validation.go
+++ b/pkg/apis/coordination/validation/validation.go
@@ -112,7 +112,7 @@ func ValidateLeaseCandidateSpec(spec *coordination.LeaseCandidateSpec, fldPath *
 	}
 	bv := semver.Version{}
 	if spec.BinaryVersion == "" {
-		allErrs = append(allErrs, field.Required(fldPath.Child("binaryVersion"), ""))
+		allErrs = append(allErrs, field.Required(fldPath.Child("binaryVersion"), "").MarkCoveredByDeclarative())
 	} else {
 		var err error
 		bv, err = semver.Parse(spec.BinaryVersion)

--- a/staging/src/k8s.io/api/coordination/v1alpha2/generated.proto
+++ b/staging/src/k8s.io/api/coordination/v1alpha2/generated.proto
@@ -81,6 +81,7 @@ message LeaseCandidateSpec {
   // binaryVersion is the binary version. It must be in a semver format without leading `v`.
   // This field is required.
   // +required
+  // +k8s:alpha(since: "1.38")=+k8s:required
   optional string binaryVersion = 4;
 
   // emulationVersion is the emulation version. It must be in a semver format without leading `v`.

--- a/staging/src/k8s.io/api/coordination/v1alpha2/types.go
+++ b/staging/src/k8s.io/api/coordination/v1alpha2/types.go
@@ -64,6 +64,7 @@ type LeaseCandidateSpec struct {
 	// binaryVersion is the binary version. It must be in a semver format without leading `v`.
 	// This field is required.
 	// +required
+	// +k8s:alpha(since: "1.38")=+k8s:required
 	BinaryVersion string `json:"binaryVersion" protobuf:"bytes,4,name=binaryVersion"`
 	// emulationVersion is the emulation version. It must be in a semver format without leading `v`.
 	// EmulationVersion must be less than or equal to BinaryVersion.

--- a/staging/src/k8s.io/api/coordination/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/coordination/v1beta1/generated.proto
@@ -96,6 +96,7 @@ message LeaseCandidateSpec {
   // binaryVersion is the binary version. It must be in a semver format without leading `v`.
   // This field is required.
   // +required
+  // +k8s:alpha(since: "1.38")=+k8s:required
   optional string binaryVersion = 4;
 
   // emulationVersion is the emulation version. It must be in a semver format without leading `v`.

--- a/staging/src/k8s.io/api/coordination/v1beta1/types.go
+++ b/staging/src/k8s.io/api/coordination/v1beta1/types.go
@@ -138,6 +138,7 @@ type LeaseCandidateSpec struct {
 	// binaryVersion is the binary version. It must be in a semver format without leading `v`.
 	// This field is required.
 	// +required
+	// +k8s:alpha(since: "1.38")=+k8s:required
 	BinaryVersion string `json:"binaryVersion" protobuf:"bytes,4,name=binaryVersion"`
 	// emulationVersion is the emulation version. It must be in a semver format without leading `v`.
 	// EmulationVersion must be less than or equal to BinaryVersion.

--- a/test/declarative_validation/coordination/leasecandidate/declarative_validation_test.go
+++ b/test/declarative_validation/coordination/leasecandidate/declarative_validation_test.go
@@ -20,7 +20,9 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	coordination "k8s.io/kubernetes/pkg/apis/coordination"
 	registry "k8s.io/kubernetes/pkg/registry/coordination/leasecandidate"
 	"k8s.io/kubernetes/test/declarative_validation/meta"
@@ -52,6 +54,23 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		Verb:              "create",
 	}), metav1.NamespaceDefault)
 
+	testCases := map[string]struct {
+		input        coordination.LeaseCandidate
+		expectedErrs field.ErrorList
+	}{
+		"spec.binaryVersion: empty = invalid": {
+			input: mkValidLeaseCandidate(tweakBinaryVersion("")),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "binaryVersion"), "").MarkAlpha(),
+			},
+		},
+	}
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, registry.Strategy, tc.expectedErrs)
+		})
+	}
+
 	obj := mkValidLeaseCandidate()
 	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy)
 }
@@ -67,12 +86,32 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 		Verb:              "update",
 	}), metav1.NamespaceDefault)
 
+	testCases := map[string]struct {
+		old, update  coordination.LeaseCandidate
+		expectedErrs field.ErrorList
+	}{
+		"spec.binaryVersion: set to empty = invalid": {
+			old:    mkValidLeaseCandidate(),
+			update: mkValidLeaseCandidate(tweakBinaryVersion("")),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "binaryVersion"), "").MarkAlpha(),
+			},
+		},
+	}
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			tc.old.ResourceVersion = "1"
+			tc.update.ResourceVersion = "1"
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, registry.Strategy, tc.expectedErrs)
+		})
+	}
+
 	updateObj := mkValidLeaseCandidate()
 	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy)
 }
 
-func mkValidLeaseCandidate() coordination.LeaseCandidate {
-	return coordination.LeaseCandidate{
+func mkValidLeaseCandidate(tweaks ...func(lc *coordination.LeaseCandidate)) coordination.LeaseCandidate {
+	lc := coordination.LeaseCandidate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "valid-obj",
 			Namespace: metav1.NamespaceDefault,
@@ -83,5 +122,15 @@ func mkValidLeaseCandidate() coordination.LeaseCandidate {
 			EmulationVersion: "1.0.0",
 			Strategy:         coordination.OldestEmulationVersion,
 		},
+	}
+	for _, tweak := range tweaks {
+		tweak(&lc)
+	}
+	return lc
+}
+
+func tweakBinaryVersion(binaryVersion string) func(*coordination.LeaseCandidate) {
+	return func(lc *coordination.LeaseCandidate) {
+		lc.Spec.BinaryVersion = binaryVersion
 	}
 }

--- a/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1alpha2_test.go
+++ b/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1alpha2_test.go
@@ -61,6 +61,9 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.binaryVersion": {
+				{ErrorType: "FieldValueRequired"},
+			},
 		},
 	)
 }

--- a/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1beta1_test.go
@@ -61,6 +61,9 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.binaryVersion": {
+				{ErrorType: "FieldValueRequired"},
+			},
 		},
 	)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Migrates `LeaseCandidate.spec.binaryVersion` from handwritten validation to Declarative Validation, following the "Good First Migration" criteria in #135752:

- simple required check (`len(spec.BinaryVersion) == 0` -> `field.Required`)
- field exists at the same path in all versions that serve the type (`coordination/v1alpha2`, `coordination/v1beta1`)
- `LeaseCandidateSpec` is always validated (struct field, not a pointer)
- field is not `+optional` and had no `+k8s:` tag yet

Changes:

- add `+k8s:alpha(since: "1.38")=+k8s:required` to `LeaseCandidateSpec.BinaryVersion` in `coordination/v1alpha2` and `coordination/v1beta1`
- mark the handwritten required check as `.MarkCoveredByDeclarative()`
- regenerate `zz_generated.validations.go` for both versions and the `test/declarative_validation/coordination/leasecandidate` coverage fixtures
- add create/update equivalence cases exercising the new rule (empty `binaryVersion`)
- keep `generated.proto` type comments in sync

#### Which issue(s) this PR fixes:

Fixes #135752

#### Special notes for your reviewer:

Equivalence coverage: `spec.binaryVersion: empty = invalid` (create) and `spec.binaryVersion: set to empty = invalid` (update).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g. KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5073-declarative-validation