### PR TITLE
Don't set nf_conntrack_max if it's already larger than needed

### DIFF
--- a/pkg/proxy/conntrack/sysctls.go
+++ b/pkg/proxy/conntrack/sysctls.go
@@ -33,7 +33,7 @@ import (
 )
 
 func SetSysctls(ctx context.Context, config *kubeproxyconfig.KubeProxyConntrackConfiguration) error {
-	return setSysctls(ctx, realConntrackConfigurer{}, config)
+	return setSysctls(ctx, realConntrackConfigurer{sys: sysctl.New()}, config)
 }
 
 // conntrackConfigurer is a mockable interface for setting conntrack sysctls.
@@ -41,6 +41,8 @@ func SetSysctls(ctx context.Context, config *kubeproxyconfig.KubeProxyConntrackC
 // Descriptions of the various sysctl fields can be found here:
 // https://www.kernel.org/doc/Documentation/networking/nf_conntrack-sysctl.txt
 type conntrackConfigurer interface {
+	// GetMax gets the current value of nf_conntrack_max.
+	GetMax(ctx context.Context) (int, error)
 	// SetMax adjusts nf_conntrack_max.
 	SetMax(ctx context.Context, max int) error
 	// SetTCPEstablishedTimeout adjusts nf_conntrack_tcp_timeout_established.
@@ -69,9 +71,11 @@ func setSysctls(ctx context.Context, ct conntrackConfigurer, config *kubeproxyco
 		return err
 	}
 	if max > 0 {
-		err := ct.SetMax(ctx, max)
-		if err != nil {
-			return err
+		if curMax, err := ct.GetMax(ctx); err != nil || curMax < max {
+			err := ct.SetMax(ctx, max)
+			if err != nil {
+				return err
+			}
 		}
 
 		// Check if hashsize is large enough for the nf_conntrack_max value.
@@ -149,6 +153,7 @@ func getConntrackMax(ctx context.Context, config *kubeproxyconfig.KubeProxyConnt
 }
 
 type realConntrackConfigurer struct {
+	sys sysctl.Interface
 }
 
 // DetectNumCPU returns the CPU count used to size nf_conntrack_max. That limit
@@ -163,13 +168,12 @@ func (rct realConntrackConfigurer) DetectNumCPU() int {
 	return runtime.NumCPU()
 }
 
+func (rct realConntrackConfigurer) GetMax(_ context.Context) (int, error) {
+	return rct.sys.GetSysctl("net/netfilter/nf_conntrack_max")
+}
+
 func (rct realConntrackConfigurer) SetMax(ctx context.Context, max int) error {
-	logger := klog.FromContext(ctx)
-	logger.Info("Setting nf_conntrack_max", "nfConntrackMax", max)
-	if err := rct.setIntSysCtl(ctx, "nf_conntrack_max", max); err != nil {
-		return err
-	}
-	return nil
+	return rct.setIntSysCtl(ctx, "nf_conntrack_max", max)
 }
 
 func (rct realConntrackConfigurer) SetTCPEstablishedTimeout(ctx context.Context, seconds int) error {
@@ -196,10 +200,9 @@ func (rct realConntrackConfigurer) setIntSysCtl(ctx context.Context, name string
 	logger := klog.FromContext(ctx)
 	entry := "net/netfilter/" + name
 
-	sys := sysctl.New()
-	if val, _ := sys.GetSysctl(entry); val != value {
+	if val, _ := rct.sys.GetSysctl(entry); val != value {
 		logger.Info("Set sysctl", "entry", entry, "value", value)
-		if err := sys.SetSysctl(entry, value); err != nil {
+		if err := rct.sys.SetSysctl(entry, value); err != nil {
 			return err
 		}
 	}

--- a/pkg/proxy/conntrack/sysctls.go
+++ b/pkg/proxy/conntrack/sysctls.go
@@ -54,6 +54,11 @@ type conntrackConfigurer interface {
 	// SetUDPStreamTimeout adjusts nf_conntrack_udp_timeout_stream.
 	SetUDPStreamTimeout(ctx context.Context, seconds int) error
 
+	// GetHashsize gets the conntrack module "hashsize" parameter
+	GetHashsize(ctx context.Context) (int, error)
+	// SetHashsize sets the conntrack module "hashsize" parameter
+	SetHashsize(ctx context.Context, value int) error
+
 	// DetectNumCPU returns the number of CPU cores in the system
 	DetectNumCPU() int
 }
@@ -67,6 +72,18 @@ func setSysctls(ctx context.Context, ct conntrackConfigurer, config *kubeproxyco
 		err := ct.SetMax(ctx, max)
 		if err != nil {
 			return err
+		}
+
+		// Check if hashsize is large enough for the nf_conntrack_max value.
+		hashsize, err := ct.GetHashsize(ctx)
+		if err != nil {
+			return err
+		}
+		if hashsize < max/4 {
+			err = ct.SetHashsize(ctx, max/4)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -152,18 +169,7 @@ func (rct realConntrackConfigurer) SetMax(ctx context.Context, max int) error {
 	if err := rct.setIntSysCtl(ctx, "nf_conntrack_max", max); err != nil {
 		return err
 	}
-
-	// Check if hashsize is large enough for the nf_conntrack_max value.
-	hashsize, err := readIntStringFile("/sys/module/nf_conntrack/parameters/hashsize")
-	if err != nil {
-		return err
-	}
-	if hashsize >= (max / 4) {
-		return nil
-	}
-
-	logger.Info("Setting conntrack hashsize", "conntrackHashsize", max/4)
-	return writeIntStringFile("/sys/module/nf_conntrack/parameters/hashsize", max/4)
+	return nil
 }
 
 func (rct realConntrackConfigurer) SetTCPEstablishedTimeout(ctx context.Context, seconds int) error {
@@ -200,14 +206,15 @@ func (rct realConntrackConfigurer) setIntSysCtl(ctx context.Context, name string
 	return nil
 }
 
-func readIntStringFile(filename string) (int, error) {
-	b, err := os.ReadFile(filename)
+func (rct realConntrackConfigurer) GetHashsize(_ context.Context) (int, error) {
+	b, err := os.ReadFile("/sys/module/nf_conntrack/parameters/hashsize")
 	if err != nil {
 		return -1, err
 	}
 	return strconv.Atoi(strings.TrimSpace(string(b)))
 }
 
-func writeIntStringFile(filename string, value int) error {
-	return os.WriteFile(filename, []byte(strconv.Itoa(value)), 0640)
+func (rct realConntrackConfigurer) SetHashsize(ctx context.Context, value int) error {
+	klog.FromContext(ctx).Info("Setting conntrack hashsize", "conntrackHashsize", value)
+	return os.WriteFile("/sys/module/nf_conntrack/parameters/hashsize", []byte(strconv.Itoa(value)), 0640)
 }

--- a/pkg/proxy/conntrack/sysctls.go
+++ b/pkg/proxy/conntrack/sysctls.go
@@ -53,10 +53,13 @@ type conntrackConfigurer interface {
 	SetUDPTimeout(ctx context.Context, seconds int) error
 	// SetUDPStreamTimeout adjusts nf_conntrack_udp_timeout_stream.
 	SetUDPStreamTimeout(ctx context.Context, seconds int) error
+
+	// DetectNumCPU returns the number of CPU cores in the system
+	DetectNumCPU() int
 }
 
 func setSysctls(ctx context.Context, ct conntrackConfigurer, config *kubeproxyconfig.KubeProxyConntrackConfiguration) error {
-	max, err := getConntrackMax(ctx, config, detectNumCPU())
+	max, err := getConntrackMax(ctx, config, ct.DetectNumCPU())
 	if err != nil {
 		return err
 	}
@@ -128,19 +131,19 @@ func getConntrackMax(ctx context.Context, config *kubeproxyconfig.KubeProxyConnt
 	return 0, nil
 }
 
-// detectNumCPU returns the CPU count used to size nf_conntrack_max. That limit
+type realConntrackConfigurer struct {
+}
+
+// DetectNumCPU returns the CPU count used to size nf_conntrack_max. That limit
 // is host-wide, so it must be based on the node's CPU count, not runtime.NumCPU():
 // runtime.NumCPU() honors the process cpuset and undercounts when kube-proxy
 // runs under a static CPU policy. cpuset.NumCPU() reads the node's online CPU
 // count from sysfs instead, falling back to runtime.NumCPU() if it can't.
-func detectNumCPU() int {
+func (rct realConntrackConfigurer) DetectNumCPU() int {
 	if n, err := cpuset.NumCPU(); err == nil && n > 0 {
 		return n
 	}
 	return runtime.NumCPU()
-}
-
-type realConntrackConfigurer struct {
 }
 
 func (rct realConntrackConfigurer) SetMax(ctx context.Context, max int) error {

--- a/pkg/proxy/conntrack/sysctls_test.go
+++ b/pkg/proxy/conntrack/sysctls_test.go
@@ -84,12 +84,16 @@ func TestGetConntrackMax(t *testing.T) {
 }
 
 type fakeConntracker struct {
+	max      int
 	hashsize int
 	err      error
 
 	called []string
 }
 
+func (fc *fakeConntracker) GetMax(ctx context.Context) (int, error) {
+	return fc.max, fc.err
+}
 func (fc *fakeConntracker) SetMax(ctx context.Context, max int) error {
 	fc.called = append(fc.called, fmt.Sprintf("SetMax(%d)", max))
 	return fc.err
@@ -130,6 +134,7 @@ func TestSetupConntrack(t *testing.T) {
 	tests := []struct {
 		name         string
 		config       kubeproxyconfig.KubeProxyConntrackConfiguration
+		max          int
 		hashsize     int
 		conntrackErr error
 		expect       []string
@@ -141,11 +146,38 @@ func TestSetupConntrack(t *testing.T) {
 			expect: nil,
 		},
 		{
-			name: "SetMax is called if conntrack.maxPerCore is specified",
+			name: "SetMax is called if conntrack.maxPerCore is specified and sysctl is unset",
 			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
 				MaxPerCore: ptr.To(int32(12)),
 			},
 			expect: []string{"SetMax(96)", "SetHashsize(24)"},
+		},
+		{
+			name: "SetMax is not called if sysctl value is already correct",
+			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
+				MaxPerCore: ptr.To(int32(12)),
+			},
+			max:      96,
+			hashsize: 24,
+			expect:   nil,
+		},
+		{
+			name: "SetMax is not called if sysctl value is higher than wanted",
+			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
+				MaxPerCore: ptr.To(int32(12)),
+			},
+			max:      192,
+			hashsize: 48,
+			expect:   nil,
+		},
+		{
+			name: "SetMax is called if sysctl value is too low",
+			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
+				MaxPerCore: ptr.To(int32(12)),
+			},
+			max:      48,
+			hashsize: 12,
+			expect:   []string{"SetMax(96)", "SetHashsize(24)"},
 		},
 		{
 			name: "SetMax is not called if conntrack.maxPerCore is 0",
@@ -155,10 +187,20 @@ func TestSetupConntrack(t *testing.T) {
 			expect: nil,
 		},
 		{
+			name: "SetHashsize is called if max is correct but hashsize isn't",
+			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
+				MaxPerCore: ptr.To(int32(12)),
+			},
+			max:      96,
+			hashsize: 0,
+			expect:   []string{"SetHashsize(24)"},
+		},
+		{
 			name: "SetHashsize is not called if max is wrong but hashsize is correct",
 			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
 				MaxPerCore: ptr.To(int32(12)),
 			},
+			max:      48,
 			hashsize: 24,
 			expect:   []string{"SetMax(96)"},
 		},
@@ -245,7 +287,7 @@ func TestSetupConntrack(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			fc := &fakeConntracker{hashsize: test.hashsize, err: test.conntrackErr}
+			fc := &fakeConntracker{max: test.max, hashsize: test.hashsize, err: test.conntrackErr}
 			err := setSysctls(ctx, fc, &test.config)
 			if test.wantErr && err == nil {
 				t.Errorf("Test %q: Expected error, got nil", test.name)

--- a/pkg/proxy/conntrack/sysctls_test.go
+++ b/pkg/proxy/conntrack/sysctls_test.go
@@ -88,9 +88,8 @@ type fakeConntracker struct {
 	err    error
 }
 
-// SetMax value is calculated based on the number of CPUs by getConntrackMax()
 func (fc *fakeConntracker) SetMax(ctx context.Context, max int) error {
-	fc.called = append(fc.called, "SetMax")
+	fc.called = append(fc.called, fmt.Sprintf("SetMax(%d)", max))
 	return fc.err
 }
 func (fc *fakeConntracker) SetTCPEstablishedTimeout(ctx context.Context, seconds int) error {
@@ -113,6 +112,9 @@ func (fc *fakeConntracker) SetUDPStreamTimeout(ctx context.Context, seconds int)
 	fc.called = append(fc.called, fmt.Sprintf("SetUDPStreamTimeout(%d)", seconds))
 	return fc.err
 }
+func (fc *fakeConntracker) DetectNumCPU() int {
+	return 8
+}
 
 func TestSetupConntrack(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
@@ -133,7 +135,7 @@ func TestSetupConntrack(t *testing.T) {
 			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
 				MaxPerCore: ptr.To(int32(12)),
 			},
-			expect: []string{"SetMax"},
+			expect: []string{"SetMax(96)"},
 		},
 		{
 			name: "SetMax is not called if conntrack.maxPerCore is 0",

--- a/pkg/proxy/conntrack/sysctls_test.go
+++ b/pkg/proxy/conntrack/sysctls_test.go
@@ -84,8 +84,10 @@ func TestGetConntrackMax(t *testing.T) {
 }
 
 type fakeConntracker struct {
+	hashsize int
+	err      error
+
 	called []string
-	err    error
 }
 
 func (fc *fakeConntracker) SetMax(ctx context.Context, max int) error {
@@ -112,6 +114,13 @@ func (fc *fakeConntracker) SetUDPStreamTimeout(ctx context.Context, seconds int)
 	fc.called = append(fc.called, fmt.Sprintf("SetUDPStreamTimeout(%d)", seconds))
 	return fc.err
 }
+func (fc *fakeConntracker) GetHashsize(ctx context.Context) (int, error) {
+	return fc.hashsize, fc.err
+}
+func (fc *fakeConntracker) SetHashsize(ctx context.Context, value int) error {
+	fc.called = append(fc.called, fmt.Sprintf("SetHashsize(%d)", value))
+	return fc.err
+}
 func (fc *fakeConntracker) DetectNumCPU() int {
 	return 8
 }
@@ -121,8 +130,9 @@ func TestSetupConntrack(t *testing.T) {
 	tests := []struct {
 		name         string
 		config       kubeproxyconfig.KubeProxyConntrackConfiguration
-		expect       []string
+		hashsize     int
 		conntrackErr error
+		expect       []string
 		wantErr      bool
 	}{
 		{
@@ -135,7 +145,7 @@ func TestSetupConntrack(t *testing.T) {
 			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
 				MaxPerCore: ptr.To(int32(12)),
 			},
-			expect: []string{"SetMax(96)"},
+			expect: []string{"SetMax(96)", "SetHashsize(24)"},
 		},
 		{
 			name: "SetMax is not called if conntrack.maxPerCore is 0",
@@ -143,6 +153,14 @@ func TestSetupConntrack(t *testing.T) {
 				MaxPerCore: ptr.To(int32(0)),
 			},
 			expect: nil,
+		},
+		{
+			name: "SetHashsize is not called if max is wrong but hashsize is correct",
+			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
+				MaxPerCore: ptr.To(int32(12)),
+			},
+			hashsize: 24,
+			expect:   []string{"SetMax(96)"},
 		},
 		{
 			name: "SetTCPEstablishedTimeout is called if conntrack.tcpEstablishedTimeout is specified",
@@ -227,7 +245,7 @@ func TestSetupConntrack(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			fc := &fakeConntracker{err: test.conntrackErr}
+			fc := &fakeConntracker{hashsize: test.hashsize, err: test.conntrackErr}
 			err := setSysctls(ctx, fc, &test.config)
 			if test.wantErr && err == nil {
 				t.Errorf("Test %q: Expected error, got nil", test.name)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind regression

#### What this PR does / why we need it:
#137002 (in 1.36) changed kube-proxy to cap the value of `nf_conntrack_max` (and the associated `hashsize` parameter) so that it didn't grow ridiculously large on machines with lots of cores.

But this means that if someone was previously manually setting `nf_conntrack_max` to the correct value and then running kube-proxy without the ability to modify that sysctl, that kube-proxy would now fail, because "the correct value" is now different.

Years ago, #103174 tried to fix a similar problem by making kube-proxy's behavior be "only change a sysctl if its current value is lower than the value we want", but this was later reverted (#120448) because that behavior doesn't make sense for sysctls in general. This PR brings back that behavior for just `nf_conntrack_max`.

#### Which issue(s) this PR is related to:
Fixes #141943

#### Special notes for your reviewer:
I had another version of this that _just_ fixed the bug without the unit test changes, etc, which is maybe more backport-able, but I didn't like the fact that it was untested...

#### Does this PR introduce a user-facing change?
```release-note
kube-proxy no longer tries to set the `nf_conntrack_max` sysctl if its
value is already higher than the value kube-proxy wants it to be. This
fixes a regression in 1.36 on systems where kube-proxy does not have
permission to modify the sysctls, since the new maximum value for
`nf_conntrack_max` could cause kube-proxy to now want a different
(lower) value than it had before.
```

/assign @aojea @aroradaman 
/sig network
/priority important-soon