### PR TITLE
Automated cherry pick of #141648: fix: make nil DeviceTaintSelector match no devices (tracker)

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
@@ -380,7 +380,11 @@ func sliceDriverPoolDeviceIndexFunc(slice *resourceapi.ResourceSlice) ([]string,
 }
 
 func driverPoolDeviceIndexPatchKey(patch *resourceapi.DeviceTaintRule) string {
-	deviceSelector := ptr.Deref(patch.Spec.DeviceSelector, resourceapi.DeviceTaintSelector{})
+	deviceSelector := patch.Spec.DeviceSelector
+	if deviceSelector == nil {
+		// No selector matches no devices, so it matches no slices.
+		return ""
+	}
 	driverKey := ptr.Deref(deviceSelector.Driver, anyDriver)
 	poolKey := ptr.Deref(deviceSelector.Pool, anyPool)
 	deviceKey := ptr.Deref(deviceSelector.Device, anyDevice)
@@ -578,18 +582,20 @@ func (t *Tracker) applyPatches(ctx context.Context, slice *resourceapi.ResourceS
 		logger.V(6).Info("processing DeviceTaintRule")
 
 		deviceSelector := taintRule.Spec.DeviceSelector
-		var deviceName *string
-		if deviceSelector != nil {
-			if deviceSelector.Driver != nil && *deviceSelector.Driver != slice.Spec.Driver {
-				logger.V(7).Info("DeviceTaintRule does not apply, mismatched driver", "sliceDriver", slice.Spec.Driver, "taintDriver", *deviceSelector.Driver)
-				continue
-			}
-			if deviceSelector.Pool != nil && *deviceSelector.Pool != slice.Spec.Pool.Name {
-				logger.V(7).Info("DeviceTaintRule does not apply, mismatched pool", "slicePool", slice.Spec.Pool.Name, "taintPool", *deviceSelector.Pool)
-				continue
-			}
-			deviceName = deviceSelector.Device
+		if deviceSelector == nil {
+			// No selector matches no devices.
+			logger.V(7).Info("DeviceTaintRule does not apply, no selector")
+			continue
 		}
+		if deviceSelector.Driver != nil && *deviceSelector.Driver != slice.Spec.Driver {
+			logger.V(7).Info("DeviceTaintRule does not apply, mismatched driver", "sliceDriver", slice.Spec.Driver, "taintDriver", *deviceSelector.Driver)
+			continue
+		}
+		if deviceSelector.Pool != nil && *deviceSelector.Pool != slice.Spec.Pool.Name {
+			logger.V(7).Info("DeviceTaintRule does not apply, mismatched pool", "slicePool", slice.Spec.Pool.Name, "taintPool", *deviceSelector.Pool)
+			continue
+		}
+		deviceName := deviceSelector.Device
 		for dIndex, device := range slice.Spec.Devices {
 			deviceID := deviceID(slice.Spec.Driver, slice.Spec.Pool.Name, device.Name)
 			logger := logger.WithValues("device", deviceID)

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker_test.go
@@ -278,6 +278,15 @@ var (
 			Name: "rule",
 		},
 		Spec: resourceapi.DeviceTaintRuleSpec{
+			DeviceSelector: &resourceapi.DeviceTaintSelector{},
+			Taint:          deviceTaint(deviceTaint1),
+		},
+	}
+	taintNoSelectorRule = &resourceapi.DeviceTaintRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "rule-no-selector",
+		},
+		Spec: resourceapi.DeviceTaintRuleSpec{
 			Taint: deviceTaint(deviceTaint1),
 		},
 	}
@@ -560,6 +569,21 @@ func TestListPatchedResourceSlices(t *testing.T) {
 				{event: handlerEventUpdate, oldObj: sliceWithDevices(slice2, threeDevicesOneTainted), newObj: sliceWithDevices(slice2, taintedDevices)},
 			},
 		},
+		"nil-selector-matches-none": {
+			events: []any{
+				add(slice1),
+				add(slice2),
+				add(taintNoSelectorRule),
+			},
+			expectedPatchedSlices: []*resourceapi.ResourceSlice{
+				slice1,
+				slice2,
+			},
+			expectedHandlerEvents: []handlerEvent{
+				{event: handlerEventAdd, newObj: slice1},
+				{event: handlerEventAdd, newObj: slice2},
+			},
+		},
 	}
 
 	setup := func(t *testing.T) *testContext {
@@ -780,7 +804,7 @@ func BenchmarkEventHandlers(b *testing.B) {
 						Name: "taintRule",
 					},
 					Spec: resourceapi.DeviceTaintRuleSpec{
-						DeviceSelector: nil, // all slices
+						DeviceSelector: &resourceapi.DeviceTaintSelector{}, // all slices
 						Taint: resourceapi.DeviceTaint{
 							Key:       "example.com/taint",
 							Value:     "tainted",
@@ -815,7 +839,7 @@ func BenchmarkEventHandlers(b *testing.B) {
 						Name: "taintRule",
 					},
 					Spec: resourceapi.DeviceTaintRuleSpec{
-						DeviceSelector: nil, // all slices
+						DeviceSelector: &resourceapi.DeviceTaintSelector{}, // all slices
 						Taint: resourceapi.DeviceTaint{
 							Key:       "example.com/taint",
 							Value:     "tainted",


### PR DESCRIPTION
Cherry pick of #141648 on release-1.37.

#141648: fix: make nil DeviceTaintSelector match no devices (tracker)

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
Fixed a bug where a DeviceTaintRule with no `spec.deviceSelector` incorrectly matched every device cluster-wide and made all DRA devices unschedulable for `NoSchedule` or `NoExecute` taints. The rule now correctly matches no devices as documented. Use an explicit empty selector (`deviceSelector: {}`) to target all devices.
```