### PR TITLE
Pin grpc and grpc-gateway to the last versions without unwanted deps

### DIFF
--- a/hack/unwanted-dependencies.json
+++ b/hack/unwanted-dependencies.json
@@ -8,6 +8,14 @@
       "github.com/google/cel-go": {
         "version": "v0.29.2",
         "reason": "pin to v0.29.2 until the CEL runtime cost changes in newer releases are handled, see #141056"
+      },
+      "github.com/grpc-ecosystem/grpc-gateway/v2": {
+        "version": "v2.29.0",
+        "reason": "pin to v2.29.0 until grpc-gateway drops go-openapi, see grpc-ecosystem/grpc-gateway#7343 and #7325; v2.30.0 pulls in go-openapi analysis, spec, strfmt and validate"
+      },
+      "google.golang.org/grpc": {
+        "version": "v1.82.2",
+        "reason": "pin to v1.82.2 until grpc-go drops cloud.google.com/go/auth, see grpc/grpc-go#9320 and grpc/grpc-go#9385; v1.83.0+ pulls in s2a-go, enterprise-certificate-proxy and gax-go/v2, see #142005"
       }
     },
     "unwantedModules": {


### PR DESCRIPTION
**What this PR does / why we need it**:

`google.golang.org/grpc` v1.83.0+ pulls in `s2a-go`, `enterprise-certificate-proxy` and `gax-go/v2`. `github.com/grpc-ecosystem/grpc-gateway/v2` v2.30.0 pulls in `go-openapi` analysis, spec, strfmt and validate. All six are in `spec.unwantedModules`.

Pins both at the newest version that stays clean, so a routine bump cannot pull them back in. Upstream fixes are in flight: grpc/grpc-go#9385, grpc-ecosystem/grpc-gateway#7343 and #7325.

**Which issue(s) this PR fixes**:

xref #142005

**Special notes for your reviewer**:

v1.82.2 does not carry the CVE-2026-84304 fix. That fix is grpc/grpc-go#9331, cherry-picked only into v1.83.1, so this pin holds that CVE open on purpose until #9385 lands. xref #141798.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```
