### PR TITLE
ktesting: fix auto-cancellation

### DIFF
--- a/test/e2e/dra/utils/deploy.go
+++ b/test/e2e/dra/utils/deploy.go
@@ -490,7 +490,12 @@ func (d *Driver) SetUp(tCtx ktesting.TContext, kubeletRootDir string, nodes *Nod
 	tCtx.Logf("deploying driver %s on nodes %v", d.Name, nodes.NodeNames)
 	d.Nodes = make(map[string]KubeletPlugin)
 
-	tCtx = tCtx.WithCancel()
+	// The driver must keep running until TearDown explicitly cancels it via
+	// d.cleanup, regardless of whether tCtx itself gets cancelled earlier
+	// (e.g. because the sub-test that called SetUp has already ended while
+	// TearDown, registered as a cleanup callback, still needs the driver to
+	// be up).
+	tCtx = tCtx.WithoutCancel().WithCancel()
 	logger := klog.FromContext(tCtx)
 	logger = klog.LoggerWithValues(logger, "driverName", d.Name)
 	if d.InstanceSuffix != "" {

--- a/test/integration/dra/core.go
+++ b/test/integration/dra/core.go
@@ -555,7 +555,12 @@ func testPublishResourceSlices(tCtx ktesting.TContext, haveLatestAPI bool, disab
 
 		controller, err := resourceslice.StartController(tCtx, opts)
 		tCtx.ExpectNoError(err, "start controller")
-		tCtx.Cleanup(controller.Stop)
+		// The controller must be stopped before tCtx gets canceled at the
+		// end of the (sub-)test, otherwise in-flight requests get aborted
+		// with a "context canceled" error which the ErrorHandler above
+		// treats as unexpected. Callers must "defer controller.Stop()"
+		// themselves instead of relying on tCtx.Cleanup, whose callbacks
+		// only run *after* automatic cancellation.
 
 		numSlices := 0
 		for _, pool := range resources.Pools {
@@ -574,6 +579,7 @@ func testPublishResourceSlices(tCtx ktesting.TContext, haveLatestAPI bool, disab
 
 	runSubTest(tCtx, "create", func(tCtx ktesting.TContext) {
 		controller, getStats, expectedStats := setup(tCtx, resources)
+		defer controller.Stop()
 		tCtx.Eventually(getStats).WithTimeout(syncDelay + 5*time.Second).Should(gomega.Equal(expectedStats))
 		expectSlices(tCtx, expectedSliceSpecs)
 		tCtx.Consistently(getStats).WithTimeout(quiesencePeriod).Should(gomega.Equal(expectedStats))
@@ -604,7 +610,8 @@ func testPublishResourceSlices(tCtx ktesting.TContext, haveLatestAPI bool, disab
 	}
 
 	runSubTest(tCtx, "recreate-after-delete", func(tCtx ktesting.TContext) {
-		_, getStats, expectedStats := setup(tCtx, resources)
+		controller, getStats, expectedStats := setup(tCtx, resources)
+		defer controller.Stop()
 		tCtx.Eventually(getStats).WithTimeout(syncDelay + 5*time.Second).Should(gomega.Equal(expectedStats))
 		expectSlices(tCtx, expectedSliceSpecs)
 		tCtx.Consistently(getStats).WithTimeout(quiesencePeriod).Should(gomega.Equal(expectedStats))
@@ -622,7 +629,8 @@ func testPublishResourceSlices(tCtx ktesting.TContext, haveLatestAPI bool, disab
 	})
 
 	runSubTest(tCtx, "fix-after-update", func(tCtx ktesting.TContext) {
-		_, getStats, expectedStats := setup(tCtx, resources)
+		controller, getStats, expectedStats := setup(tCtx, resources)
+		defer controller.Stop()
 		tCtx.Eventually(getStats).WithTimeout(syncDelay + 5*time.Second).Should(gomega.Equal(expectedStats))
 		expectSlices(tCtx, expectedSliceSpecs)
 		tCtx.Consistently(getStats).WithTimeout(quiesencePeriod).Should(gomega.Equal(expectedStats))
@@ -681,7 +689,8 @@ func testPublishResourceSlices(tCtx ktesting.TContext, haveLatestAPI bool, disab
 		}
 		slice, err := tCtx.Client().ResourceV1().ResourceSlices().Create(tCtx, slice, metav1.CreateOptions{})
 		tCtx.ExpectNoError(err, "create slice")
-		_, getStats, expectedStats := setup(tCtx, resources)
+		controller, getStats, expectedStats := setup(tCtx, resources)
+		defer controller.Stop()
 		expectedStats.NumCreates = 0
 		expectedStats.NumUpdates = 1
 		tCtx.Eventually(getStats).WithTimeout(syncDelay + 5*time.Second).Should(gomega.Equal(expectedStats))

--- a/test/utils/ktesting/tcontext.go
+++ b/test/utils/ktesting/tcontext.go
@@ -311,6 +311,9 @@ type InitOption = initoption.InitOption
 //	   })
 //
 // withTB sets up cancellation for the sub-test and uses per-test output.
+//
+// Like [Init], it cancels the returned TContext automatically when the
+// sub-test ends.
 func (tCtx TContext) withTB(tb TB) TContext {
 	tCtx.testingTB.TB = tb
 	if tCtx.perTestHeader != nil {
@@ -323,7 +326,15 @@ func (tCtx TContext) withTB(tb TB) TContext {
 	// progress report.
 	defaultProgressReporter.trackRunningTest(tb)
 
-	return tCtx.WithCancel()
+	// Cancellation for sync tests has to be handled differently,
+	// see run below.
+	tCtx = tCtx.WithCancel()
+	if !tCtx.isSyncTest {
+		runWhenDone(tb, func() {
+			tCtx.Cancel(cleanupErr(tCtx.Name()).Error())
+		})
+	}
+	return tCtx
 }
 
 // run implements the different Run and SyncTest methods. It's not an exported
@@ -343,6 +354,11 @@ func run(tCtx TContext, name string, syncTest bool, cb func(tCtx TContext)) bool
 				// so this seems okay.
 				tCtx.isSyncTest = true
 				tCtx = tCtx.WithoutCancel().withTB(t)
+				// runWhenDone's context.AfterFunc runs in a new goroutine,
+				// which synctest has no reason to schedule before its
+				// deadlock check fires the instant cb returns. Cancel
+				// synchronously here instead.
+				defer tCtx.Cancel(cleanupErr(tCtx.Name()).Error())
 				cb(tCtx)
 			}
 			if name != "" {

--- a/test/utils/ktesting/tcontext_test.go
+++ b/test/utils/ktesting/tcontext_test.go
@@ -93,6 +93,41 @@ func TestCancelBeforeCleanup(t *testing.T) {
 	})
 }
 
+func TestRunCancelBeforeCleanup(t *testing.T) {
+	tCtx := ktesting.Init(t)
+
+	tCtx.Run("sub", func(tCtx ktesting.TContext) {
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			// Blocks until the sub-test's context gets canceled automatically.
+			<-tCtx.Done()
+		}()
+
+		// See TestCancelBeforeCleanup: same reasoning applies to sub-tests.
+		tCtx.Cleanup(func() {
+			select {
+			case <-done:
+			case <-time.After(10 * time.Second):
+				t.Fatal("sub-test's TContext should already have been canceled by the time this Cleanup function runs")
+			}
+		})
+	})
+}
+
+func TestSyncTestAutoCancel(t *testing.T) {
+	tCtx := ktesting.Init(t)
+
+	// Without synchronous cancellation before the callback returns, this
+	// goroutine would still be blocked and synctest would panic with
+	// "deadlock: main bubble goroutine has exited but blocked goroutines remain".
+	tCtx.SyncTest("sub", func(tCtx ktesting.TContext) {
+		go func() {
+			<-tCtx.Done()
+		}()
+	})
+}
+
 func TestNoDeadline(t *testing.T) {
 	mockT := &deadlineT{T: t, deadline: nil}
 	tCtx := ktesting.Init(mockT)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Init cancels its TContext automatically when the test ends, via runWhenDone (context.AfterFunc on the test's own context). withTB, used by TContext.Run for sub-tests, never set this up, so a sub-test's TContext was only canceled when the whole parent test finished, not when that sub-test itself ended. Found when using the new ktesting semantic more widely.

SyncTest has a related but distinct problem: even with the above fixed, automatic cancellation via context.AfterFunc runs the callback in a new goroutine, but synctest checks for durably blocked goroutines the instant the bubble's main goroutine returns, with no guarantee that the AfterFunc goroutine ran in time. Fixed by canceling synchronously via defer around the callback instead.

Besides these fixes in ktesting itself, some tests also hadn't been fully updated to handle the revised semantic - see commits.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

Found in https://github.com/kubernetes/kubernetes/pull/141917. The same commit is currently being tested there, too.

/assign @nojnhuh 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### AI usage disclosure:

YES: AI helped with the failure analysis.