### PR TITLE
Fix ResourceFieldSelector.Divisor doc: unset or 0 means unscaled

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -11736,7 +11736,7 @@
         },
         "divisor": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
-          "description": "Specifies the output format of the exposed resources, defaults to \"1\""
+          "description": "Divisor optionally indicates how the resource from the container should be scaled. If unset or 0, the resource is not scaled (divisor is treated as 1)."
         },
         "resource": {
           "description": "Required: resource to select",

--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -6779,7 +6779,7 @@
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
               }
             ],
-            "description": "Specifies the output format of the exposed resources, defaults to \"1\""
+            "description": "Divisor optionally indicates how the resource from the container should be scaled. If unset or 0, the resource is not scaled (divisor is treated as 1)."
           },
           "resource": {
             "default": "",

--- a/api/openapi-spec/v3/apis__apps__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apps__v1_openapi.json
@@ -4333,7 +4333,7 @@
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
               }
             ],
-            "description": "Specifies the output format of the exposed resources, defaults to \"1\""
+            "description": "Divisor optionally indicates how the resource from the container should be scaled. If unset or 0, the resource is not scaled (divisor is treated as 1)."
           },
           "resource": {
             "default": "",

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -3595,7 +3595,7 @@
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
               }
             ],
-            "description": "Specifies the output format of the exposed resources, defaults to \"1\""
+            "description": "Divisor optionally indicates how the resource from the container should be scaled. If unset or 0, the resource is not scaled (divisor is treated as 1)."
           },
           "resource": {
             "default": "",

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -2490,7 +2490,8 @@ type ResourceFieldSelector struct {
 	ContainerName string
 	// Required: resource to select
 	Resource string
-	// Specifies the output format of the exposed resources, defaults to "1"
+	// Divisor optionally indicates how the resource from the container should be scaled.
+	// If unset or 0, the resource is not scaled (divisor is treated as 1).
 	// +optional
 	Divisor resource.Quantity
 }

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -30860,7 +30860,7 @@ func schema_k8sio_api_core_v1_ResourceFieldSelector(ref common.ReferenceCallback
 					},
 					"divisor": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Specifies the output format of the exposed resources, defaults to \"1\"",
+							Description: "Divisor optionally indicates how the resource from the container should be scaled. If unset or 0, the resource is not scaled (divisor is treated as 1).",
 							Ref:         ref(resource.Quantity{}.OpenAPIModelName()),
 						},
 					},

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -5861,7 +5861,8 @@ message ResourceFieldSelector {
   // Required: resource to select
   optional string resource = 2;
 
-  // Specifies the output format of the exposed resources, defaults to "1"
+  // Divisor optionally indicates how the resource from the container should be scaled.
+  // If unset or 0, the resource is not scaled (divisor is treated as 1).
   // +optional
   optional .k8s.io.apimachinery.pkg.api.resource.Quantity divisor = 3;
 }

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2811,7 +2811,8 @@ type ResourceFieldSelector struct {
 	ContainerName string `json:"containerName,omitempty" protobuf:"bytes,1,opt,name=containerName"`
 	// Required: resource to select
 	Resource string `json:"resource" protobuf:"bytes,2,opt,name=resource"`
-	// Specifies the output format of the exposed resources, defaults to "1"
+	// Divisor optionally indicates how the resource from the container should be scaled.
+	// If unset or 0, the resource is not scaled (divisor is treated as 1).
 	// +optional
 	Divisor resource.Quantity `json:"divisor,omitempty" protobuf:"bytes,3,opt,name=divisor"`
 }

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -2306,7 +2306,7 @@ var map_ResourceFieldSelector = map[string]string{
 	"":              "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
 	"containerName": "Container name: required for volumes, optional for env vars",
 	"resource":      "Required: resource to select",
-	"divisor":       "Specifies the output format of the exposed resources, defaults to \"1\"",
+	"divisor":       "Divisor optionally indicates how the resource from the container should be scaled. If unset or 0, the resource is not scaled (divisor is treated as 1).",
 }
 
 func (ResourceFieldSelector) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcefieldselector.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcefieldselector.go
@@ -31,7 +31,8 @@ type ResourceFieldSelectorApplyConfiguration struct {
 	ContainerName *string `json:"containerName,omitempty"`
 	// Required: resource to select
 	Resource *string `json:"resource,omitempty"`
-	// Specifies the output format of the exposed resources, defaults to "1"
+	// Divisor optionally indicates how the resource from the container should be scaled.
+	// If unset or 0, the resource is not scaled (divisor is treated as 1).
 	Divisor *resource.Quantity `json:"divisor,omitempty"`
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

The doc comment on `ResourceFieldSelector.Divisor` says the field "defaults to 1". It does not: there is no server-side defaulting for the field, so an object written without a divisor is read back with an explicit `0`. Only when the value is consumed do the helpers treat an unset or `0` divisor as `1` (a divisor of 0 is meaningless). The mismatch between the comment and the persisted value has confused users of GitOps tooling that diffs live objects against manifests.

This updates the comment in `pkg/apis/core/types.go` and `staging/src/k8s.io/api/core/v1/types.go` to the wording the API approver proposed in the issue, describing both meanings, and regenerates the derived docs (protobuf comments, swagger doc strings, applyconfigurations, OpenAPI specs). The approver preferred a documentation fix over changing defaulting or serialization, since that would make consecutive API server versions default and serialize the same persisted resource differently.

#### Which issue(s) this PR is related to:

Fixes #128865

#### Special notes for your reviewer:

@soltysh, pinging you per your offer in the issue to shepherd this through. This is a comment-only change with regenerated docs; no API behaviour, defaulting, validation, or serialization changes. The change was drafted with an AI coding agent under my direction; I reviewed the diff and ran the generators and verify scripts.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
