### PR TITLE
Migrate PriorityClass.preemptionPolicy to declarative validation

### DIFF
--- a/pkg/apis/scheduling/v1/zz_generated.validations.go
+++ b/pkg/apis/scheduling/v1/zz_generated.validations.go
@@ -25,6 +25,7 @@ import (
 	context "context"
 	fmt "fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
@@ -91,6 +92,38 @@ func Validate_PriorityClass(
 	// field schedulingv1.PriorityClass.Value has no validation
 	// field schedulingv1.PriorityClass.GlobalDefault has no validation
 	// field schedulingv1.PriorityClass.Description has no validation
-	// field schedulingv1.PriorityClass.PreemptionPolicy has no validation
+
+	{ // field schedulingv1.PriorityClass.PreemptionPolicy
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *corev1.PreemptionPolicy,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *schedulingv1.PriorityClass) *corev1.PreemptionPolicy {
+				return oldObj.PreemptionPolicy
+			})
+		errs = append(errs, fn(fldPath.Child("preemptionPolicy"), obj.PreemptionPolicy, oldVal, oldObj != nil)...)
+	}
+
 	return errs
 }

--- a/pkg/apis/scheduling/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/scheduling/v1beta1/zz_generated.validations.go
@@ -25,6 +25,7 @@ import (
 	context "context"
 	fmt "fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
@@ -2002,7 +2003,39 @@ func Validate_PriorityClass(
 	// field schedulingv1beta1.PriorityClass.Value has no validation
 	// field schedulingv1beta1.PriorityClass.GlobalDefault has no validation
 	// field schedulingv1beta1.PriorityClass.Description has no validation
-	// field schedulingv1beta1.PriorityClass.PreemptionPolicy has no validation
+
+	{ // field schedulingv1beta1.PriorityClass.PreemptionPolicy
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *corev1.PreemptionPolicy,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *schedulingv1beta1.PriorityClass) *corev1.PreemptionPolicy {
+				return oldObj.PreemptionPolicy
+			})
+		errs = append(errs, fn(fldPath.Child("preemptionPolicy"), obj.PreemptionPolicy, oldVal, oldObj != nil)...)
+	}
+
 	return errs
 }
 

--- a/pkg/apis/scheduling/validation/validation.go
+++ b/pkg/apis/scheduling/validation/validation.go
@@ -69,7 +69,7 @@ func ValidatePriorityClassUpdate(pc, oldPc *scheduling.PriorityClass) field.Erro
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("value"), "may not be changed in an update."))
 	}
 	// preemptionPolicy is immutable.
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(pc.PreemptionPolicy, oldPc.PreemptionPolicy, field.NewPath("preemptionPolicy"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(pc.PreemptionPolicy, oldPc.PreemptionPolicy, field.NewPath("preemptionPolicy")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
 	return allErrs
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1/generated.proto
@@ -59,6 +59,8 @@ message PriorityClass {
   // One of Never, PreemptLowerPriority.
   // Defaults to PreemptLowerPriority if unset.
   // +optional
+  // +k8s:optional
+  // +k8s:alpha(since: "1.38")=+k8s:immutable
   optional string preemptionPolicy = 5;
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1/types.go
@@ -57,6 +57,8 @@ type PriorityClass struct {
 	// One of Never, PreemptLowerPriority.
 	// Defaults to PreemptLowerPriority if unset.
 	// +optional
+	// +k8s:optional
+	// +k8s:alpha(since: "1.38")=+k8s:immutable
 	PreemptionPolicy *apiv1.PreemptionPolicy `json:"preemptionPolicy,omitempty" protobuf:"bytes,5,opt,name=preemptionPolicy"`
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/generated.proto
@@ -700,6 +700,8 @@ message PriorityClass {
   // One of Never, PreemptLowerPriority.
   // Defaults to PreemptLowerPriority if unset.
   // +optional
+  // +k8s:optional
+  // +k8s:alpha(since: "1.38")=+k8s:immutable
   optional string preemptionPolicy = 5;
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1beta1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/types.go
@@ -61,6 +61,8 @@ type PriorityClass struct {
 	// One of Never, PreemptLowerPriority.
 	// Defaults to PreemptLowerPriority if unset.
 	// +optional
+	// +k8s:optional
+	// +k8s:alpha(since: "1.38")=+k8s:immutable
 	PreemptionPolicy *apiv1.PreemptionPolicy `json:"preemptionPolicy,omitempty" protobuf:"bytes,5,opt,name=preemptionPolicy"`
 }
 

--- a/test/declarative_validation/scheduling/priorityclass/declarative_validation_test.go
+++ b/test/declarative_validation/scheduling/priorityclass/declarative_validation_test.go
@@ -20,7 +20,10 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/apis/core"
 	scheduling "k8s.io/kubernetes/pkg/apis/scheduling"
 	registry "k8s.io/kubernetes/pkg/registry/scheduling/priorityclass"
 	"k8s.io/kubernetes/test/declarative_validation/meta"
@@ -67,6 +70,44 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 		Verb:              "update",
 	})
 
+	testCases := map[string]struct {
+		old, update  scheduling.PriorityClass
+		expectedErrs field.ErrorList
+	}{
+		"preemptionPolicy: unchanged = valid": {
+			old:    mkPriorityClass(tweakPreemptionPolicy(core.PreemptLowerPriority)),
+			update: mkPriorityClass(tweakPreemptionPolicy(core.PreemptLowerPriority)),
+		},
+		"preemptionPolicy: nil to set = invalid": {
+			old:    mkPriorityClass(),
+			update: mkPriorityClass(tweakPreemptionPolicy(core.PreemptLowerPriority)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("preemptionPolicy"), nil, "field is immutable").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
+		"preemptionPolicy: set to different = invalid": {
+			old:    mkPriorityClass(tweakPreemptionPolicy(core.PreemptLowerPriority)),
+			update: mkPriorityClass(tweakPreemptionPolicy(core.PreemptNever)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("preemptionPolicy"), nil, "field is immutable").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
+		"preemptionPolicy: set to nil = invalid": {
+			old:    mkPriorityClass(tweakPreemptionPolicy(core.PreemptLowerPriority)),
+			update: mkPriorityClass(),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("preemptionPolicy"), nil, "field is immutable").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
+	}
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			tc.old.ResourceVersion = "1"
+			tc.update.ResourceVersion = "1"
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, registry.Strategy, tc.expectedErrs)
+		})
+	}
+
 	updateObj := mkPriorityClass()
 	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
@@ -81,4 +122,10 @@ func mkPriorityClass(tweaks ...func(pc *scheduling.PriorityClass)) scheduling.Pr
 		tweak(&pc)
 	}
 	return pc
+}
+
+func tweakPreemptionPolicy(policy core.PreemptionPolicy) func(*scheduling.PriorityClass) {
+	return func(pc *scheduling.PriorityClass) {
+		pc.PreemptionPolicy = &policy
+	}
 }

--- a/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1_test.go
@@ -61,6 +61,9 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"preemptionPolicy": {
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
+			},
 		},
 	)
 }

--- a/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1beta1_test.go
@@ -61,6 +61,9 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"preemptionPolicy": {
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
+			},
 		},
 	)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Migrates `PriorityClass.preemptionPolicy` immutability from handwritten validation to Declarative Validation, following the "Good First Migration" criteria in #136785:

- simple immutable check (`apivalidation.ValidateImmutableField`)
- field exists at the same path in `scheduling/v1` and `scheduling/v1beta1`
- field had no `+k8s:immutable`/`+k8s:update` tag yet

Changes:

- add `+k8s:optional` and `+k8s:alpha(since: "1.38")=+k8s:immutable` to `PriorityClass.PreemptionPolicy` in `scheduling/v1` and `scheduling/v1beta1`
- mark the handwritten immutability check as `.WithOrigin("immutable").MarkCoveredByDeclarative()`
- regenerate `zz_generated.validations.go` for both versions and the `test/declarative_validation/scheduling/priorityclass` coverage fixtures
- add update equivalence cases exercising the new rule (nil->set, set->different, set->nil, unchanged)
- keep `generated.proto` type comments in sync

#### Which issue(s) this PR fixes:

Fixes #136785

#### Special notes for your reviewer:

The handwritten check already reports `FieldValueInvalid` with "field is immutable", matching the declarative `immutable` rule, so the update error type is unchanged.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g. KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5073-declarative-validation