### PR TITLE
garbagecollector: remove informer event handler when a monitor stops

### DIFF
--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -125,6 +125,14 @@ type monitor struct {
 	controller cache.Controller
 	store      cache.Store
 
+	// informer is the shared informer the monitor's event handler is
+	// registered on, and registration identifies that handler. They are kept
+	// so the handler can be removed when the monitor is torn down; the
+	// informer is cached per resource by the factory and outlives the monitor,
+	// so leaving the handler registered leaks it.
+	informer     cache.SharedIndexInformer
+	registration cache.ResourceEventHandlerRegistration
+
 	// stopCh stops Controller. If stopCh is nil, the monitor is considered to be
 	// not yet started.
 	stopCh chan struct{}
@@ -137,6 +145,19 @@ func (m *monitor) Run() {
 }
 
 type monitors map[schema.GroupVersionResource]*monitor
+
+// removeMonitorHandler unregisters the event handler that controllerFor added
+// to the monitor's shared informer, so the handler is not leaked once the
+// monitor is torn down. It is safe to call for monitors built before this field
+// was populated (informer/registration nil).
+func (gb *GraphBuilder) removeMonitorHandler(logger klog.Logger, m *monitor) {
+	if m == nil || m.informer == nil || m.registration == nil {
+		return
+	}
+	if err := m.informer.RemoveEventHandler(m.registration); err != nil {
+		logger.V(4).Info("unable to remove event handler for monitor", "err", err)
+	}
+}
 
 func NewDependencyGraphBuilder(
 	ctx context.Context,
@@ -189,7 +210,7 @@ func NewDependencyGraphBuilder(
 	return graphBuilder
 }
 
-func (gb *GraphBuilder) controllerFor(logger klog.Logger, resource schema.GroupVersionResource, kind schema.GroupVersionKind) (cache.Controller, cache.Store, error) {
+func (gb *GraphBuilder) controllerFor(logger klog.Logger, resource schema.GroupVersionResource, kind schema.GroupVersionKind) (cache.Controller, cache.Store, cache.SharedIndexInformer, cache.ResourceEventHandlerRegistration, error) {
 	handlers := cache.ResourceEventHandlerFuncs{
 		// add the event to the dependencyGraphBuilder's graphChanges.
 		AddFunc: func(obj interface{}) {
@@ -228,17 +249,18 @@ func (gb *GraphBuilder) controllerFor(logger klog.Logger, resource schema.GroupV
 	shared, err := gb.sharedInformers.ForResource(resource)
 	if err != nil {
 		logger.V(4).Info("unable to use a shared informer", "resource", resource, "kind", kind, "err", err)
-		return nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	logger.V(4).Info("using a shared informer", "resource", resource, "kind", kind)
 	resyncPeriod := time.Duration(0)
-	if _, err := shared.Informer().AddEventHandlerWithOptions(handlers, cache.HandlerOptions{
+	registration, err := shared.Informer().AddEventHandlerWithOptions(handlers, cache.HandlerOptions{
 		Logger:       &logger,
 		ResyncPeriod: &resyncPeriod,
-	}); err != nil {
-		return nil, nil, err
+	})
+	if err != nil {
+		return nil, nil, nil, nil, err
 	}
-	return shared.Informer().GetController(), shared.Informer().GetStore(), nil
+	return shared.Informer().GetController(), shared.Informer().GetStore(), shared.Informer(), registration, nil
 }
 
 // syncMonitors rebuilds the monitor set according to the supplied resources,
@@ -274,12 +296,12 @@ func (gb *GraphBuilder) syncMonitors(logger klog.Logger, resources map[schema.Gr
 			errs = append(errs, fmt.Errorf("couldn't look up resource %q: %v", resource, err))
 			continue
 		}
-		c, s, err := gb.controllerFor(logger, resource, kind)
+		c, s, informer, registration, err := gb.controllerFor(logger, resource, kind)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("couldn't start monitor for resource %q: %v", resource, err))
 			continue
 		}
-		current[resource] = &monitor{store: s, controller: c}
+		current[resource] = &monitor{store: s, controller: c, informer: informer, registration: registration}
 		added++
 	}
 	gb.monitors = current
@@ -288,6 +310,12 @@ func (gb *GraphBuilder) syncMonitors(logger klog.Logger, resources map[schema.Gr
 		if monitor.stopCh != nil {
 			close(monitor.stopCh)
 		}
+		// Remove the event handler that controllerFor registered on the shared
+		// informer. The factory caches the informer per resource, so it
+		// outlives the monitor (e.g. when a CRD is deleted and later recreated
+		// with the same GroupVersionResource); not removing the handler leaks
+		// it. See https://github.com/kubernetes/kubernetes/issues/114066.
+		gb.removeMonitorHandler(logger, monitor)
 	}
 
 	logger.V(4).Info("synced monitors", "added", added, "kept", kept, "removed", len(toRemove))
@@ -346,6 +374,7 @@ func (gb *GraphBuilder) stopMonitors(logger klog.Logger) {
 				stopped++
 				close(monitor.stopCh)
 			}
+			gb.removeMonitorHandler(logger, monitor)
 		}
 
 		// reset monitors so that the graph builder can be safely re-run/synced.

--- a/pkg/controller/garbagecollector/graph_builder_leak_test.go
+++ b/pkg/controller/garbagecollector/graph_builder_leak_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package garbagecollector
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2/ktesting"
+)
+
+// countingInformer is a minimal SharedIndexInformer that records how many event
+// handlers have been added and removed, so a test can detect handlers that are
+// leaked when a monitor is torn down. Only the methods exercised by
+// GraphBuilder.controllerFor and the monitor teardown are implemented; the rest
+// are inherited from the embedded interface and panic if called.
+type countingInformer struct {
+	cache.SharedIndexInformer
+	added   int
+	removed int
+}
+
+func (c *countingInformer) AddEventHandlerWithOptions(handler cache.ResourceEventHandler, options cache.HandlerOptions) (cache.ResourceEventHandlerRegistration, error) {
+	c.added++
+	return noopRegistration{}, nil
+}
+
+func (c *countingInformer) RemoveEventHandler(handle cache.ResourceEventHandlerRegistration) error {
+	c.removed++
+	return nil
+}
+
+func (c *countingInformer) GetController() cache.Controller { return nil }
+
+func (c *countingInformer) GetStore() cache.Store { return nil }
+
+// live is the number of event handlers currently registered on the informer.
+func (c *countingInformer) live() int { return c.added - c.removed }
+
+type noopRegistration struct{}
+
+func (noopRegistration) HasSynced() bool                     { return true }
+func (noopRegistration) HasSyncedChecker() cache.DoneChecker { return nil }
+
+// genericCountingInformer adapts countingInformer to informers.GenericInformer.
+type genericCountingInformer struct {
+	informer *countingInformer
+}
+
+func (g *genericCountingInformer) Informer() cache.SharedIndexInformer { return g.informer }
+
+func (g *genericCountingInformer) Lister() cache.GenericLister { return nil }
+
+// countingInformerFactory hands out one cached countingInformer per resource,
+// so that re-adding the same resource reuses the same informer. This mirrors
+// the real (metadata) informer factory, which caches informers by GVR and
+// therefore reuses the same informer when a deleted resource (e.g. a CRD) is
+// recreated with the same GroupVersionResource.
+type countingInformerFactory struct {
+	informers map[schema.GroupVersionResource]*countingInformer
+}
+
+func newCountingInformerFactory() *countingInformerFactory {
+	return &countingInformerFactory{informers: map[schema.GroupVersionResource]*countingInformer{}}
+}
+
+func (f *countingInformerFactory) ForResource(resource schema.GroupVersionResource) (informers.GenericInformer, error) {
+	ci, ok := f.informers[resource]
+	if !ok {
+		ci = &countingInformer{}
+		f.informers[resource] = ci
+	}
+	return &genericCountingInformer{informer: ci}, nil
+}
+
+func (f *countingInformerFactory) Start(stopCh <-chan struct{}) {}
+
+// TestSyncMonitorsRemovesEventHandlerOnResourceRemoval is a regression test for
+// https://github.com/kubernetes/kubernetes/issues/114066: syncMonitors added an
+// event handler to the (per-GVR cached) shared informer for every resource, but
+// on teardown it only stopped the monitor without removing that handler. When a
+// resource such as a CRD is repeatedly created and deleted, the handlers pile up
+// on the reused informer and leak, growing kube-controller-manager memory.
+func TestSyncMonitorsRemovesEventHandlerOnResourceRemoval(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
+	gvr := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
+	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Widget"}
+
+	rm := meta.NewDefaultRESTMapper(nil)
+	rm.AddSpecific(gvk, gvr, schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widget"}, meta.RESTScopeNamespace)
+
+	factory := newCountingInformerFactory()
+	gb := &GraphBuilder{
+		restMapper:       rm,
+		sharedInformers:  factory,
+		ignoredResources: map[schema.GroupResource]struct{}{},
+	}
+
+	withResource := map[schema.GroupVersionResource]struct{}{gvr: {}}
+	withoutResource := map[schema.GroupVersionResource]struct{}{}
+
+	// Add then remove the resource several times. Each add registers one event
+	// handler on the cached informer; each removal must unregister it.
+	const cycles = 3
+	for i := 0; i < cycles; i++ {
+		if err := gb.syncMonitors(logger, withResource); err != nil {
+			t.Fatalf("cycle %d: syncMonitors(add) returned an error: %v", i, err)
+		}
+		if err := gb.syncMonitors(logger, withoutResource); err != nil {
+			t.Fatalf("cycle %d: syncMonitors(remove) returned an error: %v", i, err)
+		}
+	}
+
+	ci := factory.informers[gvr]
+	if ci == nil {
+		t.Fatalf("expected an informer to have been created for %s", gvr)
+	}
+	if ci.added != cycles {
+		t.Fatalf("expected %d handler registrations across %d cycles, got %d", cycles, cycles, ci.added)
+	}
+	if leaked := ci.live(); leaked != 0 {
+		t.Fatalf("event handlers leaked: %d handler(s) still registered after %d add/remove cycles (added=%d, removed=%d); monitor teardown must call RemoveEventHandler", leaked, cycles, ci.added, ci.removed)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The garbage collector's dependency graph builder registers an event handler on the shared informer for every monitored resource, but when a monitor is torn down it only stopped the monitor without removing that handler. The informer factory caches informers per resource, so the informer outlives the monitor — for example when a CRD is deleted and later recreated with the same `GroupVersionResource`. The leaked handlers accumulate on the reused informer and grow kube-controller-manager's memory over time.

This stores the informer and its handler registration on the `monitor` and calls `RemoveEventHandler` when the monitor is removed, in both `syncMonitors` (runtime resource removal) and `stopMonitors` (shutdown).

**Which issue(s) this PR fixes**:

Fixes #114066

**Special notes for your reviewer**:

Reproduced and verified on a local kind cluster, running kube-controller-manager with `--controllers=garbagecollector` to isolate the path, by counting the informer's per-handler goroutines (`processorListener.run`/`.pop`) via `/debug/pprof/goroutine` while repeatedly creating and deleting 40 CRDs:

| step | before (this branch reverted) | after |
|------|------|-------|
| baseline | 118 | 118 |
| create 40 CRDs | 198 | 198 |
| delete them | **198** (not released) | **118** (released) |
| create again | 278 | 198 |
| delete again | **278** (monotonic growth) | **118** (stable) |

Added a unit test (`TestSyncMonitorsRemovesEventHandlerOnResourceRemoval`) that fails before the change and passes after.

Note: the resource quota controller's `QuotaMonitor` (`pkg/controller/resourcequota/resource_quota_monitor.go`) discards the handler registration in the same way and likely leaks similarly; happy to send a follow-up for it if that seems right.

**Does this PR introduce a user-facing change?**

```release-note
kube-controller-manager: fixed a memory leak in the garbage collector controller where event handlers were leaked on shared informers when a monitored resource (for example a CRD) was deleted and recreated.
```
