### PR TITLE
e2e: retry transient OpenAPI request errors

### DIFF
--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -652,14 +652,18 @@ func waitForDefinitionCleanup(c k8sclientset.Interface, name string) error {
 
 func waitForOpenAPISchema(c k8sclientset.Interface, pred func(*spec.Swagger) (bool, string)) error {
 	client := c.Discovery().RESTClient().(*rest.RESTClient).Client
-	url := c.Discovery().RESTClient().Get().AbsPath("openapi", "v2").URL()
+	url := c.Discovery().RESTClient().Get().AbsPath("openapi", "v2").URL().String()
+	return waitForOpenAPISchemaWithClient(client, url, 500*time.Millisecond, 60*time.Second, pred)
+}
+
+func waitForOpenAPISchemaWithClient(client *http.Client, url string, pollInterval, pollTimeout time.Duration, pred func(*spec.Swagger) (bool, string)) error {
 	lastMsg := ""
 	etag := ""
 	var etagSpec *spec.Swagger
-	if err := wait.Poll(500*time.Millisecond, 60*time.Second, mustSucceedMultipleTimes(waitSuccessThreshold, func() (bool, error) {
+	if err := wait.Poll(pollInterval, pollTimeout, mustSucceedMultipleTimes(waitSuccessThreshold, func() (bool, error) {
 		// download spec with etag support
 		spec := &spec.Swagger{}
-		req, err := http.NewRequest("GET", url.String(), nil)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
 		if err != nil {
 			return false, err
 		}
@@ -669,7 +673,8 @@ func waitForOpenAPISchema(c k8sclientset.Interface, pred func(*spec.Swagger) (bo
 		}
 		resp, err := client.Do(req)
 		if err != nil {
-			return false, err
+			lastMsg = fmt.Sprintf("failed to get OpenAPI spec: %v", err)
+			return false, nil
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode == http.StatusNotModified {

--- a/test/e2e/apimachinery/crd_publish_openapi_test.go
+++ b/test/e2e/apimachinery/crd_publish_openapi_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apimachinery
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestWaitForOpenAPISchemaRetriesRequestErrors(t *testing.T) {
+	requestCount := 0
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if requestCount == 1 {
+			return nil, errors.New("temporary network failure")
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader(`{"swagger":"2.0"}`)),
+			Request:    req,
+		}, nil
+	})}
+
+	err := waitForOpenAPISchemaWithClient(client, "https://example.com/openapi/v2", time.Millisecond, time.Second, func(*spec.Swagger) (bool, string) {
+		return true, ""
+	})
+	if err != nil {
+		t.Fatalf("waitForOpenAPISchemaWithClient returned an error: %v", err)
+	}
+	if want := waitSuccessThreshold + 1; requestCount != want {
+		t.Fatalf("expected %d requests, got %d", want, requestCount)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

The CRD OpenAPI E2E helper stops polling when `GET /openapi/v2` returns a transient transport error. This makes the spec update tests fail during brief control-plane connectivity interruptions.

Retry request errors within the helper's existing polling timeout, preserve the last request error in timeout diagnostics, and add focused coverage for recovery after a transient failure.

#### Which issue(s) this PR is related to:

#141951

#### Special notes for your reviewer:

Tested with:

`go test -p=2 ./test/e2e/apimachinery -run '^TestWaitForOpenAPISchemaRetriesRequestErrors$' -count=1`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

#### AI usage disclosure:

---
