### PR TITLE
kubelet: prevent duplicate static pod manifests

### DIFF
--- a/pkg/kubelet/config/file.go
+++ b/pkg/kubelet/config/file.go
@@ -156,7 +156,8 @@ func (s *sourceFile) listConfig(logger klog.Logger) error {
 
 // Get as many pod manifests as we can from a directory. Return an error if and only if something
 // prevented us from reading anything at all. Do not return an error if only some files
-// were problematic.
+// were problematic. If multiple manifests define the same pod, use the first one found
+// and ignore the duplicates.
 func (s *sourceFile) extractFromDir(logger klog.Logger, name string) ([]*v1.Pod, error) {
 	dirents, err := filepath.Glob(filepath.Join(name, "[^.]*"))
 	if err != nil {
@@ -169,6 +170,9 @@ func (s *sourceFile) extractFromDir(logger klog.Logger, name string) ([]*v1.Pod,
 	}
 
 	sort.Strings(dirents)
+
+	seenPods := make(map[string]string)
+
 	for _, path := range dirents {
 		statInfo, err := os.Stat(path)
 		if err != nil {
@@ -185,16 +189,34 @@ func (s *sourceFile) extractFromDir(logger klog.Logger, name string) ([]*v1.Pod,
 				if !os.IsNotExist(err) {
 					logger.Error(err, "Could not process manifest file", "path", path)
 				}
-			} else {
-				pods = append(pods, pod)
+				continue
 			}
+
+			podKey, err := cache.MetaNamespaceKeyFunc(pod)
+			if err != nil {
+				logger.Error(err, "Could not get pod key", "path", path)
+				continue
+			}
+
+			if previousPath, exists := seenPods[podKey]; exists {
+				klog.Warningf(
+					"Static pod %q already defined by %s, ignoring duplicate from %s",
+					podKey,
+					previousPath,
+					path,
+				)
+				continue
+			}
+
+			seenPods[podKey] = path
+			pods = append(pods, pod)
 		default:
 			logger.Error(nil, "Manifest path is not a directory or file", "path", path, "mode", statInfo.Mode())
 		}
 	}
+
 	return pods, nil
 }
-
 // extractFromFile parses a file for Pod configuration information.
 func (s *sourceFile) extractFromFile(logger klog.Logger, filename string) (pod *v1.Pod, err error) {
 	logger.V(3).Info("Reading config file", "path", filename)

--- a/pkg/kubelet/config/file_test.go
+++ b/pkg/kubelet/config/file_test.go
@@ -83,3 +83,65 @@ func removeAll(dir string, t *testing.T) {
 		t.Fatalf("unable to remove dir %s: %v", dir, err)
 	}
 }
+
+func TestExtractFromDirDuplicatePod(t *testing.T) {
+	dirName, err := mkTempDir("file-test")
+	if err != nil {
+		t.Fatalf("unable to create temp dir: %v", err)
+	}
+	defer removeAll(dirName, t)
+
+	logger, _ := ktesting.NewTestContext(t)
+
+	podManifest := `apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: default
+spec:
+  containers:
+  - name: test
+    image: nginx:1.25
+`
+
+	backupManifest := `apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: default
+spec:
+  containers:
+  - name: test
+    image: nginx:1.26
+`
+
+	manifestPath := filepath.Join(dirName, "test-pod.yaml")
+	backupPath := filepath.Join(dirName, "test-pod.yaml.backup")
+
+	if err := os.WriteFile(manifestPath, []byte(podManifest), 0644); err != nil {
+		t.Fatalf("unable to write manifest: %v", err)
+	}
+
+	if err := os.WriteFile(backupPath, []byte(backupManifest), 0644); err != nil {
+		t.Fatalf("unable to write backup manifest: %v", err)
+	}
+
+	ch := make(chan sourceUpdate, 1)
+	lw := newSourceFile(dirName, "localhost", time.Millisecond, ch)
+
+	pods, err := lw.extractFromDir(logger, dirName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(pods) != 1 {
+		t.Fatalf("expected 1 pod, got %d", len(pods))
+	}
+
+	if pods[0].Spec.Containers[0].Image != "nginx:1.25" {
+		t.Fatalf(
+			"expected first manifest to win, got image %q",
+			pods[0].Spec.Containers[0].Image,
+		)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When the kubelet reads static pod manifests from a directory, multiple files can define the same pod. This can result in a duplicate manifest being processed for the same pod.

This change detects duplicate static pod manifests by pod namespace/name, keeps the first manifest found in sorted filename order, and logs a warning when subsequent duplicates are encountered and ignored.

A regression test has been added to verify that duplicate manifests do not result in multiple pods and that the first manifest takes precedence.

#### Which issue(s) this PR is related to:

Fixes #136962

#### Special notes for your reviewer:

The directory entries are sorted before processing, so duplicate handling is deterministic: the first manifest in filename order is retained and subsequent manifests for the same pod are ignored.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs, usage docs, etc.:

```docs
```

#### AI usage disclosure:

YES. AI was used to assist with test cases and drafting the regression test and PR description. The author is responsible for reviewing and validating all submitted changes.