### PR TITLE
kubelet: apply CrashLoopBackOff to containers that fail before ever running

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1655,6 +1655,18 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 				metrics.StartedHostProcessContainersErrorsTotal.WithLabelValues(metricLabel, err.Error()).Inc()
 			}
 			startContainerResult.Fail(err, msg)
+			// startContainer failed before the container ever reached a running state
+			// (e.g. CreateContainer was rejected because the memory limit is below the
+			// runtime's floor). Such attempts never produce a container status, so
+			// doBackOff's exit-time check below can never see them, and these failures
+			// would otherwise just repeat at the flat pod-worker retry period forever
+			// instead of escalating like other CrashLoopBackOff cases. Feed the same
+			// per-container backoff entry used by CrashLoopBackOff so these attempts
+			// get the same exponential backoff and status reporting.
+			if errors.Is(err, ErrCreateContainerConfig) || errors.Is(err, ErrPreCreateHook) || errors.Is(err, ErrCreateContainer) ||
+				errors.Is(err, ErrPreStartHook) || errors.Is(err, kubecontainer.ErrRunContainer) {
+				backOff.Next(GetBackoffKey(pod, spec.container), backOff.Clock.Now())
+			}
 			// known errors that are logged in other places are logged at higher levels here to avoid
 			// repetitive log spam
 			switch {
@@ -1821,6 +1833,22 @@ func (m *kubeGenericRuntimeManager) getImageVolumes(ctx context.Context, pod *v1
 // a detailed error message.
 func (m *kubeGenericRuntimeManager) doBackOff(ctx context.Context, pod *v1.Pod, container *v1.Container, podStatus *kubecontainer.PodStatus, backOff *flowcontrol.Backoff) (bool, string, error) {
 	logger := klog.FromContext(ctx)
+	key := GetBackoffKey(pod, container)
+
+	// Containers that fail before ever reaching a running state (see the Next() call in
+	// the start() closure above) have no exited container status for the check below to
+	// find, so check the update-time based backoff first.
+	if backOff.IsInBackOffSinceUpdate(key, backOff.Clock.Now()) {
+		if containerRef, err := kubecontainer.GenerateContainerRef(pod, container); err == nil {
+			m.recorder.WithLogger(logger).Eventf(containerRef, v1.EventTypeWarning, events.BackOffStartContainer,
+				"Back-off restarting failed container %s in pod %s", container.Name, format.Pod(pod))
+		}
+		backoff := backOff.Get(key)
+		err := fmt.Errorf("back-off %s restarting failed container=%s pod=%s", backoff, container.Name, format.Pod(pod))
+		logger.V(3).Info("Back-off restarting failed container", "err", err.Error())
+		return true, err.Error(), kubecontainer.NewBackoffError(kubecontainer.ErrCrashLoopBackOff, backOff.Clock.Now().Add(backoff))
+	}
+
 	var cStatus *kubecontainer.Status
 	for _, c := range podStatus.ContainerStatuses {
 		if c.Name == container.Name && c.State == kubecontainer.ContainerStateExited {
@@ -1836,8 +1864,6 @@ func (m *kubeGenericRuntimeManager) doBackOff(ctx context.Context, pod *v1.Pod, 
 	logger.V(3).Info("Checking backoff for container in pod", "containerName", container.Name, "pod", klog.KObj(pod))
 	// Use the finished time of the latest exited container as the start point to calculate whether to do back-off.
 	ts := cStatus.FinishedAt
-	// backOff requires a unique key to identify the container.
-	key := GetBackoffKey(pod, container)
 	if backOff.IsInBackOffSince(key, ts) {
 		if containerRef, err := kubecontainer.GenerateContainerRef(pod, container); err == nil {
 			m.recorder.WithLogger(logger).Eventf(containerRef, v1.EventTypeWarning, events.BackOffStartContainer,

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -4900,6 +4900,29 @@ func TestDoBackOff(t *testing.T) {
 			expectedInBackOff: true,
 			expectedError:     kubecontainer.NewBackoffError(kubecontainer.ErrCrashLoopBackOff, fakeClock.Now().Add(time.Second)),
 		},
+		{
+			name: "no container status, never attempted — should not be in backoff",
+			podStatus: &kubecontainer.PodStatus{
+				ContainerStatuses: []*kubecontainer.Status{},
+			},
+			backoff:           flowcontrol.NewFakeBackOff(time.Second, time.Minute, fakeClock),
+			expectedInBackOff: false,
+		},
+		{
+			name: "no container status, but CreateContainer already failed once (update-time backoff)",
+			podStatus: &kubecontainer.PodStatus{
+				ContainerStatuses: []*kubecontainer.Status{}, // CreateContainer was rejected; no status was ever recorded
+			},
+			backoff: flowcontrol.NewFakeBackOff(time.Second, time.Minute, fakeClock),
+			backoffUpdateFn: func(backoff *flowcontrol.Backoff, pod *v1.Pod, podStatus *kubecontainer.PodStatus) {
+				// Simulates the backOff.Next() call added to the start() closure when
+				// startContainer() fails with ErrCreateContainer/ErrCreateContainerConfig/etc.
+				key := GetBackoffKey(pod, &pod.Spec.Containers[0])
+				backoff.Next(key, fakeClock.Now())
+			},
+			expectedInBackOff: true,
+			expectedError:     kubecontainer.NewBackoffError(kubecontainer.ErrCrashLoopBackOff, fakeClock.Now().Add(time.Second)),
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When `startContainer` fails before the container ever reaches a running state (e.g. `CreateContainer` is rejected because the memory limit is below the runtime's floor, or a pre-create/pre-start hook fails), no container status is ever recorded for that attempt. doBackOff only checks for an exited container status to decide whether to apply CrashLoopBackOff, so these pre-run failures never got exponential backoff or CrashLoopBackOff status/event reporting — they just kept retrying at the pod-worker's flat ~10s cadence forever instead of escalating like other persistently-failing containers do.

This PR feeds these failures (`ErrCreateContainerConfig`, `ErrPreCreateHook`, `ErrCreateContainer`, `ErrPreStartHook`, `kubecontainer.ErrRunContainer`) into the same per-container backoff entry used by `CrashLoopBackOff`, and updates `doBackOff` to also check the update-time based backoff (`IsInBackOffSinceUpdate`) before falling back to the existing exited-status check. This ensures containers that fail before ever running are still rate-limited on retries

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #142032 
#### Special notes for your reviewer:
Added unit tests for this.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where kubelet did not apply exponential CrashLoopBackOff to a container that failed before ever reaching a running state (e.g. CreateContainer rejected due to an invalid resource limit), so such failures never escalated backoff or reported a CrashLoopBackOff status/event.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
NO