### PR TITLE
kubectl: display kuberc aliases in help

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -343,6 +343,10 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 	pluginCommandGroup := plugin.GetPluginCommandGroup(cmds)
 	groups = append(groups, pluginCommandGroup)
 
+	// Add alias command group to the list of command groups.
+	aliasCommandGroup := kuberc.GetAliasesCommandGroup(cmds, pref, o.Arguments)
+	groups = append(groups, aliasCommandGroup)
+
 	templates.ActsAsRootCommand(cmds, filters, groups...)
 
 	utilcomp.SetFactoryForCompletion(f)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -343,8 +343,15 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 	pluginCommandGroup := plugin.GetPluginCommandGroup(cmds)
 	groups = append(groups, pluginCommandGroup)
 
+	// Prepare prefs to generate Aliases Command Group
+	prefs, err := pref.Read(o.Arguments, o.IOStreams.ErrOut)
+	if err != nil {
+		fmt.Fprintf(o.IOStreams.ErrOut, "error occurred while applying preferences %v\n", err)
+		os.Exit(1)
+	}
+
 	// Add alias command group to the list of command groups.
-	aliasCommandGroup := kuberc.GetAliasesCommandGroup(cmds, pref, o.Arguments)
+	aliasCommandGroup := kuberc.GetAliasesCommandGroup(cmds, prefs)
 	groups = append(groups, aliasCommandGroup)
 
 	templates.ActsAsRootCommand(cmds, filters, groups...)

--- a/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go
+++ b/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go
@@ -64,6 +64,11 @@ type PreferencesHandler interface {
 	Apply(rootCmd *cobra.Command, kubeConfigFlags *genericclioptions.ConfigFlags, args []string, errOut io.Writer) ([]string, error)
 }
 
+type cachedPreference struct {
+	value *config.Preference
+	read  bool
+}
+
 // Preferences stores the kuberc file coming either from environment variable
 // or file from set in flag or the default kuberc path.
 type Preferences struct {
@@ -72,9 +77,7 @@ type Preferences struct {
 	aliases map[string]struct{}
 	policy  clientcmdapi.PluginPolicy
 
-	// memoization (cache)
-	kuberc *config.Preference
-	read   bool
+	cache cachedPreference
 }
 
 // NewPreferences returns initialized Preferences object.
@@ -99,8 +102,8 @@ func (p *Preferences) AddFlags(flags *pflag.FlagSet) {
 }
 
 func (p *Preferences) Read(args []string, errOut io.Writer) (*config.Preference, error) {
-	if p.read {
-		return p.kuberc, nil
+	if p.cache.read {
+		return p.cache.value, nil
 	}
 
 	kubercPath, err := getExplicitKuberc(args)
@@ -119,14 +122,7 @@ func (p *Preferences) Read(args []string, errOut io.Writer) (*config.Preference,
 
 	p.convertPluginPolicy(kuberc)
 
-	err = p.validate(kuberc)
-	if err != nil {
-		return nil, err
-	}
-
-	p.kuberc = kuberc
-	p.read = true
-
+	p.cache = cachedPreference{value: kuberc, read: true}
 	return kuberc, nil
 }
 
@@ -142,6 +138,10 @@ func (p *Preferences) Apply(rootCmd *cobra.Command, kubeConfigFlags *genericclio
 		return args, err
 	} else if kuberc == nil {
 		return args, nil
+	}
+
+	if err = p.validate(kuberc); err != nil {
+		return nil, err
 	}
 
 	p.applyPluginPolicy(kubeConfigFlags, kuberc)
@@ -355,11 +355,13 @@ func (p *Preferences) applyAliases(rootCmd *cobra.Command, kuberc *config.Prefer
 		// We are appending the additional args defined in kuberc in here and
 		// expect that it will be passed along to the actual command.
 		rootCmd.SetArgs(args[1:])
+
 		// Remove alias arg to add the remaining arguments that are not flags nor part of the preferences
 		sanitizedArgs := strings.ReplaceAll(strings.Join(args[1:], " "), foundAliasCmd.Name(), "")
 		if len(sanitizedArgs) > 0 {
 			aliasArgs.originalCommand.WriteString(fmt.Sprintf(" %s", sanitizedArgs))
 		}
+
 		// Add annotation to trace back command built without aliases applied
 		if aliasArgs.command.Annotations == nil {
 			aliasArgs.command.Annotations = make(map[string]string, 1)
@@ -383,6 +385,7 @@ func BuildAliasCommand(rootCmd *cobra.Command, alias config.AliasOverride) (*cob
 
 	newCmd := *existingCmd
 	newCmd.Use = alias.Name
+	newCmd.Short = buildFullAliasDescription(alias)
 	newCmd.Aliases = []string{}
 
 	return &newCmd, nil
@@ -598,21 +601,36 @@ func registerAliasCommands(kubectl *cobra.Command, p PreferencesHandler, args []
 
 	userDefinedCommands := []*cobra.Command{}
 	for _, alias := range kuberc.Aliases {
-		aliasCmd, err := BuildAliasCommand(kubectl, alias)
+		_, err := BuildAliasCommand(kubectl, alias)
 		if err != nil {
 			continue
 		}
 
-		aliasCmd.Short = strings.Join(
-			append(
-				append([]string{alias.Command}, alias.PrependArgs...),
-				alias.AppendArgs...,
-			),
-			" ",
-		)
-
-		userDefinedCommands = append(userDefinedCommands, aliasCmd)
+		userDefinedCommands = append(userDefinedCommands, &cobra.Command{
+			Use:                alias.Name,
+			Short:              buildFullAliasDescription(alias),
+			DisableFlagParsing: true,
+			Run:                func(cmd *cobra.Command, args []string) {},
+		})
 	}
 
 	return userDefinedCommands
+}
+
+// buildFullAliasDescription creates a description showing the full expanded command
+// including prependArgs, appendArgs, and default flag values
+func buildFullAliasDescription(alias config.AliasOverride) string {
+	parts := []string{alias.Command}
+
+	if len(alias.PrependArgs) > 0 {
+		parts = append(parts, alias.PrependArgs...)
+	}
+	for _, option := range alias.Options {
+		parts = append(parts, fmt.Sprintf("--%s=%s", option.Name, option.Default))
+	}
+	if len(alias.AppendArgs) > 0 {
+		parts = append(parts, alias.AppendArgs...)
+	}
+
+	return fmt.Sprintf(i18n.T("Alias for '%s'"), strings.Join(parts, " "))
 }

--- a/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go
+++ b/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go
@@ -121,6 +121,9 @@ func (p *Preferences) Read(args []string, errOut io.Writer) (*config.Preference,
 	}
 
 	p.convertPluginPolicy(kuberc)
+	if err := p.validate(kuberc); err != nil {
+		return nil, err
+	}
 
 	p.cache = cachedPreference{value: kuberc, read: true}
 	return kuberc, nil
@@ -138,10 +141,6 @@ func (p *Preferences) Apply(rootCmd *cobra.Command, kubeConfigFlags *genericclio
 		return args, err
 	} else if kuberc == nil {
 		return args, nil
-	}
-
-	if err = p.validate(kuberc); err != nil {
-		return nil, err
 	}
 
 	p.applyPluginPolicy(kubeConfigFlags, kuberc)
@@ -577,28 +576,17 @@ func (p *Preferences) validate(plugin *config.Preference) error {
 	return nil
 }
 
-func GetAliasesCommandGroup(kubectl *cobra.Command, p PreferencesHandler, args []string) templates.CommandGroup {
+func GetAliasesCommandGroup(kubectl *cobra.Command, kuberc *config.Preference) templates.CommandGroup {
 	// Find root level
 	return templates.CommandGroup{
 		Message:  i18n.T("Aliases provided by kuberc:"),
-		Commands: registerAliasCommands(kubectl, p, args),
+		Commands: registerAliasCommands(kubectl, kuberc),
 	}
 }
 
 // registerAliasCommand allows adding Cobra command to the command tree or extracting them for usage in
 // e.g. the help function or for registering the completion function
-func registerAliasCommands(kubectl *cobra.Command, p PreferencesHandler, args []string) (cmds []*cobra.Command) {
-	streams := genericclioptions.IOStreams{
-		In:     &bytes.Buffer{},
-		Out:    io.Discard,
-		ErrOut: io.Discard,
-	}
-
-	kuberc, err := p.Read(args, streams.ErrOut)
-	if err != nil || kuberc == nil {
-		return []*cobra.Command{}
-	}
-
+func registerAliasCommands(kubectl *cobra.Command, kuberc *config.Preference) (cmds []*cobra.Command) {
 	userDefinedCommands := []*cobra.Command{}
 	for _, alias := range kuberc.Aliases {
 		_, err := BuildAliasCommand(kubectl, alias)

--- a/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go
+++ b/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go
@@ -36,6 +36,8 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/util/homedir"
 	"k8s.io/kubectl/pkg/config"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
 )
 
 const (
@@ -58,6 +60,7 @@ var _ = clientcmdapi.AllowlistEntry(config.AllowlistEntry{})
 // arguments based on user's kuberc configuration.
 type PreferencesHandler interface {
 	AddFlags(flags *pflag.FlagSet)
+	Read(args []string, errOut io.Writer) (*config.Preference, error)
 	Apply(rootCmd *cobra.Command, kubeConfigFlags *genericclioptions.ConfigFlags, args []string, errOut io.Writer) ([]string, error)
 }
 
@@ -68,6 +71,10 @@ type Preferences struct {
 
 	aliases map[string]struct{}
 	policy  clientcmdapi.PluginPolicy
+
+	// memoization (cache)
+	kuberc *config.Preference
+	read   bool
 }
 
 // NewPreferences returns initialized Preferences object.
@@ -91,6 +98,38 @@ func (p *Preferences) AddFlags(flags *pflag.FlagSet) {
 	flags.String("kuberc", "", "Path to the kuberc file to use for preferences. This can be disabled by exporting KUBECTL_KUBERC=false feature gate or turning off the feature KUBERC=off.")
 }
 
+func (p *Preferences) Read(args []string, errOut io.Writer) (*config.Preference, error) {
+	if p.read {
+		return p.kuberc, nil
+	}
+
+	kubercPath, err := getExplicitKuberc(args)
+	if err != nil {
+		return nil, err
+	}
+
+	kuberc, err := p.getPreferencesFunc(kubercPath, errOut)
+	if err != nil {
+		return nil, fmt.Errorf("kuberc error %w", err)
+	}
+
+	if kuberc == nil {
+		return nil, nil
+	}
+
+	p.convertPluginPolicy(kuberc)
+
+	err = p.validate(kuberc)
+	if err != nil {
+		return nil, err
+	}
+
+	p.kuberc = kuberc
+	p.read = true
+
+	return kuberc, nil
+}
+
 // Apply firstly applies the aliases in the preferences file and secondly overrides
 // the default values of flags.
 func (p *Preferences) Apply(rootCmd *cobra.Command, kubeConfigFlags *genericclioptions.ConfigFlags, args []string, errOut io.Writer) ([]string, error) {
@@ -98,24 +137,11 @@ func (p *Preferences) Apply(rootCmd *cobra.Command, kubeConfigFlags *genericclio
 		return args, nil
 	}
 
-	kubercPath, err := getExplicitKuberc(args)
+	kuberc, err := p.Read(args, errOut)
 	if err != nil {
 		return args, err
-	}
-	kuberc, err := p.getPreferencesFunc(kubercPath, errOut)
-	if err != nil {
-		return args, fmt.Errorf("kuberc error %w", err)
-	}
-
-	if kuberc == nil {
+	} else if kuberc == nil {
 		return args, nil
-	}
-
-	p.convertPluginPolicy(kuberc)
-
-	err = p.validate(kuberc)
-	if err != nil {
-		return args, err
 	}
 
 	p.applyPluginPolicy(kubeConfigFlags, kuberc)
@@ -257,16 +283,10 @@ func (p *Preferences) applyAliases(rootCmd *cobra.Command, kuberc *config.Prefer
 			break
 		}
 
-		commands := strings.Fields(alias.Command)
-		existingCmd, flags, err := rootCmd.Find(commands)
+		aliasCmd, err := BuildAliasCommand(rootCmd, alias)
 		if err != nil {
-			return args, fmt.Errorf("command %q not found to set alias %q: %v", alias.Command, alias.Name, flags)
+			return args, err
 		}
-
-		newCmd := *existingCmd
-		newCmd.Use = alias.Name
-		newCmd.Aliases = []string{}
-		aliasCmd := &newCmd
 
 		if alias.Name == commandName {
 			aliasArgs = &aliasing{
@@ -349,6 +369,23 @@ func (p *Preferences) applyAliases(rootCmd *cobra.Command, kuberc *config.Prefer
 	}
 
 	return args, nil
+}
+
+// BuildAliasCommand resolves the underlying command referenced by alias.Command
+// and returns a copy of it renamed to alias.Name, suitable for registration
+// in the command tree or for listing (e.g. in help output).
+func BuildAliasCommand(rootCmd *cobra.Command, alias config.AliasOverride) (*cobra.Command, error) {
+	commands := strings.Fields(alias.Command)
+	existingCmd, flags, err := rootCmd.Find(commands)
+	if err != nil {
+		return nil, fmt.Errorf("command %q not found to set alias %q: %v", alias.Command, alias.Name, flags)
+	}
+
+	newCmd := *existingCmd
+	newCmd.Use = alias.Name
+	newCmd.Aliases = []string{}
+
+	return &newCmd, nil
 }
 
 // LoadKuberc returns the correct kuberc file. Explicitly specified is always highest priority.
@@ -535,4 +572,47 @@ func (p *Preferences) validate(plugin *config.Preference) error {
 	}
 
 	return nil
+}
+
+func GetAliasesCommandGroup(kubectl *cobra.Command, p PreferencesHandler, args []string) templates.CommandGroup {
+	// Find root level
+	return templates.CommandGroup{
+		Message:  i18n.T("Aliases provided by kuberc:"),
+		Commands: registerAliasCommands(kubectl, p, args),
+	}
+}
+
+// registerAliasCommand allows adding Cobra command to the command tree or extracting them for usage in
+// e.g. the help function or for registering the completion function
+func registerAliasCommands(kubectl *cobra.Command, p PreferencesHandler, args []string) (cmds []*cobra.Command) {
+	streams := genericclioptions.IOStreams{
+		In:     &bytes.Buffer{},
+		Out:    io.Discard,
+		ErrOut: io.Discard,
+	}
+
+	kuberc, err := p.Read(args, streams.ErrOut)
+	if err != nil || kuberc == nil {
+		return []*cobra.Command{}
+	}
+
+	userDefinedCommands := []*cobra.Command{}
+	for _, alias := range kuberc.Aliases {
+		aliasCmd, err := BuildAliasCommand(kubectl, alias)
+		if err != nil {
+			continue
+		}
+
+		aliasCmd.Short = strings.Join(
+			append(
+				append([]string{alias.Command}, alias.PrependArgs...),
+				alias.AppendArgs...,
+			),
+			" ",
+		)
+
+		userDefinedCommands = append(userDefinedCommands, aliasCmd)
+	}
+
+	return userDefinedCommands
 }

--- a/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc_test.go
@@ -3248,27 +3248,6 @@ func TestRegisterAliasCommands(t *testing.T) {
 			expectedCmdCount: 1,
 		},
 		{
-			name: "duplicate alias names deduplicated",
-			nestedCmds: []fakeCmds[string]{
-				{name: "command1"},
-			},
-			args: []string{"root", "getcmd"},
-			getPreferencesFunc: func(kuberc string, errOut io.Writer) (*config.Preference, error) {
-				return &config.Preference{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "Preference",
-						APIVersion: "kubectl.config.k8s.io/v1alpha1",
-					},
-					Aliases: []config.AliasOverride{
-						{Name: "getcmd", Command: "command1"},
-						{Name: "getcmd", Command: "command1"},
-					},
-				}, nil
-			},
-			expectedCmdNames: []string{},
-			expectedCmdCount: 0,
-		},
-		{
 			name: "no aliases in kuberc",
 			nestedCmds: []fakeCmds[string]{
 				{name: "command1"},
@@ -3308,15 +3287,10 @@ func TestRegisterAliasCommands(t *testing.T) {
 				t.Fatalf("expected %d command(s), got %d", test.expectedCmdCount, len(group.Commands))
 			}
 
-			seen := map[string]bool{}
 			for _, c := range group.Commands {
 				if !slices.Contains(test.expectedCmdNames, c.Name()) {
 					t.Fatalf("unexpected command %s, expected one of %v", c.Name(), test.expectedCmdNames)
 				}
-				if seen[c.Name()] {
-					t.Fatalf("duplicate command %s in group.Commands", c.Name())
-				}
-				seen[c.Name()] = true
 			}
 		})
 	}

--- a/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -3198,6 +3199,124 @@ credentialPluginPolicy: ""
 				require.Error(t, err, "expected error, but error was nil")
 			} else {
 				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRegisterAliasCommands(t *testing.T) {
+	tests := []struct {
+		name               string
+		nestedCmds         []fakeCmds[string]
+		args               []string
+		getPreferencesFunc func(kuberc string, errOut io.Writer) (*config.Preference, error)
+		expectedCmdNames   []string
+		expectedCmdCount   int
+	}{
+		{
+			name: "single alias registered",
+			nestedCmds: []fakeCmds[string]{
+				{
+					name: "command1",
+					flags: []fakeFlag[string]{
+						{
+							name:  "firstflag",
+							value: "test",
+						},
+					},
+				},
+			},
+			args: []string{
+				"root",
+				"getcmd",
+			},
+			getPreferencesFunc: func(kuberc string, errOut io.Writer) (*config.Preference, error) {
+				return &config.Preference{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Preference",
+						APIVersion: "kubectl.config.k8s.io/v1alpha1",
+					},
+					Aliases: []config.AliasOverride{
+						{
+							Name:    "getcmd",
+							Command: "command1",
+						},
+					},
+				}, nil
+			},
+			expectedCmdNames: []string{"getcmd"},
+			expectedCmdCount: 1,
+		},
+		{
+			name: "duplicate alias names deduplicated",
+			nestedCmds: []fakeCmds[string]{
+				{name: "command1"},
+			},
+			args: []string{"root", "getcmd"},
+			getPreferencesFunc: func(kuberc string, errOut io.Writer) (*config.Preference, error) {
+				return &config.Preference{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Preference",
+						APIVersion: "kubectl.config.k8s.io/v1alpha1",
+					},
+					Aliases: []config.AliasOverride{
+						{Name: "getcmd", Command: "command1"},
+						{Name: "getcmd", Command: "command1"},
+					},
+				}, nil
+			},
+			expectedCmdNames: []string{},
+			expectedCmdCount: 0,
+		},
+		{
+			name: "no aliases in kuberc",
+			nestedCmds: []fakeCmds[string]{
+				{name: "command1"},
+			},
+			args: []string{"root", "getcmd"},
+			getPreferencesFunc: func(kuberc string, errOut io.Writer) (*config.Preference, error) {
+				return &config.Preference{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Preference",
+						APIVersion: "kubectl.config.k8s.io/v1alpha1",
+					},
+					Aliases: []config.AliasOverride{},
+				}, nil
+			},
+			expectedCmdNames: []string{},
+			expectedCmdCount: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rootCmd := &cobra.Command{
+				Use: "root",
+			}
+			prefHandler := NewPreferences()
+			prefHandler.AddFlags(rootCmd.PersistentFlags())
+			pref, ok := prefHandler.(*Preferences)
+			if !ok {
+				t.Fatal("unexpected type. Expected *Preferences")
+			}
+			addCommands(rootCmd, test.nestedCmds)
+			pref.getPreferencesFunc = test.getPreferencesFunc
+
+			group := GetAliasesCommandGroup(rootCmd, pref, test.args)
+
+			if len(group.Commands) != test.expectedCmdCount {
+				t.Fatalf("expected %d command(s), got %d", test.expectedCmdCount, len(group.Commands))
+			}
+
+			seen := map[string]bool{}
+			for _, c := range group.Commands {
+				if !slices.Contains(test.expectedCmdNames, c.Name()) {
+					t.Fatalf("unexpected command %s, expected one of %v", c.Name(), test.expectedCmdNames)
+				}
+				if seen[c.Name()] {
+					t.Fatalf("duplicate command %s in group.Commands", c.Name())
+				}
+				seen[c.Name()] = true
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR adds kuberc aliases to the kubectl help output.

#### Which issue(s) this PR is related to:
Fixes #1740
https://github.com/kubernetes/kubectl/issues/1740

#### Special notes for your reviewer:
Aliases are displayed using a dedicated CommandGroup, similar to plugin-provided commands.
@soltysh 

#### Does this PR introduce a user-facing change?
Output format changes: kubectl now displays kuberc aliases in its help output.
<img width="1439" height="649" alt="image" src="https://github.com/user-attachments/assets/0db27303-62de-48c3-b399-914849fc77fa" />

In case of alias duplication - a warning is shown
<img width="1079" height="179" alt="image" src="https://github.com/user-attachments/assets/1fd2fad7-1a90-4290-83c2-63a23c3c7db3" />


#### AI usage disclosure:
No
