### PR TITLE
storage: avoid VAC admission panic on unexpected object

### DIFF
--- a/plugin/pkg/admission/storage/storageobjectinuseprotection/admission.go
+++ b/plugin/pkg/admission/storage/storageobjectinuseprotection/admission.go
@@ -137,7 +137,6 @@ func (c *storageProtectionPlugin) admitVAC(a admission.Attributes) error {
 	vac, ok := a.GetObject().(*storageapi.VolumeAttributesClass)
 	// if we can't convert the obj to VAC, just return
 	if !ok {
-		klog.V(2).Infof("can't convert the obj to VAC to %s", vac.Name)
 		return nil
 	}
 	for _, f := range vac.Finalizers {

--- a/plugin/pkg/admission/storage/storageobjectinuseprotection/admission_test.go
+++ b/plugin/pkg/admission/storage/storageobjectinuseprotection/admission_test.go
@@ -145,6 +145,14 @@ func TestAdmit(t *testing.T) {
 			vac.Namespace,
 			true,
 		},
+		{
+			"volumeattributesclasses VacFeatureGate enabled: wrong object type -> no finalizer added",
+			storageapi.SchemeGroupVersion.WithResource("volumeattributesclasses"),
+			&api.Pod{},
+			&api.Pod{},
+			"",
+			true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig storage

#### What this PR does / why we need it:

`admitVAC` dereferences `vac.Name` after a failed `*VolumeAttributesClass` type assertion, when `vac` is nil. An unexpected object type therefore panics the admission path instead of returning without mutation like the existing PV and PVC guards.

Remove the invalid dereference and add a regression case that passes a non-VAC object for the VAC resource.

#### Which issue(s) this PR is related to:

Addresses the VolumeAttributesClass nil-dereference finding in #140078.

#### Special notes for your reviewer:

Tested with:

`go test -p=2 ./plugin/pkg/admission/storage/storageobjectinuseprotection -count=1`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

#### AI usage disclosure:

---
