### PR TITLE
Handle resource request overflow in the HPA replica calculator

### DIFF
--- a/pkg/controller/podautoscaler/replica_calculator.go
+++ b/pkg/controller/podautoscaler/replica_calculator.go
@@ -514,7 +514,11 @@ func calculatePodLevelRequests(pod *v1.Pod, resource v1.ResourceName) (int64, er
 	if !ok {
 		return 0, fmt.Errorf("missing pod-level request for %s in Pod %s", resource, pod.Name)
 	}
-	return podRequest.MilliValue(), nil
+	request, ok := podRequest.AsMilliInt64()
+	if !ok {
+		return 0, fmt.Errorf("pod-level request for %s in Pod %s exceeds the int64 milli-unit range", resource, pod.Name)
+	}
+	return request, nil
 }
 
 // calculatePodRequestsFromContainers computes the requests for the specified
@@ -535,7 +539,16 @@ func calculatePodRequestsFromContainers(pod *v1.Pod, container string, resource 
 			if !ok {
 				return 0, fmt.Errorf("missing request for %s in container %s of Pod %s", resource, c.Name, pod.Name)
 			}
-			request += containerRequest.MilliValue()
+			containerValue, ok := containerRequest.AsMilliInt64()
+			if !ok {
+				return 0, fmt.Errorf("request for %s in container %s of Pod %s exceeds the int64 milli-unit range", resource, c.Name, pod.Name)
+			}
+			// Requests are non-negative. Check the sum as well as each conversion
+			// so an overflow cannot become a negative utilization denominator.
+			if containerValue > math.MaxInt64-request {
+				return 0, fmt.Errorf("total request for %s in Pod %s exceeds the int64 milli-unit range", resource, pod.Name)
+			}
+			request += containerValue
 		}
 		// container names are unique inside the pod
 		if container == c.Name {

--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -2538,3 +2538,61 @@ func TestGetPerPodUsage(t *testing.T) {
 		})
 	}
 }
+
+func TestCalculateRequestsOverflow(t *testing.T) {
+	for _, resourceName := range []v1.ResourceName{v1.ResourceCPU, v1.ResourceMemory} {
+		t.Run(string(resourceName), func(t *testing.T) {
+			for _, tc := range []struct {
+				name      string
+				values    []string
+				podLevel  bool
+				sidecar   bool
+				container string
+				want      int64
+				wantError bool
+			}{
+				{name: "sum at limit", values: []string{"9223372036854775806m", "1m"}, want: math.MaxInt64},
+				{name: "sum exceeds limit", values: []string{"4611686018427387904m", "4611686018427387904m"}, wantError: true},
+				{name: "sidecar sum exceeds limit", values: []string{"4611686018427387904m", "4611686018427387904m"}, sidecar: true, wantError: true},
+				{name: "container exceeds limit", values: []string{"9223372036854775808m"}, wantError: true},
+				{name: "pod request at limit", values: []string{"9223372036854775807m"}, podLevel: true, want: math.MaxInt64},
+				{name: "pod request exceeds limit", values: []string{"9223372036854775808m"}, podLevel: true, wantError: true},
+				{name: "selected container excludes other requests", values: []string{"1m", "9223372036854775808m"}, container: "c0", want: 1},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, tc.podLevel)
+					pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod"}}
+					for i, value := range tc.values {
+						c := v1.Container{Name: fmt.Sprintf("c%d", i), Resources: v1.ResourceRequirements{Requests: v1.ResourceList{resourceName: resource.MustParse(value)}}}
+						if tc.podLevel {
+							pod.Spec.Resources = &c.Resources
+						} else if tc.sidecar && i == 1 {
+							policy := v1.ContainerRestartPolicyAlways
+							c.RestartPolicy = &policy
+							pod.Spec.InitContainers = append(pod.Spec.InitContainers, c)
+						} else {
+							pod.Spec.Containers = append(pod.Spec.Containers, c)
+						}
+					}
+					got, err := calculateRequests([]*v1.Pod{pod}, tc.container, resourceName)
+					if tc.wantError {
+						if err == nil {
+							t.Fatalf("expected unrepresentable request to return an error, got %v", got)
+						}
+						assert.ErrorContains(t, err, "exceeds the int64 milli-unit range")
+						if got != nil {
+							t.Fatalf("expected no requests on error, got %v", got)
+						}
+						return
+					}
+					if err != nil {
+						t.Fatal(err)
+					}
+					if got[pod.Name] != tc.want {
+						t.Fatalf("request = %d, want %d", got[pod.Name], tc.want)
+					}
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig autoscaling

#### What this PR does / why we need it:

The HPA replica calculator sums container resource requests in milli-units using unchecked `int64` arithmetic. Two requests of `4611686018427387904m` each are individually representable, but their sum wraps to `-9223372036854775808`. That negative total is then passed to the resource utilization calculation.

Individual requests have a related problem: `MilliValue()` saturates when the quantity cannot be represented, without telling the caller that precision was lost.

This change uses `AsMilliInt64()` to check pod-level and container-level requests, and checks for overflow before adding container requests. If a value cannot be represented, the calculator returns an error through its existing error path rather than calculating utilization from an incorrect request.

Requests within the supported range retain their existing behavior.

#### Which issue(s) this PR is related to:

Related to #141166.

#### Special notes for your reviewer:

The proposed behavior is to report an error for an unrepresentable request rather than cap the utilization denominator, which would change the ratio.

Regression coverage includes CPU and memory requests, sums at and above the `int64` boundary, restartable init containers, pod-level requests, and selection of a single container.

Against the original code, the overflow cases fail: sums wrap to a negative value, while oversized individual requests silently saturate.

Validation completed with Go 1.27.0:

* `go test -p=4 ./pkg/controller/podautoscaler/... -count=1`
* `gofmt` on both changed files
* `git diff --check`

The full repository verification and integration suites have not been run locally.

#### Does this PR introduce a user-facing change?

```release-note
The HorizontalPodAutoscaler now reports an error when resource requests or their per-Pod container sum exceed the int64 milli-unit range, instead of calculating resource utilization from saturated or overflowed request values.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
