### PR TITLE
e2e framework: report the PV create error instead of the timeout

### DIFF
--- a/test/e2e/framework/pv/pv.go
+++ b/test/e2e/framework/pv/pv.go
@@ -320,7 +320,7 @@ func createPV(ctx context.Context, c clientset.Interface, timeouts *framework.Ti
 	})
 	// if we have an error from creating the PV, use that instead of a timeout error
 	if lastCreateErr != nil {
-		return nil, fmt.Errorf("PV Create API error: %w", err)
+		return nil, fmt.Errorf("PV Create API error: %w", lastCreateErr)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("PV Create API error: %w", err)

--- a/test/e2e/framework/pv/pv_test.go
+++ b/test/e2e/framework/pv/pv_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pv
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func TestCreatePV(t *testing.T) {
+	quotaErr := errors.New("googleapi: Error 403: Quota exceeded for quota group 'CPUS'")
+	otherErr := errors.New("admission webhook denied the request")
+
+	tcs := []struct {
+		desc      string
+		createErr error
+		wantErr   error
+	}{
+		{
+			desc: "create succeeds",
+		}, {
+			// The quota error is retried until PVCreate expires. The caller
+			// should see why creation kept failing, not just the timeout.
+			desc:      "quota error until timeout reports the API error",
+			createErr: quotaErr,
+			wantErr:   quotaErr,
+		}, {
+			desc:      "other API error fails immediately",
+			createErr: otherErr,
+			wantErr:   otherErr,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			client := fake.NewClientset()
+			if tc.createErr != nil {
+				client.PrependReactor("create", "persistentvolumes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, tc.createErr
+				})
+			}
+			timeouts := framework.NewTimeoutContext()
+			timeouts.PVCreate = 100 * time.Millisecond
+
+			pv := &v1.PersistentVolume{ObjectMeta: metav1.ObjectMeta{Name: "test-pv"}}
+			got, err := createPV(context.Background(), client, timeouts, pv)
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == nil || got.Name != pv.Name {
+					t.Fatalf("expected PV %q, got %v", pv.Name, got)
+				}
+				return
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("expected error wrapping %q, got: %v", tc.wantErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

I was looking at the RealFIFO.Resync fix that wrapped `err` instead of `retErr` (836a62aa300) and searched for the same shape elsewhere. `createPV` in `test/e2e/framework/pv` has it: the poll retries while the create call returns the GCP quota error, and the comment after the loop says "if we have an error from creating the PV, use that instead of a timeout error", but the branch wraps `err` (the poll result) rather than `lastCreateErr`.

For a non-quota error both variables hold the same error, so nothing changes there. The difference shows up when the quota error persists until `timeouts.PVCreate` runs out: the test then fails with "PV Create API error: context deadline exceeded" and the actual quota message is lost.

The fix wraps `lastCreateErr`. I also added a unit test for `createPV` with a fake clientset and a 100ms `PVCreate` timeout. It covers a successful create, a quota error lasting until the timeout, and a non-retried error. On master the quota case fails with:

```
pv_test.go:80: expected error wrapping "googleapi: Error 403: Quota exceeded for quota group 'CPUS'", got: PV Create API error: context deadline exceeded
```

With the change, all three cases pass. The other two cases pass both before and after. I ran `go test ./test/e2e/framework/pv/`, `go vet`, `gofmt -l` and `hack/boilerplate/boilerplate.py` on the two files.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

AI disclosure: I used an AI coding agent (Claude Code) for this change. It searched the tree for the same mistake as the RealFIFO fix, wrote the one-line fix and the unit test, and ran the check that the test fails without the fix and passes with it.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
