### PR TITLE
DRA kubeletplugin: shorten rolling service socket paths

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
@@ -60,7 +60,7 @@ const (
 	unixPathMax = 108
 
 	// rollingUpdateUIDHashBytes is how much of the SHA-256 digest of a pod UID
-	// is base64-encoded when the full UID does not fit in the registration socket
+	// is base64-encoded when the full UID does not fit in a rolling-update socket
 	// path. 8 bytes (64 bits) is ample for node-local uniqueness during rolling
 	// updates.
 	rollingUpdateUIDHashBytes = 8
@@ -95,6 +95,21 @@ func RollingUpdateRegistrarSocketFile(registryDir, driverName string, podUID typ
 		}
 	}
 	return candidates[len(candidates)-1]
+}
+
+// rollingUpdatePluginSocketFile returns the automatic DRA service socket
+// basename for rolling updates. Keep the pod UID visible when possible. The
+// fallback omits the ".sock" suffix so that the shortened basename also fits
+// with the longest valid driver name under the default plugin directory.
+func rollingUpdatePluginSocketFile(pluginDir string, podUID types.UID) string {
+	uid := string(podUID)
+	basename := "dra-" + uid + ".sock"
+	if len(path.Join(pluginDir, basename)) < unixPathMax {
+		return basename
+	}
+
+	uidHash := sha256Sum(uid)
+	return "dra-" + base64.RawURLEncoding.EncodeToString(uidHash[:rollingUpdateUIDHashBytes])
 }
 
 func sha256Sum(data string) [32]byte {
@@ -447,9 +462,9 @@ func PluginListener(listen func(ctx context.Context, path string) (net.Listener,
 // in parallel while a newer instance replaces the older. When enabled, both
 // instances must share the same plugin data directory and driver name.
 // They create different registration sockets (and DRA gRPC sockets) so the
-// kubelet can connect to both at the same time. The default registration socket
-// basename is chosen to fit within AF_UNIX path limits (see
-// [RollingUpdateRegistrarSocketFile]).
+// kubelet can connect to both at the same time. Automatic socket basenames are
+// shortened when necessary to keep the default paths within AF_UNIX limits
+// (see [RollingUpdateRegistrarSocketFile] for registration socket naming).
 //
 // There is no guarantee which of the two instances are used by kubelet.
 // For example, it can happen that a claim gets prepared by one instance
@@ -922,10 +937,6 @@ func Start(ctx context.Context, plugin DRAPlugin, opts ...Option) (result *Helpe
 	if o.rollingUpdateUID != "" && o.pluginRegistrationEndpoint.file != "" {
 		return nil, errors.New("rolling updates and explicit registration socket filename are mutually exclusive")
 	}
-	uidPart := ""
-	if o.rollingUpdateUID != "" {
-		uidPart = "-" + string(o.rollingUpdateUID)
-	}
 	if o.pluginRegistrationEndpoint.file == "" {
 		if o.rollingUpdateUID != "" {
 			o.pluginRegistrationEndpoint.file = RollingUpdateRegistrarSocketFile(o.pluginRegistrationEndpoint.dir, o.driverName, o.rollingUpdateUID)
@@ -937,7 +948,11 @@ func Start(ctx context.Context, plugin DRAPlugin, opts ...Option) (result *Helpe
 		o.pluginDataDirectoryPath = path.Join(KubeletPluginsDir, o.driverName)
 	}
 	if o.pluginSocket == "" {
-		o.pluginSocket = "dra" + uidPart + ".sock" // "dra" is hard-coded. The directory is unique, so we get a unique full path also without the UID.
+		if o.rollingUpdateUID != "" {
+			o.pluginSocket = rollingUpdatePluginSocketFile(o.pluginDataDirectoryPath, o.rollingUpdateUID)
+		} else {
+			o.pluginSocket = "dra.sock" // "dra" is hard-coded. The directory is unique, so we get a unique full path also without the UID.
+		}
 	}
 
 	d := &Helper{

--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin_test.go
@@ -18,6 +18,10 @@ package kubeletplugin
 
 import (
 	"context"
+	"errors"
+	"net"
+	"path"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,6 +32,7 @@ import (
 
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes/fake"
 	drahealthv1 "k8s.io/kubelet/pkg/apis/dra-health/v1"
 )
@@ -97,6 +102,84 @@ func TestStartWithoutDRAAPI(t *testing.T) {
 		NodeV1beta1(false),
 	)
 	require.ErrorContains(t, err, "no supported DRA gRPC API")
+}
+
+func TestRollingUpdatePluginSocketPathLength(t *testing.T) {
+	podUID := types.UID("11111111-2222-3333-4444-555555555555")
+	for _, tc := range []struct {
+		name            string
+		driverName      string
+		driverLen       int
+		fullEndpointLen int
+	}{
+		{name: "36-byte driver", driverName: "abcde.dra-example-driver.sigs.k8s.io", driverLen: 36, fullEndpointLen: 107},
+		{name: "37-byte driver", driverName: "abcdef.dra-example-driver.sigs.k8s.io", driverLen: 37, fullEndpointLen: 108},
+		{name: "63-byte driver", driverName: "a." + strings.Repeat("a", 61), driverLen: 63, fullEndpointLen: 134},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Len(t, tc.driverName, tc.driverLen)
+			require.Empty(t, validation.IsDNS1123Subdomain(tc.driverName))
+
+			fullUIDEndpoint := path.Join(KubeletPluginsDir, tc.driverName, "dra-"+string(podUID)+".sock")
+			require.Len(t, fullUIDEndpoint, tc.fullEndpointLen)
+			pluginEndpoint := capturePluginEndpoint(t, tc.driverName, RollingUpdate(podUID))
+			require.Lessf(t, len(pluginEndpoint), unixPathMax, "DRA plugin endpoint %q must be shorter than %d bytes", pluginEndpoint, unixPathMax)
+			if tc.fullEndpointLen < unixPathMax {
+				require.Equal(t, fullUIDEndpoint, pluginEndpoint)
+			} else {
+				require.NotEqual(t, fullUIDEndpoint, pluginEndpoint)
+			}
+		})
+	}
+}
+
+func TestPluginSocketAutomaticNaming(t *testing.T) {
+	podUID := types.UID("11111111-2222-3333-4444-555555555555")
+	shortDriverName := "driver.example.com"
+	require.Empty(t, validation.IsDNS1123Subdomain(shortDriverName))
+	t.Run("non-rolling", func(t *testing.T) {
+		driverName := "a." + strings.Repeat("a", 61)
+		got := capturePluginEndpoint(t, driverName)
+		require.Equal(t, path.Join(KubeletPluginsDir, driverName, "dra.sock"), got)
+	})
+	t.Run("rolling with short driver", func(t *testing.T) {
+		got := capturePluginEndpoint(t, shortDriverName, RollingUpdate(podUID))
+		require.Equal(t, path.Join(KubeletPluginsDir, shortDriverName, "dra-"+string(podUID)+".sock"), got)
+	})
+	t.Run("explicit with rolling", func(t *testing.T) {
+		got := capturePluginEndpoint(t, shortDriverName, RollingUpdate(podUID), PluginSocket("custom.sock"))
+		require.Equal(t, path.Join(KubeletPluginsDir, shortDriverName, "custom.sock"), got)
+	})
+}
+
+func TestRollingUpdatePluginSocketFile_distinctInputs(t *testing.T) {
+	driverName := "a." + strings.Repeat("a", 61)
+	pluginDir := path.Join(KubeletPluginsDir, driverName)
+	first := rollingUpdatePluginSocketFile(pluginDir, "11111111-2222-3333-4444-555555555555")
+	second := rollingUpdatePluginSocketFile(pluginDir, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+	require.Equal(t, first, rollingUpdatePluginSocketFile(pluginDir, "11111111-2222-3333-4444-555555555555"))
+	require.NotEqual(t, first, second)
+	require.Less(t, len(path.Join(pluginDir, first)), unixPathMax)
+	require.Less(t, len(path.Join(pluginDir, second)), unixPathMax)
+}
+
+func capturePluginEndpoint(t *testing.T, driverName string, opts ...Option) string {
+	t.Helper()
+	var pluginEndpoint string
+	listenerErr := errors.New("listener disabled")
+	opts = append(opts,
+		DriverName(driverName),
+		KubeClient(fake.NewClientset()),
+		RegistrationService(false),
+		PluginListener(func(_ context.Context, endpoint string) (net.Listener, error) {
+			pluginEndpoint = endpoint
+			return nil, listenerErr
+		}),
+	)
+	_, err := Start(t.Context(), &stubPlugin{}, opts...)
+	require.ErrorIs(t, err, listenerErr)
+	return pluginEndpoint
 }
 
 // fakeHealthStream captures the responses sent by the helper's gRPC bridge.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node
/wg device-management

#### What this PR does / why we need it:

With `RollingUpdate`, the DRA kubelet plugin helper normally uses `dra-<Pod UID>.sock` for the automatic service socket. The default plugin directory also contains the full driver name, so a valid 37-byte driver name makes the full endpoint exactly 108 bytes and therefore unusable as a pathname-based AF_UNIX socket.

This change preserves `dra-<Pod UID>.sock` whenever the full path fits. If it would exceed the AF_UNIX limit, the helper switches to a deterministic shortened basename containing 64 bits of the Pod UID's SHA-256 digest encoded with URL-safe, unpadded Base64. With the default directory and the maximum valid 63-byte driver name, the resulting endpoint is 104 bytes.

Non-rolling `dra.sock` naming, ordinary short-driver rolling naming, and explicit `PluginSocket` behavior remain unchanged. Arbitrary custom `PluginDataDirectoryPath` values are not guaranteed to fit.

#### Which issue(s) this PR is related to:

Fixes #142002

#### Special notes for your reviewer:

Related work is distinct: #139166 and #139623 addressed the rolling registration socket under `plugins_registry`; #139623 explicitly left `dra-<uid>.sock` service sockets unchanged. #141815 corrected the registration fallback's exact-108 boundary. #140837 added kubelet-side endpoint and driver validation, but does not prevent this helper from generating an invalid automatic service endpoint.

Verification on Kubernetes master `3af569e862d19a046cdfd63cda837f9bb29da6fa` with Go 1.27.1:

```console
go test ./staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin -run='Test(RollingUpdatePluginSocketPathLength|PluginSocketAutomaticNaming|RollingUpdatePluginSocketFile_distinctInputs)$' -count=1
go test ./staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin -count=1
go test -race ./staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin -count=1
go vet ./staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin
gofmt -d staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin_test.go
git diff --check
```

#### Does this PR introduce a user-facing change?

```release-note
Fixed DRA kubelet plugin helper rolling updates for drivers with long valid names by shortening automatic DRA service socket paths when needed.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

YES

AI tools were used to assist with source analysis, regression-test development, and code review. I manually reviewed and understood the changes, reproduced the regression before the production fix, and verified the fix with focused unit and race tests.
