### PR TITLE
resource: keep Quantity.Cmp bounded when scales differ by more than int32

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/amount.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/amount.go
@@ -154,9 +154,15 @@ func (a int64Amount) Cmp(b int64Amount) int {
 	case a.scale == b.scale:
 		// compare only the unscaled portion
 	case a.scale > b.scale:
-		result, remainder, exact := divideByScaleInt64(b.value, a.scale-b.scale)
+		// Widen before subtracting: the difference of two int32 scales does not
+		// have to fit one, and a wrapped negative reaches a zero divisor.
+		diff := int64(a.scale) - int64(b.scale)
+		if diff >= 18 {
+			return cmpDec(a.AsDec(), b.AsDec())
+		}
+		result, remainder, exact := divideByScaleInt64(b.value, Scale(diff))
 		if !exact {
-			return a.AsDec().Cmp(b.AsDec())
+			return cmpDec(a.AsDec(), b.AsDec())
 		}
 		if result == a.value {
 			switch {
@@ -170,9 +176,13 @@ func (a int64Amount) Cmp(b int64Amount) int {
 		}
 		b.value = result
 	default:
-		result, remainder, exact := divideByScaleInt64(a.value, b.scale-a.scale)
+		diff := int64(b.scale) - int64(a.scale)
+		if diff >= 18 {
+			return cmpDec(a.AsDec(), b.AsDec())
+		}
+		result, remainder, exact := divideByScaleInt64(a.value, Scale(diff))
 		if !exact {
-			return a.AsDec().Cmp(b.AsDec())
+			return cmpDec(a.AsDec(), b.AsDec())
 		}
 		if result == b.value {
 			switch {
@@ -195,6 +205,39 @@ func (a int64Amount) Cmp(b int64Amount) int {
 	default:
 		return 1
 	}
+}
+
+// decimalExponentBounds brackets the e for which 10^(e-1) <= |c|*10^-s < 10^e,
+// for a non-zero c. An n-bit magnitude has at least n/4 and at most n/3+1
+// decimal digits, so neither bound has to count them.
+func decimalExponentBounds(bitLen int, s int64) (lo, hi int64) {
+	n := int64(bitLen)
+	return n/4 - s, n/3 + 1 - s
+}
+
+// cmpDec compares x and y. inf.Dec.Cmp aligns the two scales by writing their
+// difference out in digits, and a parsed exponent sets that difference, so
+// settle what the magnitudes already decide before reaching it.
+func cmpDec(x, y *inf.Dec) int {
+	xSign, ySign := x.Sign(), y.Sign()
+	switch {
+	case xSign != ySign:
+		if xSign > ySign {
+			return 1
+		}
+		return -1
+	case xSign == 0:
+		return 0
+	}
+	xLo, xHi := decimalExponentBounds(x.UnscaledBig().BitLen(), int64(x.Scale()))
+	yLo, yHi := decimalExponentBounds(y.UnscaledBig().BitLen(), int64(y.Scale()))
+	switch {
+	case xLo > yHi:
+		return xSign
+	case xHi < yLo:
+		return -xSign
+	}
+	return x.Cmp(y)
 }
 
 // Add adds two int64Amounts together, matching scales. It will return false and not mutate

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -695,14 +695,14 @@ func (q *Quantity) Cmp(y Quantity) int {
 	if q.d.Dec == nil && y.d.Dec == nil {
 		return q.i.Cmp(y.i)
 	}
-	return q.AsDec().Cmp(y.AsDec())
+	return cmpDec(q.AsDec(), y.AsDec())
 }
 
 // CmpInt64 returns 0 if the quantity is equal to y, -1 if the quantity is less than y, or 1 if the
 // quantity is greater than y.
 func (q *Quantity) CmpInt64(y int64) int {
 	if q.d.Dec != nil {
-		return q.d.Dec.Cmp(inf.NewDec(y, inf.Scale(0)))
+		return cmpDec(q.d.Dec, inf.NewDec(y, inf.Scale(0)))
 	}
 	return q.i.Cmp(int64Amount{value: y})
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_cmp_overflow_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_cmp_overflow_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import "testing"
+
+// Cmp is bounded and correct when the two operands' scales differ by more than
+// an int32 can represent.
+func TestCmpLargeScaleDifference(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"1e2147483647", "1n", 1},
+		{"1n", "1e2147483647", -1},
+		{"1e2147483647", "500m", 1},
+		{"1e2147483647", "1", 1},
+		{"-1e2147483647", "1n", -1},
+		{"-1e2147483647", "-1n", -1},
+		{"1e2147483647", "1e2147483647", 0},
+		{"1e2147483647", "1e2147483646", 1},
+		{"1e10000000", "1Gi", 1},
+		{"1Gi", "1e10000000", -1},
+	}
+	for _, tc := range cases {
+		a, b := MustParse(tc.a), MustParse(tc.b)
+		if got := a.Cmp(b); got != tc.want {
+			t.Errorf("MustParse(%q).Cmp(MustParse(%q)) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+// CmpInt64 is bounded the same way for a decimal-backed receiver.
+func TestCmpInt64LargeScaleDifference(t *testing.T) {
+	q := MustParse("1e2147483647")
+	q.ToDec()
+	if got := q.CmpInt64(1); got != 1 {
+		t.Errorf("CmpInt64(1) = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig api-machinery

#### What this PR does / why we need it:

`Quantity.Cmp` can panic, or take a very long time, when the two values it compares have scales that are far apart.

`int64Amount.Cmp` subtracts the two scales as an `int32`, and that difference does not have to fit in an `int32`. `1e2147483647` parses to `int64Amount{value: 1, scale: 2147483647}`, so comparing it against a nanoscale value subtracts `2147483647 - (-9)`, which wraps to a negative number. `divideByScaleInt64` passes that to `pow10Int64`, gets back `0`, and divides by it. A little below the point where it wraps, the comparison falls through to `inf.Dec` instead, which lines the two values up by writing the whole scale gap out in digits. The scale comes straight from the parsed text, so neither path is bounded by how large the numbers actually are.

The fix does the subtraction in `int64`. When the `int64` fast path cannot represent the result, it settles the comparison from the range of the decimal exponents before reaching `inf.Dec`: a number with `n` bits has between `n/4` and `n/3 + 1` decimal digits, which is enough to bracket the two exponents without counting them. `Quantity.Cmp` and `Quantity.CmpInt64` go through the same helper on their decimal path.

#### Which issue(s) this PR is related to:

Part of #141166.

#### Special notes for your reviewer:

I checked the result against `big.Rat` over a grid of int64- and decimal-backed operands; every pair that `inf.Dec` can already compare gets the same answer. The added test pins the pairs the old code could not handle, the ones that wrapped onto a zero divisor and the ones that aligned on the exponent.

The exponent-bounds helper is the one from #141348. Once this lands, the ratio path there can drop its own comparator and use `Cmp`.

#### Does this PR introduce a user-facing change?

```release-note
resource.Quantity.Cmp and CmpInt64 now return the correct result when the two quantities' scales differ by more than an int32 can represent.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

YES. AI-assisted tools were used during implementation, test planning, and review; I reviewed and validated the final change.
