### PR TITLE
Fix: Reject kubectl ingress TLS secrets without equals separators

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress.go
@@ -50,9 +50,8 @@ var (
 
 	// This Regex is optional -> (....)?
 	// (?P<istls>tls) -> Verify if the argument after "," is 'tls'
-	// Optional Separator from tls to the secret name -> "=?"
-	// (?P<secretname>[\w\-]+)? -> Optional secret name after the separator -> 1-N characters
-	regexTLS = `(,(?P<istls>tls)=?(?P<secretname>[\w\-]+)?)?`
+	// Optional secret name must be separated from tls by "="
+	regexTLS = `(,(?P<istls>tls)(=(?P<secretname>[\w\-]+)?)?)?`
 
 	// The validation Regex is the concatenation of hostPathSvc validation regex
 	// and the TLS validation regex

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress_test.go
@@ -142,6 +142,12 @@ func TestCreateIngressValidation(t *testing.T) {
 			},
 			expected: "rule foo.com/=svc:http,tls,garbage is invalid and should be in format host/path=svcname:svcport[,tls[=secret]]",
 		},
+		"invalid tls secret without separator": {
+			rules: []string{
+				"foo.com/=svc:http,tlssecret123",
+			},
+			expected: "rule foo.com/=svc:http,tlssecret123 is invalid and should be in format host/path=svcname:svcport[,tls[=secret]]",
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The correct rule format is  --rule='foo.com/=svc:http,tls=secret123' . 
However, when creating an Ingress, the user provides the following invalid input, where the TLS option is missing the  `=`  separator:

```
kubectl create ingress demo \
  --rule='foo.com/=svc:http,tlssecret123' \
  --dry-run=client \
  -o yaml
```

The current regular expression has a validation flaw. It fails to detect and report this malformed input and silently accepts it instead. 
More important , the accepted malformed value is not processed as if the user had specified  `tls=secret123` . The generated Ingress contains the TLS host but omits  `secretName: secret123` , so the requested Secret is silently ignored. If the Ingress is submitted to the cluster, the controller may use a default certificate or apply other implementation-specific behavior.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix: Reject kubectl ingress TLS secrets without equals separators
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
