### PR TITLE
DRA: call GatherAllocatedState directly in PreFilter

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -779,37 +779,19 @@ func (pl *DynamicResources) PreFilter(ctx context.Context, state fwk.CycleState,
 		// the result invalid.
 		var allocatedState *structured.AllocatedState
 		err = wait.PollUntilContextTimeout(ctx, time.Microsecond, 5*time.Second, true /* immediate */, func(context.Context) (bool, error) {
-			if pl.fts.EnableDRAConsumableCapacity {
-				allocatedState, err = pl.draManager.ResourceClaims().GatherAllocatedState()
-				if err != nil {
-					if errors.Is(err, errClaimTrackerConcurrentModification) {
-						logger.V(6).Info("Conflicting modification during GatherAllocatedState, trying again")
-						return false, nil
-					}
-					return false, err
+			allocatedState, err = pl.draManager.ResourceClaims().GatherAllocatedState()
+			if err != nil {
+				if errors.Is(err, errClaimTrackerConcurrentModification) {
+					logger.V(6).Info("Conflicting modification during GatherAllocatedState, trying again")
+					return false, nil
 				}
-				if allocatedState == nil {
-					return false, errors.New("nil allocated state")
-				}
-				// Done.
-				return true, nil
-			} else {
-				allocatedDevices, err := pl.draManager.ResourceClaims().ListAllAllocatedDevices()
-				if err != nil {
-					if errors.Is(err, errClaimTrackerConcurrentModification) {
-						logger.V(6).Info("Conflicting modification during ListAllAllocatedDevices, trying again")
-						return false, nil
-					}
-					return false, err
-				}
-				allocatedState = &structured.AllocatedState{
-					AllocatedDevices:         allocatedDevices,
-					AllocatedSharedDeviceIDs: sets.New[structured.SharedDeviceID](),
-					AggregatedCapacity:       structured.NewConsumedCapacityCollection(),
-				}
-				// Done.
-				return true, nil
+				return false, err
 			}
+			if allocatedState == nil {
+				return false, errors.New("nil allocated state")
+			}
+			// Done.
+			return true, nil
 		})
 		if err != nil {
 			return nil, statusError(logger, fmt.Errorf("gather allocation state: %w", err))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
`GatherAllocatedState` already handles disabled consumable capacity internally. This PR simplifies `PreFilter` by calling `GatherAllocatedState` directly, removing the redundant `ListAllAllocatedDevices` branch.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A
#### Special notes for your reviewer:
I didn't remove `ListAllAllocatedDevices` from `ResourceClaimTracker`, preserving the public interface contract for downstream consumers such as Cluster Autoscaler.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:
YES. AI helped generate changes with my guidance. I have reviewed all the changes.
<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
