### PR TITLE
kubelet: skip cgroup reads when the pod cgroup is gone

### DIFF
--- a/pkg/kubelet/kubelet_pod_level_resources_status_test.go
+++ b/pkg/kubelet/kubelet_pod_level_resources_status_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package kubelet
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -94,6 +95,7 @@ func TestConvertToAPIPodLevelResourcesStatus(t *testing.T) {
 			}
 
 			mockPCM := cmtesting.NewMockPodContainerManager(t)
+			mockPCM.EXPECT().Exists(pod).Return(true)
 			mockPCM.EXPECT().GetPodCgroupConfig(pod, v1.ResourceMemory).Return(nil, nil)
 			mockPCM.EXPECT().GetPodCgroupConfig(pod, v1.ResourceCPU).Return(cpuCfg, nil)
 
@@ -106,4 +108,68 @@ func TestConvertToAPIPodLevelResourcesStatus(t *testing.T) {
 			require.Equal(t, tc.expectedMilliCPU, got.Requests.Cpu().MilliValue())
 		})
 	}
+}
+
+func TestConvertToAPIPodLevelResourcesStatusMissingCgroup(t *testing.T) {
+	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+		features.PodLevelResources:                       true,
+		features.InPlacePodLevelResourcesVerticalScaling: true,
+	})
+
+	runningPod := func() *v1.Pod {
+		return &v1.Pod{
+			Spec: v1.PodSpec{
+				Resources: &v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("50m"),
+						v1.ResourceMemory: resource.MustParse("50Mi"),
+					},
+					Limits: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("100m"),
+						v1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				Containers: []v1.Container{{Name: "pause"}},
+			},
+			Status: v1.PodStatus{Phase: v1.PodRunning},
+		}
+	}
+
+	t.Run("skip cgroup read when pod cgroup is gone", func(t *testing.T) {
+		logger, _ := ktesting.NewTestContext(t)
+		pod := runningPod()
+
+		mockPCM := cmtesting.NewMockPodContainerManager(t)
+		mockPCM.EXPECT().Exists(pod).Return(false)
+
+		mockCM := cmtesting.NewMockContainerManager(t)
+		mockCM.EXPECT().NewPodContainerManager().Return(mockPCM)
+
+		kl := &Kubelet{containerManager: mockCM}
+		got := kl.convertToAPIPodLevelResourcesStatus(logger, pod, v1.PodStatus{})
+		require.NotNil(t, got)
+		require.Equal(t, int64(50), got.Requests.Cpu().MilliValue())
+		require.Equal(t, resource.MustParse("50Mi"), got.Requests[v1.ResourceMemory])
+		require.Equal(t, int64(100), got.Limits.Cpu().MilliValue())
+		require.Equal(t, resource.MustParse("100Mi"), got.Limits[v1.ResourceMemory])
+	})
+
+	t.Run("ENOENT from cgroup read is not fatal", func(t *testing.T) {
+		logger, _ := ktesting.NewTestContext(t)
+		pod := runningPod()
+
+		mockPCM := cmtesting.NewMockPodContainerManager(t)
+		mockPCM.EXPECT().Exists(pod).Return(true)
+		mockPCM.EXPECT().GetPodCgroupConfig(pod, v1.ResourceMemory).Return(nil, os.ErrNotExist)
+		mockPCM.EXPECT().GetPodCgroupConfig(pod, v1.ResourceCPU).Return(nil, os.ErrNotExist)
+
+		mockCM := cmtesting.NewMockContainerManager(t)
+		mockCM.EXPECT().NewPodContainerManager().Return(mockPCM)
+
+		kl := &Kubelet{containerManager: mockCM}
+		got := kl.convertToAPIPodLevelResourcesStatus(logger, pod, v1.PodStatus{})
+		require.NotNil(t, got)
+		require.Equal(t, int64(50), got.Requests.Cpu().MilliValue())
+		require.Equal(t, resource.MustParse("100Mi"), got.Limits[v1.ResourceMemory])
+	})
 }

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2225,17 +2225,22 @@ func (kl *Kubelet) convertToAPIPodLevelResourcesStatus(logger klog.Logger, alloc
 	// output inconsistent. We should decide if the information is useful enough to
 	//  outweigh the consistency issues,
 	pcm := kl.containerManager.NewPodContainerManager()
-	memoryConfig, err := pcm.GetPodCgroupConfig(allocatedPod, v1.ResourceMemory)
-	if err != nil {
-		logger.Error(err, "failed to read memory cgroup config for the pod", "podName", allocatedPod.Name)
+	var memoryConfig, cpuConfig *cm.ResourceConfig
+	// Phase stays Running through teardown after the pod cgroup is gone.
+	// Skip the read so that expected ENOENT is not logged at error level.
+	if pcm.Exists(allocatedPod) {
+		var err error
+		memoryConfig, err = pcm.GetPodCgroupConfig(allocatedPod, v1.ResourceMemory)
+		if err != nil {
+			logPodCgroupReadError(logger, err, "failed to read memory cgroup config for the pod", allocatedPod.Name)
+		}
+		cpuConfig, err = pcm.GetPodCgroupConfig(allocatedPod, v1.ResourceCPU)
+		if err != nil {
+			logPodCgroupReadError(logger, err, "failed to read cpu cgroup config for the pod", allocatedPod.Name)
+		}
 	}
+
 	memoryLimit := cm.MemoryLimitsFromConfig(memoryConfig)
-	cpuConfig, err := pcm.GetPodCgroupConfig(allocatedPod, v1.ResourceCPU)
-	if err != nil {
-		logger.Error(err, "failed to read memory cgroup limits for the pod", "podName", allocatedPod.Name)
-
-	}
-
 	cpuRequest := cm.CPURequestsFromConfig(cpuConfig)
 	cpuLimit := cm.CPULimitsFromConfig(cpuConfig)
 
@@ -2320,6 +2325,16 @@ func (kl *Kubelet) convertToAPIPodLevelResourcesStatus(logger klog.Logger, alloc
 	}
 
 	return resources
+}
+
+// logPodCgroupReadError logs a failed cgroup read. ENOENT is expected when
+// teardown races the Exists check, so it is not an error-level event.
+func logPodCgroupReadError(logger klog.Logger, err error, msg, podName string) {
+	if os.IsNotExist(err) {
+		logger.V(4).Info(msg, "err", err, "podName", podName)
+		return
+	}
+	logger.Error(err, msg, "podName", podName)
 }
 
 // convertToAPIContainerStatuses converts the given internal container


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node

#### What this PR does / why we need it:

`convertToAPIPodLevelResourcesStatus` only skipped the cgroup read when `Phase != Running`. During teardown the phase is still Running after the pod cgroup is gone, so `GetPodCgroupConfig` hits ENOENT and kubelet logs two error-level lines for pods that are already terminating.

Skip the read when `pcm.Exists(pod)` is false. If a race still returns `os.IsNotExist`, log it at V(4) instead of error. Also correct the CPU path log that said "memory".

#### Which issue(s) this PR is related to:

Fixes #141927

#### Special notes for your reviewer:

```
go test ./pkg/kubelet -count=1 -run 'TestConvertToAPIPodLevelResourcesStatus'
```

- existing v2 round-trip cases still pass (`Exists=true`)
- Running pod, cgroup already gone → no `GetPodCgroupConfig` call, spec resources used
- `GetPodCgroupConfig` returning `os.ErrNotExist` is not fatal

The CPU log typo is the same string noted on #141760. The Windows `not implemented` path there is out of scope.

#### Does this PR introduce a user-facing change?

```release-note
kubelet no longer logs an error when reading pod-level cgroup config for a pod whose cgroup has already been removed during teardown.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

Made with [Cursor](https://cursor.com)