### PR TITLE
Automated cherry pick of #138408: Fix flapping pod.status.resourceClaimStatuses

### DIFF
--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 	"sync"
@@ -520,10 +521,25 @@ func (ec *Controller) syncPod(ctx context.Context, namespace, name string) error
 	if newPodClaims != nil {
 		// Patch the pod status with the new information about
 		// generated ResourceClaims.
-		statuses := make([]*corev1apply.PodResourceClaimStatusApplyConfiguration, 0, len(newPodClaims))
-		for podClaimName, resourceClaimName := range newPodClaims {
-			statuses = append(statuses, corev1apply.PodResourceClaimStatus().WithName(podClaimName).WithResourceClaimName(resourceClaimName))
+		mergedStatuses := make(map[string]string)
+		for _, status := range pod.Status.ResourceClaimStatuses {
+			if status.ResourceClaimName != nil {
+				mergedStatuses[status.Name] = *status.ResourceClaimName
+			}
 		}
+		maps.Copy(mergedStatuses, newPodClaims)
+
+		names := make([]string, 0, len(mergedStatuses))
+		for name := range mergedStatuses {
+			names = append(names, name)
+		}
+		slices.Sort(names)
+
+		statuses := make([]*corev1apply.PodResourceClaimStatusApplyConfiguration, 0, len(names))
+		for _, name := range names {
+			statuses = append(statuses, corev1apply.PodResourceClaimStatus().WithName(name).WithResourceClaimName(mergedStatuses[name]))
+		}
+
 		podApply := corev1apply.Pod(name, namespace).WithStatus(corev1apply.PodStatus().WithResourceClaimStatuses(statuses...))
 		if _, err := ec.kubeClient.CoreV1().Pods(namespace).ApplyStatus(ctx, podApply, metav1.ApplyOptions{FieldManager: fieldManager, Force: true}); err != nil {
 			return fmt.Errorf("update pod %s/%s ResourceClaimStatuses: %v", namespace, name, err)

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -399,6 +399,36 @@ func TestSyncHandler(t *testing.T) {
 			},
 			expectedMetrics: expectedMetrics{0, 0, 0, 0},
 		},
+		{
+			name: "flapping-resourceclaim-statuses",
+			pods: func() []*v1.Pod {
+				pod := makePod(testPodName, testNamespace, testPodUID,
+					*makePodResourceClaim("claimA", templateName),
+					*makePodResourceClaim("claimB", templateName),
+				)
+				// Initially only claimA is in status
+				pod.Status.ResourceClaimStatuses = []v1.PodResourceClaimStatus{
+					{Name: "claimA", ResourceClaimName: ptr.To("claimA-object")},
+				}
+				return []*v1.Pod{pod}
+			}(),
+			templates: []*resourceapi.ResourceClaimTemplate{template},
+			claims: []*resourceapi.ResourceClaim{
+				makeClaim("claimA-object", testNamespace, className, makeOwnerReference(testPod, true)),
+			},
+			key: podKeyPrefix + testNamespace + "/" + testPodName,
+			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
+				testPodName: {
+					{Name: "claimA", ResourceClaimName: ptr.To("claimA-object")},
+					{Name: "claimB", ResourceClaimName: ptr.To("test-pod-claimB--1")},
+				},
+			},
+			expectedClaims: []resourceapi.ResourceClaim{
+				*makeClaim("claimA-object", testNamespace, className, makeOwnerReference(testPod, true)),
+				*makeTemplatedClaim("claimB", testPodName+"-claimB-", testNamespace, className, 1, makeOwnerReference(testPod, true), nil),
+			},
+			expectedMetrics: expectedMetrics{1, 0, 0, 0},
+		},
 	}
 
 	for _, tc := range tests {
@@ -424,6 +454,14 @@ func TestSyncHandler(t *testing.T) {
 					return true, nil, apierrors.NewConflict(action.GetResource().GroupResource(), "fake name", errors.New("fake conflict"))
 				})
 			}
+			var appliedPatches []string
+			fakeKubeClient.PrependReactor("patch", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+				patchAction := action.(k8stesting.PatchAction)
+				if patchAction.GetSubresource() == "status" {
+					appliedPatches = append(appliedPatches, string(patchAction.GetPatch()))
+				}
+				return false, nil, nil
+			})
 			informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
 			podInformer := informerFactory.Core().V1().Pods()
 			claimInformer := informerFactory.Resource().V1().ResourceClaims()
@@ -469,6 +507,12 @@ func TestSyncHandler(t *testing.T) {
 			}
 			if tc.expectedError != "" {
 				t.Fatalf("expected error, got none")
+			}
+
+			if tc.name == "flapping-resourceclaim-statuses" {
+				assert.Len(t, appliedPatches, 1, "should have applied status once")
+				assert.Contains(t, appliedPatches[0], `"name":"claimA"`, "patch should contain claimA")
+				assert.Contains(t, appliedPatches[0], `"name":"claimB"`, "patch should contain claimB")
 			}
 
 			claims, err := fakeKubeClient.ResourceV1().ResourceClaims("").List(tCtx, metav1.ListOptions{})


### PR DESCRIPTION
Cherry pick of #138408 on release-1.35.

#138408: Fix flapping pod.status.resourceClaimStatuses

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

Manual conflict resolution was required in `controller_test.go` but the diff is the same.

### Cherry-pick criteria: critical bug fix.

- Impact: `pod.status.resourceClaimStatuses` keeps flipping between subsets of the pod's claims. Each sync drops the entries it didn't include and a later sync restores them. Consumers reading the status can observe an incomplete claim list at any given moment, and the pod is rewritten in a hot loop. Details in #138407 / #138408.
- Scope/risk: ~15 lines in `syncPod`, no API or behavior change beyond making the apply include existing claims. Covered by a new unit test.
- Not alpha-gated: DRA core is on by default. Any pod with ≥2 template claims is affected.

AI was used to help prepare this PR.

#### What type of PR is this?
/kind bug

```release-note
Fixed a bug where Pod `.status.resourceClaimStatuses` could flap between partial lists of claims, when multiple claims were used in the pod.
```