### PR TITLE
memorymanager: test non-zero NUMA affinity restoration

### DIFF
--- a/pkg/kubelet/cm/memorymanager/policy_static_restore_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static_restore_test.go
@@ -51,6 +51,7 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 		podMemoryRequest                string
 		containers                      []containerSpec
 		expectPodBlocks                 bool
+		allocationAffinity              []int
 		expectedAffinity                []int
 	}{
 		{
@@ -63,6 +64,18 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 			},
 			expectPodBlocks:  true,
 			expectedAffinity: []int{0},
+		},
+		{
+			description:                     "Pod topology hint is restored from a non-zero NUMA node",
+			podLevelResourcesEnabled:        true,
+			podLevelResourceManagersEnabled: true,
+			podMemoryRequest:                "128Mi",
+			containers: []containerSpec{
+				{name: "container1", memRequest: "100Mi", memLimit: "100Mi"},
+			},
+			expectPodBlocks:    true,
+			allocationAffinity: []int{1},
+			expectedAffinity:   []int{1},
 		},
 		{
 			description:                     "Pod topology hint is restored from a multi-container pod allocation",
@@ -137,6 +150,12 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 				},
 			}
 			affinity := topologymanager.NewFakeManager(logger)
+			if tc.allocationAffinity != nil {
+				affinity = topologymanager.NewFakeManagerWithHint(logger, &topologymanager.TopologyHint{
+					NUMANodeAffinity: newNUMAAffinity(tc.allocationAffinity...),
+					Preferred:        true,
+				})
+			}
 
 			// Create new manager
 			sDir := t.TempDir()
@@ -184,7 +203,8 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 			}
 
 			// Re-create manager to simulate restart
-			mgr2, err := NewManager(logger, string(PolicyTypeStatic), &machineInfo, nodeAllocatableReservation, systemReservedMemory, sDir, affinity)
+			restoredAffinity := topologymanager.NewFakeManager(logger)
+			mgr2, err := NewManager(logger, string(PolicyTypeStatic), &machineInfo, nodeAllocatableReservation, systemReservedMemory, sDir, restoredAffinity)
 			if err != nil {
 				t.Fatalf("could not create manager 2: %v", err)
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig node

#### What this PR does / why we need it:

Adds restore coverage for a pod allocated on NUMA node 1. The restarted Memory Manager uses an empty topology affinity store, so the regenerated hint must come from the checkpointed memory blocks rather than the original allocation hint.

This follows up on the review comment left after #141070 was merged: https://github.com/kubernetes/kubernetes/pull/141070#discussion_r3768460038

#### Which issue(s) this PR is related to:

#141069

#### Special notes for your reviewer:

The focused restore test, the full Memory Manager package tests, and the restore test with the race detector pass locally.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
