### PR TITLE
apiserver: use atomic types for atomic operations

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -2283,11 +2283,11 @@ func TestStoreDeletionPropagation(t *testing.T) {
 type storageWithCounter struct {
 	storage.Interface
 
-	listCounter int64
+	listCounter atomic.Int64
 }
 
 func (s *storageWithCounter) GetList(ctx context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
-	atomic.AddInt64(&s.listCounter, 1)
+	s.listCounter.Add(1)
 	return s.Interface.GetList(ctx, key, opts, listObj)
 }
 
@@ -2324,7 +2324,7 @@ func TestStoreDeleteCollection(t *testing.T) {
 		t.Errorf("Unexpected number of pods deleted: %d, expected: %d", len(deletedPods.Items), numPods)
 	}
 	expectedCalls := (int64(numPods) + deleteCollectionPageSize - 1) / deleteCollectionPageSize
-	if listCalls := atomic.LoadInt64(&storeWithCounter.listCounter); listCalls != expectedCalls {
+	if listCalls := storeWithCounter.listCounter.Load(); listCalls != expectedCalls {
 		t.Errorf("Unexpected number of list calls: %d, expected: %d", listCalls, expectedCalls)
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -284,7 +284,7 @@ type storeWithPrefixTransformer struct {
 
 func (s *storeWithPrefixTransformer) UpdatePrefixTransformer(modifier storagetesting.PrefixTransformerModifier) func() {
 	originalTransformer := s.transformer.(*storagetesting.PrefixTransformer)
-	transformer := *originalTransformer
+	transformer := *storagetesting.CopyPrefixTransformer(originalTransformer)
 	s.transformer = modifier(&transformer)
 	s.watcher.transformer = modifier(&transformer)
 	return func() {

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory_test.go
@@ -374,13 +374,12 @@ func TestTimeTravelHealthcheck(t *testing.T) {
 	signal := make(chan struct{})
 	probeStarted := make(chan struct{})
 
-	var counter uint64
+	var counter atomic.Uint64
 	newETCD3Client = func(c storagebackend.TransportConfig) (*kubernetes.Client, error) {
 		defer close(ready)
 		dummyKV := mockKV{
 			get: func(ctx context.Context) (*clientv3.GetResponse, error) {
-				atomic.AddUint64(&counter, 1)
-				val := atomic.LoadUint64(&counter)
+				val := counter.Add(1)
 				// the first request wait for a custom timeout to trigger an error.
 				// We don't use the context timeout because we want to check that
 				// the cached answer is not overridden, and since the rate limit is
@@ -436,7 +435,7 @@ func TestTimeTravelHealthcheck(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	c := atomic.LoadUint64(&counter)
+	c := counter.Load()
 	if c != 2 {
 		t.Errorf("healthcheck() called etcd %d times, expected only two calls", c)
 	}
@@ -447,7 +446,7 @@ func TestTimeTravelHealthcheck(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	c = atomic.LoadUint64(&counter)
+	c = counter.Load()
 	if c != 2 {
 		t.Errorf("healthcheck() called etcd %d times, expected only two calls", c)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/recorder.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/recorder.go
@@ -28,8 +28,8 @@ import (
 type KVRecorder struct {
 	clientv3.KV
 
-	reads       uint64
-	streamReads uint64
+	reads       atomic.Uint64
+	streamReads atomic.Uint64
 	lists       *KubernetesRecorder
 }
 
@@ -38,16 +38,16 @@ func NewKVRecorder(kv clientv3.KV, lists *KubernetesRecorder) *KVRecorder {
 }
 
 func (r *KVRecorder) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
-	atomic.AddUint64(&r.reads, 1)
+	r.reads.Add(1)
 	return r.KV.Get(ctx, key, opts...)
 }
 
 func (r *KVRecorder) GetReadsAndReset() uint64 {
-	return atomic.SwapUint64(&r.reads, 0)
+	return r.reads.Swap(0)
 }
 
 func (r *KVRecorder) GetStream(ctx context.Context, key string, opts ...clientv3.OpOption) (clientv3.GetStreamChan, error) {
-	atomic.AddUint64(&r.streamReads, 1)
+	r.streamReads.Add(1)
 	if r.lists != nil {
 		op := clientv3.OpGet(key, opts...)
 		r.lists.record(ctx, RecordedList{Key: key, Revision: op.Rev(), Limit: op.Limit()})
@@ -56,7 +56,7 @@ func (r *KVRecorder) GetStream(ctx context.Context, key string, opts ...clientv3
 }
 
 func (r *KVRecorder) GetStreamReadsAndReset() uint64 {
-	return atomic.SwapUint64(&r.streamReads, 0)
+	return r.streamReads.Swap(0)
 }
 
 type KubernetesRecorder struct {

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/utils.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/utils.go
@@ -308,7 +308,7 @@ type PrefixTransformer struct {
 	prefix []byte
 	stale  bool
 	err    error
-	reads  uint64
+	reads  atomic.Uint64
 }
 
 func NewPrefixTransformer(prefix []byte, stale bool) *PrefixTransformer {
@@ -318,8 +318,18 @@ func NewPrefixTransformer(prefix []byte, stale bool) *PrefixTransformer {
 	}
 }
 
+func CopyPrefixTransformer(source *PrefixTransformer) *PrefixTransformer {
+	copy := &PrefixTransformer{
+		prefix: source.prefix,
+		stale:  source.stale,
+		err:    source.err,
+	}
+	copy.reads.Store(source.reads.Load())
+	return copy
+}
+
 func (p *PrefixTransformer) TransformFromStorage(ctx context.Context, data []byte, dataCtx value.Context) ([]byte, bool, error) {
-	atomic.AddUint64(&p.reads, 1)
+	p.reads.Add(1)
 	if dataCtx == nil {
 		panic("no context provided")
 	}
@@ -339,7 +349,7 @@ func (p *PrefixTransformer) TransformToStorage(ctx context.Context, data []byte,
 }
 
 func (p *PrefixTransformer) GetReadsAndReset() uint64 {
-	return atomic.SwapUint64(&p.reads, 0)
+	return p.reads.Swap(0)
 }
 
 // reproducingTransformer is a custom test-only transformer used purely
@@ -351,7 +361,7 @@ type reproducingTransformer struct {
 	wrapped value.Transformer
 	store   storage.Interface
 
-	index      uint32
+	index      atomic.Uint32
 	nextObject func(uint32) (string, *example.Pod)
 }
 
@@ -367,7 +377,7 @@ func (rt *reproducingTransformer) TransformToStorage(ctx context.Context, data [
 }
 
 func (rt *reproducingTransformer) createObject(ctx context.Context) error {
-	key, obj := rt.nextObject(atomic.AddUint32(&rt.index, 1))
+	key, obj := rt.nextObject(rt.index.Add(1))
 	out := &example.Pod{}
 	return rt.store.Create(ctx, key, obj, out, 0)
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/client_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/client_test.go
@@ -121,11 +121,11 @@ func (f *fakeAuthInfoResolver) ClientConfigForService(serviceName, namespace str
 // fakeDynamicServiceResolver returns the next endpoint in the list for each request.
 type fakeDynamicServiceResolver struct {
 	endpoints []*url.URL
-	counter   int32
+	counter   atomic.Int32
 }
 
 func (f *fakeDynamicServiceResolver) ResolveEndpoint(namespace, name string, port int32) (*url.URL, error) {
-	val := atomic.AddInt32(&f.counter, 1) - 1
+	val := f.counter.Add(1) - 1
 	if val >= int32(len(f.endpoints)) {
 		val = int32(len(f.endpoints)) - 1
 	}
@@ -162,17 +162,17 @@ func TestWebhookClientIdleConnectionIPReuse(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WebhookRoundTripLoadBalancing, tc.enableFeatureGate)
 
-			var serverACalls int32
+			var serverACalls atomic.Int32
 			serverA := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				atomic.AddInt32(&serverACalls, 1)
+				serverACalls.Add(1)
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte("ServerA"))
 			}))
 			defer serverA.Close()
 
-			var serverBCalls int32
+			var serverBCalls atomic.Int32
 			serverB := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				atomic.AddInt32(&serverBCalls, 1)
+				serverBCalls.Add(1)
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte("ServerB"))
 			}))
@@ -242,10 +242,10 @@ func TestWebhookClientIdleConnectionIPReuse(t *testing.T) {
 				t.Errorf("Expected Response %s, got %s", tc.expectedSecondResponse, string(res2))
 			}
 
-			if callsA := atomic.LoadInt32(&serverACalls); callsA != tc.expectedServerACalls {
+			if callsA := serverACalls.Load(); callsA != tc.expectedServerACalls {
 				t.Errorf("Expected %d calls to Server A, got %d", tc.expectedServerACalls, callsA)
 			}
-			if callsB := atomic.LoadInt32(&serverBCalls); callsB != tc.expectedServerBCalls {
+			if callsB := serverBCalls.Load(); callsB != tc.expectedServerBCalls {
 				t.Errorf("Expected %d calls to Server B, got %d", tc.expectedServerBCalls, callsB)
 			}
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Go now provides atomic types; instead of using plain integer fields with atomic operations, with the risk of missing direct access to the fields, using atomic types ensures that no non-atomic operations are performed.

Atomic types also prevent copying; the PrefixTransformer tests copy the transformers, so this introduces a copy function which creates a new counter initialised with the original value. The two resulting counters will then count separately.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

NO.