### PR TITLE
memorymanager: reject incomplete pod-level checkpoint state

### DIFF
--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -1054,6 +1054,13 @@ func areGroupsEqual(group1, group2 []int) bool {
 func (p *staticPolicy) validateState(logger klog.Logger, s state.State) error {
 	machineState := s.GetMachineState()
 	memoryAssignments := s.GetMemoryAssignments()
+	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) {
+		for podUID := range s.GetPodMemoryAssignments() {
+			if len(memoryAssignments[podUID]) == 0 {
+				return fmt.Errorf("[memorymanager] pod %q has a pod memory assignment but no container memory assignments", podUID)
+			}
+		}
+	}
 
 	if len(machineState) == 0 {
 		// Machine state cannot be empty when assignments exist

--- a/pkg/kubelet/cm/memorymanager/policy_static_restore_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static_restore_test.go
@@ -18,6 +18,7 @@ package memorymanager
 
 import (
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -30,10 +31,22 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
+	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager/state"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/test/utils/ktesting"
 )
+
+type crashAfterPodCheckpointState struct {
+	state.State
+}
+
+const simulatedProcessInterruption = "simulated process interruption after pod allocation checkpoint"
+
+func (s *crashAfterPodCheckpointState) SetPodMemoryBlocks(podUID string, blocks []state.Block) {
+	s.State.SetPodMemoryBlocks(podUID, blocks)
+	panic(simulatedProcessInterruption)
+}
 
 // For the scope of the test, any pod that has pod-level resources and the
 // PodLevelResourceManagers feature is enabled, will be processed by AllocatePod
@@ -257,5 +270,114 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestMemoryManagerRestorePartialPodCheckpoint(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Memory Manager static policy is not available on Windows")
+	}
+
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResourceManagers, true)
+
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+	machineInfo := returnMachineInfo()
+	nodeAllocatableReservation := v1.ResourceList{
+		v1.ResourceMemory: *resource.NewQuantity(2*gb, resource.BinarySI),
+	}
+	systemReservedMemory := []kubeletconfig.MemoryReservation{
+		{
+			NumaNode: 0,
+			Limits: v1.ResourceList{
+				v1.ResourceMemory: *resource.NewQuantity(gb, resource.BinarySI),
+			},
+		},
+		{
+			NumaNode: 1,
+			Limits: v1.ResourceList{
+				v1.ResourceMemory: *resource.NewQuantity(gb, resource.BinarySI),
+			},
+		},
+	}
+	pod := getPodWithContainersAndPodLevelResources("pod1", "128Mi", "128Mi", nil, []containerSpec{
+		{name: "container1", memRequest: "100Mi", memLimit: "100Mi"},
+	})
+	pod.UID = "podUID"
+	activePods := func() []*v1.Pod { return []*v1.Pod{pod} }
+
+	stateDir := t.TempDir()
+	topologyMgr, err := topologymanager.NewManager(logger, machineInfo.Topology, topologymanager.PolicyBestEffort, topologymanager.PodTopologyScope, nil)
+	if err != nil {
+		t.Fatalf("could not create topology manager: %v", err)
+	}
+	mgr, err := NewManager(logger, string(PolicyTypeStatic), &machineInfo, nodeAllocatableReservation, systemReservedMemory, stateDir, topologyMgr)
+	if err != nil {
+		t.Fatalf("could not create manager: %v", err)
+	}
+	topologyMgr.AddHintProvider(logger, mgr)
+	if err := mgr.Start(tCtx, activePods, &sourcesReadyStub{}, mockPodStatusProvider{}, mockRuntimeService{}, containermap.NewContainerMap()); err != nil {
+		t.Fatalf("could not start manager: %v", err)
+	}
+
+	preAllocationMachineState := mgr.State().GetMachineState()
+	managerImpl := mgr.(*manager)
+	func() {
+		defer func() {
+			if recovered := recover(); recovered == nil {
+				t.Fatal("expected simulated process interruption")
+			} else if recovered != simulatedProcessInterruption {
+				t.Fatalf("unexpected panic: %v", recovered)
+			}
+		}()
+		managerImpl.state = &crashAfterPodCheckpointState{State: managerImpl.state}
+		topologyMgr.Admit(tCtx, &lifecycle.PodAdmitAttributes{Pod: pod, Operation: lifecycle.AddOperation})
+	}()
+
+	if blocks := mgr.State().GetPodMemoryBlocks(string(pod.UID)); len(blocks) == 0 {
+		t.Fatal("expected pod memory blocks to be persisted before interruption")
+	}
+	if assignments := mgr.State().GetMemoryAssignments(); len(assignments) != 0 {
+		t.Fatalf("expected no container memory assignments before interruption, got %v", assignments)
+	}
+	if diff := cmp.Diff(preAllocationMachineState, mgr.State().GetMachineState()); diff != "" {
+		t.Fatalf("machine state changed before interruption (-want +got):\n%s", diff)
+	}
+
+	topologyMgr2, err := topologymanager.NewManager(logger, machineInfo.Topology, topologymanager.PolicyBestEffort, topologymanager.PodTopologyScope, nil)
+	if err != nil {
+		t.Fatalf("could not create restored topology manager: %v", err)
+	}
+	mgr2, err := NewManager(logger, string(PolicyTypeStatic), &machineInfo, nodeAllocatableReservation, systemReservedMemory, stateDir, topologyMgr2)
+	if err != nil {
+		t.Fatalf("could not create restored manager: %v", err)
+	}
+	topologyMgr2.AddHintProvider(logger, mgr2)
+	if err := mgr2.Start(tCtx, activePods, &sourcesReadyStub{}, mockPodStatusProvider{}, mockRuntimeService{}, containermap.NewContainerMap()); err != nil {
+		// Rejecting an incomplete checkpoint is a valid recovery outcome.
+		if !strings.Contains(err.Error(), "has a pod memory assignment but no container memory assignments") {
+			t.Fatalf("unexpected restore error: %v", err)
+		}
+		return
+	}
+
+	result := topologyMgr2.Admit(tCtx, &lifecycle.PodAdmitAttributes{Pod: pod, Operation: lifecycle.AddOperation})
+	if !result.Admit {
+		// Failing allocation instead of accepting incomplete state is also safe.
+		return
+	}
+	affinity := topologyMgr2.GetAffinity(logger, string(pod.UID), pod.Spec.Containers[0].Name)
+	if !affinity.Preferred || !affinity.NUMANodeAffinity.IsEqual(newNUMAAffinity(0)) {
+		t.Fatalf("expected restored pod hint for NUMA node 0, got %v", affinity)
+	}
+
+	for _, container := range pod.Spec.Containers {
+		if blocks := mgr2.State().GetMemoryBlocks(string(pod.UID), container.Name); len(blocks) == 0 {
+			t.Errorf("successful restored pod allocation left container %q without memory blocks", container.Name)
+		}
+	}
+	if diff := cmp.Diff(preAllocationMachineState, mgr2.State().GetMachineState()); diff == "" {
+		t.Error("successful restored pod allocation left machine state without the pod reservation")
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node
/area kubelet

#### What this PR does / why we need it:

With pod-level Memory Manager allocations, `AllocatePod` writes the pod memory assignment before container assignments and machine state. If kubelet is interrupted after the PodEntry checkpoint write, the checkpoint remains structurally valid but logically incomplete.

During restore, `validateState` previously discovered pod-level allocations only while iterating container assignments, so a pod-only assignment was not checked. The restored pod hint could then make Topology Manager admission succeed while Memory Manager still had no container blocks or machine-state reservation. The subsequent pod-level allocation fast path treated the pod as already present and skipped reconstruction.

This change has `validateState` inspect pod memory assignments directly and reject any pod assignment without container assignments. The regression test uses the real checkpoint backend and pod-scope Topology Manager, interrupts immediately after `SetPodMemoryBlocks` persists the pod entry, restarts both managers from the same directory, and verifies the incomplete restored state is not accepted as a complete allocation.

#### Which issue(s) this PR is related to:

Fixes #141993

Related: #140906, #141077, #141070, #141261

KEP: https://github.com/kubernetes/enhancements/issues/5526

#### Special notes for your reviewer:

The new validation is gated by `PodLevelResourceManagers`, preserving container-scope behavior. Complete pod-level restore and multi-container hint restoration remain covered by existing tests.

Without the production guard, the regression test deterministically restores and admits the pod while leaving both its container memory blocks and machine-state reservation absent. With the guard, restore rejects the incomplete checkpoint.

Local verification:

- `go test ./pkg/kubelet/cm/memorymanager -run '^TestMemoryManagerRestore(State|PartialPodCheckpoint)$' -count=1 -v`
- `go test ./pkg/kubelet/cm/memorymanager/... ./pkg/kubelet/cm/topologymanager/... -count=1`
- `go test -race ./pkg/kubelet/cm/memorymanager -count=1`

#### Does this PR introduce a user-facing change?

```release-note
Fixed static Memory Manager restart recovery for pod-level resources by rejecting incomplete pod-level checkpoint state instead of treating it as a complete restored allocation.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/861cbafd9776e41109ebf931b035a6d8ff985f7b/keps/sig-node/5526-pod-level-resource-managers/README.md
```

#### AI usage disclosure:

YES

AI tools were used to assist with source analysis, regression-test development, and code review. I manually reviewed and understood the changes, reproduced the regression before the production fix, and verified the fix with focused unit and race tests.