### PR TITLE
DRA: optimize allocated shared device lookups in structured allocator

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/allocateddevices.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/allocateddevices.go
@@ -120,11 +120,15 @@ func (a *allocatedDevices) Get() (sets.Set[structured.DeviceID], int64) {
 	return a.ids.Clone(), a.revision
 }
 
-func (a *allocatedDevices) GetSharedDeviceIDs() (sets.Set[structured.SharedDeviceID], int64) {
+func (a *allocatedDevices) GetSharedDeviceIDs() (sets.Set[structured.DeviceID], int64) {
 	a.mutex.RLock()
 	defer a.mutex.RUnlock()
 
-	return a.shareIDs.Clone(), a.revision
+	result := make(sets.Set[structured.DeviceID], a.shareIDs.Len())
+	for sharedDeviceID := range a.shareIDs {
+		result.Insert(sharedDeviceID.GetDeviceID())
+	}
+	return result, a.revision
 }
 
 func (a *allocatedDevices) Capacities() (structured.ConsumedCapacityCollection, int64) {

--- a/pkg/scheduler/framework/plugins/dynamicresources/dra_manager.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dra_manager.go
@@ -348,7 +348,7 @@ func (c *claimTracker) ListAllAllocatedDevices() (a sets.Set[structured.DeviceID
 // GatherAllocatedState collects and returns the current allocation state of all devices
 // across the cluster. This includes:
 // - AllocatedDevices: Set of device IDs that are fully allocated (dedicated mode)
-// - AllocatedSharedDeviceIDs: Set of shared device IDs when consumable capacity is enabled
+// - AllocatedSharedDeviceIDs: Set of device IDs with shared allocations when consumable capacity is enabled
 // - AggregatedCapacity: Consumed capacity across all devices when consumable capacity is enabled
 //
 // The function handles two allocation models:
@@ -392,11 +392,11 @@ func (c *claimTracker) GatherAllocatedState() (s *structured.AllocatedState, err
 		// dedicated device allocation model.
 		// This ensures backward compatibility with the original DRA behavior where devices
 		// could only be allocated exclusively to a single claim.
-		for sharedDeviceID := range allocatedSharedDeviceIDs {
-			allocated.Insert(sharedDeviceID.GetDeviceID())
+		for deviceID := range allocatedSharedDeviceIDs {
+			allocated.Insert(deviceID)
 		}
 		// Reset allocatedSharedDeviceIDs and aggregatedCapacity
-		allocatedSharedDeviceIDs = sets.New[structured.SharedDeviceID]()
+		allocatedSharedDeviceIDs = sets.New[structured.DeviceID]()
 		aggregatedCapacity = make(schedulerapi.ConsumedCapacityCollection)
 	}
 
@@ -411,7 +411,7 @@ func (c *claimTracker) GatherAllocatedState() (s *structured.AllocatedState, err
 			enabledConsumableCapacity,
 			func(sharedDeviceID structured.SharedDeviceID) { // sharedDeviceCallback
 				c.logger.V(6).Info("Device is in flight for allocation", "shared device", sharedDeviceID, "claim", klog.KObj(claim))
-				allocatedSharedDeviceIDs.Insert(sharedDeviceID)
+				allocatedSharedDeviceIDs.Insert(sharedDeviceID.GetDeviceID())
 			},
 			func(capacity structured.DeviceConsumedCapacity) { // consumedCapacityCallback
 				c.logger.V(6).Info("Device is in flight for allocation", "consumed capacity", capacity, "claim", klog.KObj(claim))

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -804,7 +804,7 @@ func (pl *DynamicResources) PreFilter(ctx context.Context, state fwk.CycleState,
 				}
 				allocatedState = &structured.AllocatedState{
 					AllocatedDevices:         allocatedDevices,
-					AllocatedSharedDeviceIDs: sets.New[structured.SharedDeviceID](),
+					AllocatedSharedDeviceIDs: sets.New[structured.DeviceID](),
 					AggregatedCapacity:       structured.NewConsumedCapacityCollection(),
 				}
 				// Done.

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -112,6 +112,7 @@ var (
 	driver                              = "some-driver"
 	driver2                             = "some-driver-2"
 	sharedDeviceName                    = "shared-instance"
+	sharedDeviceName2                   = "shared-instance-2"
 	podName                             = "my-pod"
 	podUID                              = "1234"
 	podGroupName                        = "my-podgroup"
@@ -430,6 +431,20 @@ var (
 			return st.MakeNodeSelector().In("metadata.name", []string{nodeName}, st.NodeSelectorTypeMatchFields).Obj()
 		}(),
 	}
+	allocationResultWithSharedDevice2 = &resourceapi.AllocationResult{
+		Devices: resourceapi.DeviceAllocationResult{
+			Results: []resourceapi.DeviceRequestAllocationResult{{
+				Driver:  driver,
+				Pool:    nodeName,
+				Device:  sharedDeviceName2,
+				Request: "req-1",
+				ShareID: ptr.To(types.UID("share-456")), // Shared device allocation
+			}},
+		},
+		NodeSelector: func() *v1.NodeSelector {
+			return st.MakeNodeSelector().In("metadata.name", []string{nodeName}, st.NodeSelectorTypeMatchFields).Obj()
+		}(),
+	}
 	allocationResultWithConsumedCapacity = &resourceapi.AllocationResult{
 		Devices: resourceapi.DeviceAllocationResult{
 			Results: []resourceapi.DeviceRequestAllocationResult{{
@@ -724,6 +739,9 @@ var (
 					Obj()
 	allocatedClaimWithSharedDevice = st.FromResourceClaim(pendingClaim).
 					Allocation(allocationResultWithSharedDevice).
+					Obj()
+	allocatedClaimWithSharedDevice2 = st.FromResourceClaim(pendingClaim2).
+					Allocation(allocationResultWithSharedDevice2).
 					Obj()
 	allocatedClaimWithConsumedCapacity = st.FromResourceClaim(pendingClaim).
 						Allocation(allocationResultWithConsumedCapacity).
@@ -5738,50 +5756,59 @@ func TestGatherAllocatedState(t *testing.T) {
 }
 func testGatherAllocatedState(tCtx ktesting.TContext) {
 	testcases := map[string]struct {
-		allocatedResourceClaims   []*resourceapi.ResourceClaim
-		inflightResourceClaims    map[types.UID]*resourceapi.ResourceClaim
-		enabledConsumableCapacity bool
-		expectErr                 bool
-		expectedIDAllocated       int
-		expectedSharedIDAllocated int
-		expectedConsumedCapacity  string
+		allocatedResourceClaims          []*resourceapi.ResourceClaim
+		inflightResourceClaims           map[types.UID]*resourceapi.ResourceClaim
+		enabledConsumableCapacity        bool
+		expectErr                        bool
+		expectedAllocatedDeviceIDs       int
+		expectedAllocatedSharedDeviceIDs int
+		expectedConsumedCapacity         string
 	}{
 		"no-claims": {
-			expectedIDAllocated:       0,
-			expectedSharedIDAllocated: 0,
+			expectedAllocatedDeviceIDs:       0,
+			expectedAllocatedSharedDeviceIDs: 0,
 		},
 		"single-allocated-claim": {
 			allocatedResourceClaims: []*resourceapi.ResourceClaim{
 				allocatedClaim,
 			},
-			expectedIDAllocated:       1,
-			expectedSharedIDAllocated: 0,
+			expectedAllocatedDeviceIDs:       1,
+			expectedAllocatedSharedDeviceIDs: 0,
 		},
 		"single-allocated-claim-with-shared-device": {
 			enabledConsumableCapacity: true,
 			allocatedResourceClaims: []*resourceapi.ResourceClaim{
 				allocatedClaimWithSharedDevice,
 			},
-			expectedIDAllocated:       0,
-			expectedSharedIDAllocated: 1,
+			expectedAllocatedDeviceIDs:       0,
+			expectedAllocatedSharedDeviceIDs: 1,
+		},
+		"multiple-allocated-claims-with-distinct-shared-devices": {
+			enabledConsumableCapacity: true,
+			allocatedResourceClaims: []*resourceapi.ResourceClaim{
+				allocatedClaimWithSharedDevice,
+				allocatedClaimWithSharedDevice2,
+			},
+			expectedAllocatedDeviceIDs:       0,
+			expectedAllocatedSharedDeviceIDs: 2,
 		},
 		"single-allocated-claim-with-capacity": {
 			enabledConsumableCapacity: true,
 			allocatedResourceClaims: []*resourceapi.ResourceClaim{
 				allocatedClaimWithConsumedCapacity,
 			},
-			expectedIDAllocated:       0,
-			expectedSharedIDAllocated: 1,
-			expectedConsumedCapacity:  "1",
+			expectedAllocatedDeviceIDs:       0,
+			expectedAllocatedSharedDeviceIDs: 1,
+			expectedConsumedCapacity:         "1",
 		},
 		"disabled-single-allocated-claim-with-capacity": {
 			enabledConsumableCapacity: false,
 			allocatedResourceClaims: []*resourceapi.ResourceClaim{
 				allocatedClaimWithConsumedCapacity,
 			},
-			expectedIDAllocated:       1,
-			expectedSharedIDAllocated: 0,
-			expectedConsumedCapacity:  "",
+			expectedAllocatedDeviceIDs:       1,
+			expectedAllocatedSharedDeviceIDs: 0,
+			expectedConsumedCapacity:         "",
 		},
 		"mixed-allocated-claim": {
 			enabledConsumableCapacity: true,
@@ -5789,9 +5816,9 @@ func testGatherAllocatedState(tCtx ktesting.TContext) {
 				allocatedClaim,
 				allocatedClaimWithConsumedCapacity,
 			},
-			expectedIDAllocated:       1,
-			expectedSharedIDAllocated: 1,
-			expectedConsumedCapacity:  "1",
+			expectedAllocatedDeviceIDs:       1,
+			expectedAllocatedSharedDeviceIDs: 1,
+			expectedConsumedCapacity:         "1",
 		},
 		"add-inflight-allocated-claim-with-capacity": {
 			enabledConsumableCapacity: true,
@@ -5802,9 +5829,20 @@ func testGatherAllocatedState(tCtx ktesting.TContext) {
 			inflightResourceClaims: map[types.UID]*resourceapi.ResourceClaim{
 				"claim-2-uid": allocatedClaimWithConsumedCapacity2,
 			},
-			expectedIDAllocated:       1,
-			expectedSharedIDAllocated: 2,
-			expectedConsumedCapacity:  "2",
+			expectedAllocatedDeviceIDs:       1,
+			expectedAllocatedSharedDeviceIDs: 1,
+			expectedConsumedCapacity:         "2",
+		},
+		"add-inflight-allocated-claim-with-distinct-shared-device": {
+			enabledConsumableCapacity: true,
+			allocatedResourceClaims: []*resourceapi.ResourceClaim{
+				allocatedClaimWithSharedDevice,
+			},
+			inflightResourceClaims: map[types.UID]*resourceapi.ResourceClaim{
+				"claim-2-uid": allocatedClaimWithSharedDevice2,
+			},
+			expectedAllocatedDeviceIDs:       0,
+			expectedAllocatedSharedDeviceIDs: 2,
 		},
 		"disabled-inflight-allocated-claim-with-capacity": {
 			enabledConsumableCapacity: false,
@@ -5815,9 +5853,9 @@ func testGatherAllocatedState(tCtx ktesting.TContext) {
 			inflightResourceClaims: map[types.UID]*resourceapi.ResourceClaim{
 				"claim-2-uid": allocatedClaimWithConsumedCapacity2,
 			},
-			expectedIDAllocated:       2,
-			expectedSharedIDAllocated: 0,
-			expectedConsumedCapacity:  "",
+			expectedAllocatedDeviceIDs:       2,
+			expectedAllocatedSharedDeviceIDs: 0,
+			expectedConsumedCapacity:         "",
 		},
 	}
 	for name, tc := range testcases {
@@ -5870,11 +5908,11 @@ func testGatherAllocatedState(tCtx ktesting.TContext) {
 			aggregatedCapacity := allocatedState.AggregatedCapacity
 
 			// Verify the counts match expectations
-			if allocatedDeviceIDs.Len() != tc.expectedIDAllocated {
-				tCtx.Errorf("expected %d allocated device IDs, got %d", tc.expectedIDAllocated, allocatedDeviceIDs.Len())
+			if allocatedDeviceIDs.Len() != tc.expectedAllocatedDeviceIDs {
+				tCtx.Errorf("expected %d allocated device IDs, got %d", tc.expectedAllocatedDeviceIDs, allocatedDeviceIDs.Len())
 			}
-			if allocatedSharedDeviceIDs.Len() != tc.expectedSharedIDAllocated {
-				tCtx.Errorf("expected %d allocated shared device IDs, got %d", tc.expectedSharedIDAllocated, allocatedSharedDeviceIDs.Len())
+			if allocatedSharedDeviceIDs.Len() != tc.expectedAllocatedSharedDeviceIDs {
+				tCtx.Errorf("expected %d allocated shared device IDs, got %d", tc.expectedAllocatedSharedDeviceIDs, allocatedSharedDeviceIDs.Len())
 			}
 
 			// Verify aggregated capacity is initialized

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatedstate.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatedstate.go
@@ -31,7 +31,6 @@ import (
 // definitions are maintained. This ensures that any changes to these types
 // require autoscaler approval.
 type DeviceID = schedulerapi.DeviceID
-type SharedDeviceID = schedulerapi.SharedDeviceID
 type AllocatedState = schedulerapi.AllocatedState
 type ConsumedCapacity = schedulerapi.ConsumedCapacity
 type ConsumedCapacityCollection = schedulerapi.ConsumedCapacityCollection
@@ -40,10 +39,6 @@ type DeviceConsumedCapacity = schedulerapi.DeviceConsumedCapacity
 // Wrapper functions that delegate to the schedulerapi package
 func MakeDeviceID(driver, pool, device string) DeviceID {
 	return schedulerapi.MakeDeviceID(driver, pool, device)
-}
-
-func MakeSharedDeviceID(deviceID DeviceID, shareID *types.UID) SharedDeviceID {
-	return schedulerapi.MakeSharedDeviceID(deviceID, shareID)
 }
 
 func NewConsumedCapacity() ConsumedCapacity {
@@ -67,11 +62,8 @@ func IsDeviceAllocated(deviceID DeviceID, allocatedState *AllocatedState) bool {
 	}
 
 	// Check if device is partially consumed via shared allocations (consumable capacity case).
-	// We need to check if any shared device ID corresponds to our device.
-	for sharedDeviceID := range allocatedState.AllocatedSharedDeviceIDs {
-		if sharedDeviceID.GetDeviceID() == deviceID {
-			return true
-		}
+	if allocatedState.AllocatedSharedDeviceIDs.Has(deviceID) {
+		return true
 	}
 
 	// For scheduler-generated state, consumed capacity is recorded together with

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -52,7 +52,6 @@ type DeviceClassLister = internal.DeviceClassLister
 type Features = internal.Features
 type DeviceID = internal.DeviceID
 
-type SharedDeviceID = internal.SharedDeviceID
 type ConsumedCapacityCollection = internal.ConsumedCapacityCollection
 type ConsumedCapacity = internal.ConsumedCapacity
 type AllocatedState = internal.AllocatedState
@@ -963,7 +962,7 @@ type AllocatorTestCase struct {
 	features                 Features
 	claimsToAllocate         []wrapResourceClaim
 	allocatedDevices         []DeviceID
-	allocatedSharedDeviceIDs sets.Set[SharedDeviceID]
+	allocatedSharedDeviceIDs sets.Set[DeviceID]
 	allocatedCapacityDevices ConsumedCapacityCollection
 	classes                  []*resourceapi.DeviceClass
 	slices                   []*resourceapi.ResourceSlice
@@ -6690,7 +6689,7 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			allocatedSharedDeviceIDs: sets.New(
-				internal.MakeSharedDeviceID(MakeDeviceID(driverA, pool1, device1), &fixedShareID),
+				MakeDeviceID(driverA, pool1, device1),
 			),
 			allocatedCapacityDevices: ConsumedCapacityCollection{
 				MakeDeviceID(driverA, pool1, device1): ConsumedCapacity{
@@ -6732,7 +6731,7 @@ func TestAllocator(t *testing.T,
 			// device1 already has a persisted shared allocation. It is represented
 			// only by a share ID, with no AggregatedCapacity entry.
 			allocatedSharedDeviceIDs: sets.New(
-				internal.MakeSharedDeviceID(MakeDeviceID(driverA, pool1, device1), &fixedShareID),
+				MakeDeviceID(driverA, pool1, device1),
 			),
 			claimsToAllocate: objects(
 				claimWithRequests(claim0, nil, request(req0, classA, 1)),
@@ -6765,7 +6764,7 @@ func TestAllocator(t *testing.T,
 			// so a dedicated request must not be handed the device on top of it.
 			features: Features{ConsumableCapacity: true},
 			allocatedSharedDeviceIDs: sets.New(
-				internal.MakeSharedDeviceID(MakeDeviceID(driverA, pool1, device1), &fixedShareID),
+				MakeDeviceID(driverA, pool1, device1),
 			),
 			claimsToAllocate: objects(claimWithRequests(claim0, nil, request(req0, classA, 1))),
 			classes:          objects(class(classA, driverA)),
@@ -6781,7 +6780,7 @@ func TestAllocator(t *testing.T,
 			// The guard drops device1 without aborting the search, so the request still lands on device2.
 			features: Features{ConsumableCapacity: true},
 			allocatedSharedDeviceIDs: sets.New(
-				internal.MakeSharedDeviceID(MakeDeviceID(driverA, pool1, device1), &fixedShareID),
+				MakeDeviceID(driverA, pool1, device1),
 			),
 			claimsToAllocate: objects(claimWithRequests(claim0, nil, request(req0, classA, 1))),
 			classes:          objects(class(classA, driverA)),
@@ -6797,11 +6796,33 @@ func TestAllocator(t *testing.T,
 				deviceAllocationResult(req0, driverA, pool1, device2, false),
 			)},
 		},
+		"consumable-capacity-dedicated-request-falls-back-past-multiple-persisted-shares": {
+			// The guard drops device1 and device2 without aborting the search, so the request lands on device3.
+			features: Features{ConsumableCapacity: true},
+			allocatedSharedDeviceIDs: sets.New(
+				MakeDeviceID(driverA, pool1, device1),
+				MakeDeviceID(driverA, pool1, device2),
+			),
+			claimsToAllocate: objects(claimWithRequests(claim0, nil, request(req0, classA, 1))),
+			classes:          objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 1), driverA,
+					device(device1, nil, nil),
+					device(device2, nil, nil),
+					device(device3, nil, nil),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device3, false),
+			)},
+		},
 		"consumable-capacity-with-admin-access-request-allowed-over-persisted-share": {
 			// Admin access skips the availability checks, so the live share does not withhold device1.
 			features: Features{ConsumableCapacity: true, AdminAccess: true},
 			allocatedSharedDeviceIDs: sets.New(
-				internal.MakeSharedDeviceID(MakeDeviceID(driverA, pool1, device1), &fixedShareID),
+				MakeDeviceID(driverA, pool1, device1),
 			),
 			claimsToAllocate: func() []wrapResourceClaim {
 				c := claimWithRequest(claim0, req0, classA)

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -49,7 +49,6 @@ func MakeDeviceID(driver, pool, device string) DeviceID {
 	return internal.MakeDeviceID(driver, pool, device)
 }
 
-type SharedDeviceID = internal.SharedDeviceID
 type DeviceConsumedCapacity = internal.DeviceConsumedCapacity
 type ConsumedCapacityCollection = internal.ConsumedCapacityCollection
 type ConsumedCapacity = internal.ConsumedCapacity
@@ -1973,10 +1972,8 @@ func (alloc *allocator) deviceCapacityInUse(deviceID DeviceID) bool {
 	}
 	// A persisted allow-multiple allocation with no per-share capacity is recorded
 	// only in AllocatedSharedDeviceIDs (with no AggregatedCapacity entry).
-	for sharedDeviceID := range alloc.allocatedState.AllocatedSharedDeviceIDs {
-		if sharedDeviceID.GetDeviceID() == deviceID {
-			return true
-		}
+	if alloc.allocatedState.AllocatedSharedDeviceIDs.Has(deviceID) {
+		return true
 	}
 	return alloc.allocatingCapacityForAnyClaim(deviceID)
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
@@ -48,7 +48,6 @@ func MakeDeviceID(driver, pool, device string) DeviceID {
 	return internal.MakeDeviceID(driver, pool, device)
 }
 
-type SharedDeviceID = internal.SharedDeviceID
 type DeviceConsumedCapacity = internal.DeviceConsumedCapacity
 type ConsumedCapacityCollection = internal.ConsumedCapacityCollection
 type ConsumedCapacity = internal.ConsumedCapacity
@@ -1696,10 +1695,8 @@ func (alloc *allocator) deviceCapacityInUse(deviceID DeviceID) bool {
 	}
 	// A persisted allow-multiple allocation with no per-share capacity is recorded
 	// only in AllocatedSharedDeviceIDs (with no AggregatedCapacity entry).
-	for sharedDeviceID := range alloc.allocatedState.AllocatedSharedDeviceIDs {
-		if sharedDeviceID.GetDeviceID() == deviceID {
-			return true
-		}
+	if alloc.allocatedState.AllocatedSharedDeviceIDs.Has(deviceID) {
+		return true
 	}
 	return alloc.allocatingCapacityForAnyClaim(deviceID)
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/schedulerapi/types.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/schedulerapi/types.go
@@ -83,9 +83,14 @@ func MakeSharedDeviceID(deviceID DeviceID, shareID *types.UID) SharedDeviceID {
 // This type is used in the scheduler and autoscaler contract.
 // AllocatedState packs information of allocated devices which is gathered from allocated resource claims.
 type AllocatedState struct {
-	AllocatedDevices         sets.Set[DeviceID]
-	AllocatedSharedDeviceIDs sets.Set[SharedDeviceID]
-	AggregatedCapacity       ConsumedCapacityCollection
+	// AllocatedDevices contains device IDs that are exclusively allocated to a claim.
+	AllocatedDevices sets.Set[DeviceID]
+	// AllocatedSharedDeviceIDs contains device IDs that have one or more shared allocations
+	// when the DRAConsumableCapacity feature is enabled.
+	AllocatedSharedDeviceIDs sets.Set[DeviceID]
+	// AggregatedCapacity records the consumed capacity per device ID when
+	// the DRAConsumableCapacity feature is enabled.
+	AggregatedCapacity ConsumedCapacityCollection
 }
 
 // ConsumedCapacity represents the consumed capacity of a specific resource.

--- a/test/integration/scheduler_perf/dra.go
+++ b/test/integration/scheduler_perf/dra.go
@@ -234,7 +234,7 @@ claims:
 		claims, err := draManager.ResourceClaims().List()
 		tCtx.ExpectNoError(err, "list claims")
 		allocatedDevices := sets.New[structured.DeviceID]()
-		allocatedSharedDeviceIDs := sets.New[structured.SharedDeviceID]()
+		allocatedSharedDeviceIDs := sets.New[structured.DeviceID]()
 		aggregatedCapacity := structured.NewConsumedCapacityCollection()
 		for _, claim := range claims {
 			if claim.Status.Allocation == nil {
@@ -242,13 +242,11 @@ claims:
 			}
 			for _, result := range claim.Status.Allocation.Devices.Results {
 				deviceID := structured.MakeDeviceID(result.Driver, result.Pool, result.Device)
-				allocatedDevices.Insert(deviceID)
 				if result.ShareID == nil {
 					allocatedDevices.Insert(deviceID)
 					continue
 				}
-				sharedDeviceID := structured.MakeSharedDeviceID(deviceID, result.ShareID)
-				allocatedSharedDeviceIDs.Insert(sharedDeviceID)
+				allocatedSharedDeviceIDs.Insert(deviceID)
 				claimedCapacity := result.ConsumedCapacity
 				if claimedCapacity != nil {
 					allocatedCapacity := structured.NewDeviceConsumedCapacity(deviceID, claimedCapacity)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR optimizes the linear lookup in the DRA allocator to a constant-time lookup without introducing new fields that consume extra memory.

Note: During the last release cycle, several PRs attempted to introduce a new field to avoid linear lookup. I felt it would be better to address this at the beginning of the current cycle.

Benchmark Comparison: `SchedulingThroughput`

Results from `test/integration/scheduler_perf` running `BenchmarkPerfScheduling/ConsumableCapacity`:

| Workload | Metric | Without Fix | With Fix | Delta | Throughput Gain |
|---|---|:---:|:---:|:---:|:---:|
| **half_1000nodes** | Average<br>P50<br>P90 | 50.44 pods/s<br>51.00 pods/s<br>52.00 pods/s | 89.66 pods/s<br>90.99 pods/s<br>94.01 pods/s | +39.22 pods/s<br>+39.99 pods/s<br>+42.01 pods/s | +77.75%<br>+78.41%<br>+80.79% |
| **half_500nodes** | Average<br>P50<br>P90 | 107.56 pods/s<br>108.00 pods/s<br>112.00 pods/s | 136.56 pods/s<br>137.00 pods/s<br>138.00 pods/s | +29.00 pods/s<br>+29.00 pods/s<br>+26.00 pods/s | +26.96%<br>+26.85%<br>+23.21% |
| **full_1000nodes** | Average<br>P50<br>P90 | 35.98 pods/s<br>36.00 pods/s<br>37.00 pods/s | 42.67 pods/s<br>43.03 pods/s<br>45.00 pods/s | +6.69 pods/s<br>+7.03 pods/s<br>+8.00 pods/s | +18.58%<br>+19.53%<br>+21.62% |
| **full_500nodes** | Average<br>P50<br>P90 | 90.67 pods/s<br>90.00 pods/s<br>96.00 pods/s | 94.67 pods/s<br>96.09 pods/s<br>99.75 pods/s | +4.01 pods/s<br>+6.09 pods/s<br>+3.75 pods/s | +4.42%<br>+6.77%<br>+3.91% |
| **empty_500nodes** | Average<br>P50<br>P90 | 140.55 pods/s<br>139.99 pods/s<br>144.99 pods/s | 144.67 pods/s<br>144.00 pods/s<br>149.02 pods/s | +4.12 pods/s<br>+4.01 pods/s<br>+4.03 pods/s | +2.93%<br>+2.86%<br>+2.78% |
| **empty_1000nodes** | Average<br>P50<br>P90 | 128.11 pods/s<br>128.00 pods/s<br>132.00 pods/s | 128.33 pods/s<br>129.01 pods/s<br>134.98 pods/s | +0.22 pods/s<br>+1.01 pods/s<br>+2.98 pods/s | +0.17%<br>+0.79%<br>+2.26% |


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:
YES. AI helped created the changes and refine the PR based on my suggestion. I have verified all the content created.
<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
