### PR TITLE
test/e2e_node: match the userns mapping precheck to the kubelet's lookups

### DIFF
--- a/test/e2e_node/user_namespaces_test.go
+++ b/test/e2e_node/user_namespaces_test.go
@@ -128,12 +128,11 @@ var _ = SIGDescribe("user namespaces kubeconfig tests", "[LinuxOnly]", feature.U
 	})
 })
 
+// hasKubeletUsernsMappings reports whether the kubelet uses subordinate IDs configured for
+// its account, in the kubelet's lookup order, failing closed when they cannot be read.
 func hasKubeletUsernsMappings() (bool, error) {
-	if _, err := user.Lookup(kubeletUserForUsernsMapping); err != nil {
-		var e user.UnknownUserError
-		if errors.As(err, &e) {
-			err = nil
-		}
+	found, err := kubeletUserExists()
+	if err != nil || !found {
 		return false, err
 	}
 	cmdBin, err := exec.LookPath(getsubuidsBinary)
@@ -143,37 +142,56 @@ func hasKubeletUsernsMappings() (bool, error) {
 		}
 		return false, err
 	}
+	// The kubelet treats a getsubids failure as fatal from here on, since it cannot tell
+	// an account with no ranges from an unreachable backend, so this does not swallow it.
 	outUids, err := getsubids(cmdBin, kubeletUserForUsernsMapping)
 	if err != nil {
 		return false, err
 	}
 	if outUids == "" {
-		return false, nil
+		return false, fmt.Errorf("getsubids printed no range for user %q", kubeletUserForUsernsMapping)
 	}
 	outGids, err := getsubids(cmdBin, "-g", kubeletUserForUsernsMapping)
 	if err != nil {
 		return false, err
 	}
-	if string(outUids) != string(outGids) {
+	if outUids != outGids {
 		return false, fmt.Errorf("user %q has different subuids and subgids: %q vs %q", kubeletUserForUsernsMapping, outUids, outGids)
 	}
 	return true, nil
 }
 
-// getsubids runs the getsubids command to fetch subuid mappings for a user.
-// If the command fails with "Error fetching ranges", it returns an empty string
-// to indicate that no subuid mappings were found, which is not considered an error.
-// Otherwise, it returns the output of the command as a string.
-// (e.g., "0: user 100000 65536")
+// kubeletUserExists resolves the kubelet account through getent, so an NSS account is seen,
+// and through os/user when getent cannot be run, which is the kubelet's own order.
+func kubeletUserExists() (bool, error) {
+	getent, err := exec.LookPath("getent")
+	if err != nil {
+		if _, err := user.Lookup(kubeletUserForUsernsMapping); err != nil {
+			if _, ok := errors.AsType[user.UnknownUserError](err); ok {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	}
+	err = exec.Command(getent, "passwd", kubeletUserForUsernsMapping).Run()
+	if err == nil {
+		return true, nil
+	}
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok && exitErr.ExitCode() == 2 {
+		return false, nil // getent(1): 2 = key not found
+	}
+	return false, fmt.Errorf("looking up user %q via getent: %w", kubeletUserForUsernsMapping, err)
+}
+
+// getsubids runs getsubids for a user and returns its output, such as "0: user 100000 65536".
+// A failing command comes back as an error, which is how the kubelet treats it as well.
 func getsubids(cmdBin string, cmdArgs ...string) (string, error) {
 	var stderr bytes.Buffer
 	cmd := exec.Command(cmdBin, cmdArgs...)
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {
-		if strings.TrimSpace(stderr.String()) == "Error fetching ranges" {
-			return "", nil // No subuid mappings found, this is not an error
-		}
 		return "", fmt.Errorf("failed to run %v: %w (stderr=%q)", cmd.Args, err, stderr.String())
 	}
 	return strings.TrimSpace(string(out)), nil


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig node

#### What this PR does / why we need it:

Depends on #141971.

[`hasKubeletUsernsMappings`](https://github.com/kubernetes/kubernetes/blob/912ec3583d7733a240dad6a3755f5f2f6b76be3e/test/e2e_node/user_namespaces_test.go#L131-L161) decides whether the node has subordinate IDs configured for the kubelet account, so that the `idsPerPod` test can skip rather than restart a kubelet into a pool it did not expect. It answers that question differently from the kubelet in two places.

It resolves the account with `os/user`, while [the kubelet](https://github.com/kubernetes/kubernetes/blob/912ec3583d7733a240dad6a3755f5f2f6b76be3e/pkg/kubelet/kubelet_pods.go#L187) goes through `getent` first. The two agree on a normal CI host, but not on a node where `getent` is missing and the account is local, or where the account is served only by NSS.

It also treats a `getsubids` run that fails with `Error fetching ranges` as [no mapping](https://github.com/kubernetes/kubernetes/blob/912ec3583d7733a240dad6a3755f5f2f6b76be3e/test/e2e_node/user_namespaces_test.go#L174-L176). The kubelet treats the same run as fatal once the account exists and `getsubids` is present, and [says why](https://github.com/kubernetes/kubernetes/blob/912ec3583d7733a240dad6a3755f5f2f6b76be3e/pkg/kubelet/kubelet_pods.go#L145-L150): it cannot tell an account with no ranges from a backend it could not reach. On a node in that state the precheck said there was nothing to skip for, the test changed `idsPerPod` and restarted the kubelet, and the kubelet then failed for a reason the test never named.

This resolves the account in the kubelet's order, `getent` and then `os/user` when `getent` cannot be run, and lets a failing or empty `getsubids` run come back from the precheck as an error.

The `os/user` step is the order #141971 gives the kubelet, so this reads best alongside it. On master today the kubelet stops at `getent` and takes the default pool when it is missing, so on a node without `getent` whose local account has `getsubids` installed but no ranges, this precheck fails where the old one went ahead and the kubelet came back fine. That needs a node with no `getent`, and it is what the kubelet does once #141971 lands. The NSS-only case above stays a difference either way, since the test binary's `os/user` goes through libc and the kubelet's does not.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The test is `[Serial]`, so `pull-kubernetes-node-e2e-containerd` skips it. `pull-kubernetes-node-kubelet-serial-containerd` runs on any change under `test/e2e_node/` with a `[Serial]` focus, so it should pick this up on its own. I cannot run node e2e here, so the two new helpers were copied into a scratch package and driven with fake binaries: `getent` exiting 2 is not found and not an error, exiting 1 is an error, missing falls back to `os/user`, and a `getsubids` printing `Error fetching ranges`, or printing nothing at all, now returns an error where it returned nothing before.

The only behavior removed is the skip on that stderr text. A node that used to get past the precheck that way was about to restart a kubelet that would not come back.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

YES. Drafted with an AI coding assistant, measured and reviewed by the author.

/cc @rata



