### PR TITLE
apiserver: preserve mutating policy changes across GVKs

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/versioned_attribute_accessor_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/versioned_attribute_accessor_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generic
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+func TestVersionedAttributeAccessorRetainsIndependentKinds(t *testing.T) {
+	accessor, inputGVK, firstGVK, secondGVK := newTestVersionedAttributeAccessor(t)
+	first, err := accessor.VersionedAttribute(firstGVK)
+	require.NoError(t, err)
+	second, err := accessor.VersionedAttribute(secondGVK)
+	require.NoError(t, err)
+	require.NotSame(t, first, second)
+
+	firstObject := first.VersionedObject.Object().(*unstructured.Unstructured).DeepCopy()
+	require.NoError(t, unstructured.SetNestedField(firstObject.Object, "first", "metadata", "labels", "marker"))
+	first.UpdateObject(firstObject)
+
+	secondLabels, _, err := unstructured.NestedStringMap(second.VersionedObject.Object().(*unstructured.Unstructured).Object, "metadata", "labels")
+	require.NoError(t, err)
+	_, exists := secondLabels["marker"]
+	require.False(t, exists, "validation snapshots must remain independent")
+	input, err := accessor.VersionedAttribute(inputGVK)
+	require.NoError(t, err)
+	inputLabels, _, err := unstructured.NestedStringMap(input.VersionedObject.Object().(*unstructured.Unstructured).Object, "metadata", "labels")
+	require.NoError(t, err)
+	_, exists = inputLabels["marker"]
+	require.False(t, exists)
+}
+
+func TestVersionedAttributeAccessorConcurrentKinds(t *testing.T) {
+	accessor, _, firstGVK, secondGVK := newTestVersionedAttributeAccessor(t)
+	_, err := accessor.VersionedAttribute(firstGVK)
+	require.NoError(t, err)
+	_, err = accessor.VersionedAttribute(secondGVK)
+	require.NoError(t, err)
+	type result struct {
+		attr *admission.VersionedAttributes
+		err  error
+	}
+	results := make(chan result, 2)
+	var wg sync.WaitGroup
+	for _, gvk := range []schema.GroupVersionKind{firstGVK, secondGVK} {
+		wg.Add(1)
+		go func(gvk schema.GroupVersionKind) {
+			defer wg.Done()
+			attr, err := accessor.VersionedAttribute(gvk)
+			results <- result{attr: attr, err: err}
+		}(gvk)
+	}
+	wg.Wait()
+	close(results)
+	for result := range results {
+		require.NoError(t, result.err)
+		require.NotNil(t, result.attr)
+		require.NotNil(t, result.attr.VersionedObject.Object())
+	}
+}
+
+func newTestVersionedAttributeAccessor(t *testing.T) (*versionedAttributeAccessor, schema.GroupVersionKind, schema.GroupVersionKind, schema.GroupVersionKind) {
+	t.Helper()
+	inputGVK := schema.GroupVersionKind{Group: "example.test", Version: "v1", Kind: "Widget"}
+	firstGVK := schema.GroupVersionKind{Group: "example.test", Version: "v1alpha1", Kind: "Widget"}
+	secondGVK := schema.GroupVersionKind{Group: "example.test", Version: "v1beta1", Kind: "Widget"}
+	scheme := runtime.NewScheme()
+	for _, gvk := range []schema.GroupVersionKind{inputGVK, firstGVK, secondGVK} {
+		scheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+	}
+	object := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": inputGVK.GroupVersion().String(),
+		"kind":       inputGVK.Kind,
+		"metadata":   map[string]interface{}{"name": "demo", "labels": map[string]interface{}{}},
+	}}
+	object.SetGroupVersionKind(inputGVK)
+	attrs := admission.NewAttributesRecord(object, nil, inputGVK, "", "demo",
+		schema.GroupVersionResource{Group: inputGVK.Group, Version: inputGVK.Version, Resource: "widgets"},
+		"", admission.Create, &metav1.CreateOptions{}, false, nil)
+	return &versionedAttributeAccessor{versionedAttrs: map[schema.GroupVersionKind]*admission.VersionedAttributes{}, attr: attrs, objectInterfaces: admission.NewObjectInterfacesFromScheme(scheme)}, inputGVK, firstGVK, secondGVK
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/dispatcher.go
@@ -77,8 +77,6 @@ func (d *dispatcher) dispatchInvocations(
 	versionedAttributes webhookgeneric.VersionedAttributeAccessor,
 	invocations []generic.PolicyInvocation[*Policy, *PolicyBinding, PolicyEvaluator],
 ) ([]generic.PolicyError, *k8serrors.StatusError) {
-	var lastVersionedAttr *admission.VersionedAttributes
-
 	reinvokeCtx := a.GetReinvocationContext()
 	var policyReinvokeCtx *policyReinvokeContext
 	if v := reinvokeCtx.Value(PluginName); v != nil {
@@ -153,6 +151,9 @@ func (d *dispatcher) dispatchInvocations(
 			// accessors before starting the dispatcher
 			return nil, k8serrors.NewInternalError(err)
 		}
+		if err := syncVersionedAttributes(a, o, versionedAttr, invocation.Kind); err != nil {
+			return nil, k8serrors.NewInternalError(err)
+		}
 
 		if invocation.Evaluator.Matcher != nil {
 			matchResults := invocation.Evaluator.Matcher.Match(ctx, versionedAttr, invocation.Param, authz)
@@ -181,7 +182,6 @@ func (d *dispatcher) dispatchInvocations(
 		// Mutations for a single invocation of a MutatingAdmissionPolicy are evaluated
 		// in order.
 		for mutationIndex := range invocation.Policy.Spec.Mutations {
-			lastVersionedAttr = versionedAttr
 			if versionedAttr.VersionedObject.Object() == nil { // Do not call patchers if there is no object to patch.
 				continue
 			}
@@ -205,7 +205,11 @@ func (d *dispatcher) dispatchInvocations(
 				celmetrics.Metrics.ObserveAdmission(ctx, elapsed, invocation.Policy.Name, invocation.Binding.Name, celmetrics.MutationNoError)
 			}
 		}
-		if !apiequality.Semantic.DeepEqual(objectBeforeMutations, versionedAttr.VersionedObject.Object()) {
+		objectChanged := !apiequality.Semantic.DeepEqual(objectBeforeMutations, versionedAttr.VersionedObject.Object())
+		if err := writeBackVersionedAttributes(o, versionedAttr); err != nil {
+			return nil, k8serrors.NewInternalError(err)
+		}
+		if objectChanged {
 			// The mutation has changed the object. Prepare to reinvoke all previous mutations that are eligible for re-invocation.
 			policyReinvokeCtx.RequireReinvokingPreviouslyInvokedPlugins()
 			reinvokeCtx.SetShouldReinvoke()
@@ -215,15 +219,46 @@ func (d *dispatcher) dispatchInvocations(
 		}
 	}
 
-	if lastVersionedAttr != nil && lastVersionedAttr.VersionedObject.Object() != nil && lastVersionedAttr.Dirty {
-		policyReinvokeCtx.RequireReinvokingPreviouslyInvokedPlugins()
-		reinvokeCtx.SetShouldReinvoke()
-		if err := o.GetObjectConvertor().Convert(lastVersionedAttr.VersionedObject.Object(), lastVersionedAttr.Attributes.GetObject(), nil); err != nil {
-			return nil, k8serrors.NewInternalError(fmt.Errorf("failed to convert object: %w", err))
-		}
-	}
-
 	return policyErrors, nil
+}
+
+// syncVersionedAttributes refreshes a cached policy representation from the
+// current admission object. The generic policy dispatcher retains independent
+// per-GVK snapshots for validation and matching; mutating policies must instead
+// see mutations made by the preceding invocation in this dispatch.
+func syncVersionedAttributes(a admission.Attributes, o admission.ObjectInterfaces, attr *admission.VersionedAttributes, gvk schema.GroupVersionKind) error {
+	if oldObject := a.GetOldObject(); oldObject != nil {
+		converted, err := admission.ConvertToGVK(oldObject, gvk, o)
+		if err != nil {
+			return fmt.Errorf("failed to convert old object to %s: %w", gvk, err)
+		}
+		attr.VersionedOldObject.Set(converted)
+	} else {
+		attr.VersionedOldObject.Set(nil)
+	}
+	if object := a.GetObject(); object != nil {
+		converted, err := admission.ConvertToGVK(object, gvk, o)
+		if err != nil {
+			return fmt.Errorf("failed to convert object to %s: %w", gvk, err)
+		}
+		attr.VersionedObject.Set(converted)
+	} else {
+		attr.VersionedObject.Set(nil)
+	}
+	attr.VersionedKind = gvk
+	attr.Dirty = false
+	return nil
+}
+
+func writeBackVersionedAttributes(o admission.ObjectInterfaces, attr *admission.VersionedAttributes) error {
+	if attr.VersionedObject.Object() == nil || !attr.Dirty {
+		return nil
+	}
+	if err := o.GetObjectConvertor().Convert(attr.VersionedObject.Object(), attr.Attributes.GetObject(), nil); err != nil {
+		return fmt.Errorf("failed to convert object: %w", err)
+	}
+	attr.Dirty = false
+	return nil
 }
 
 func (d *dispatcher) dispatchOne(

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/dispatcher_writeback_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/dispatcher_writeback_test.go
@@ -1,0 +1,349 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutating
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/managedfields"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/plugin/policy/generic"
+	"k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+func TestMutatingWritebackPreservesEquivalentGVKMutations(t *testing.T) {
+	inputGVK := schema.GroupVersionKind{Group: "example.test", Version: "v1", Kind: "Widget"}
+	firstGVK := schema.GroupVersionKind{Group: "example.test", Version: "v1alpha1", Kind: "Widget"}
+	secondGVK := schema.GroupVersionKind{Group: "example.test", Version: "v1beta1", Kind: "Widget"}
+	object, attrs, objectInterfaces := newWritebackAttributes(t, inputGVK, nil, "")
+
+	first, err := admission.NewVersionedAttributes(attrs, firstGVK, objectInterfaces)
+	require.NoError(t, err)
+	require.NoError(t, syncVersionedAttributes(attrs, objectInterfaces, first, firstGVK))
+	addWritebackLabel(t, first, "first")
+	require.NoError(t, writeBackVersionedAttributes(objectInterfaces, first))
+
+	second, err := admission.NewVersionedAttributes(attrs, secondGVK, objectInterfaces)
+	require.NoError(t, err)
+	require.NoError(t, syncVersionedAttributes(attrs, objectInterfaces, second, secondGVK))
+	assertWritebackLabel(t, second, "first")
+	addWritebackLabel(t, second, "second")
+	require.NoError(t, writeBackVersionedAttributes(objectInterfaces, second))
+	assertWritebackLabel(t, &admission.VersionedAttributes{VersionedObject: admission.NewLazyObject(object)}, "first", "second")
+}
+
+func TestDispatchInvocationsPreservesPrewarmedEquivalentGVKs(t *testing.T) {
+	inputGVK := schema.GroupVersionKind{Group: "example.test", Version: "v1", Kind: "Widget"}
+	firstGVK := schema.GroupVersionKind{Group: "example.test", Version: "v1alpha1", Kind: "Widget"}
+	secondGVK := schema.GroupVersionKind{Group: "example.test", Version: "v1beta1", Kind: "Widget"}
+	object, attrs, objectInterfaces := newWritebackAttributes(t, inputGVK, nil, "")
+	first, err := admission.NewVersionedAttributes(attrs, firstGVK, objectInterfaces)
+	require.NoError(t, err)
+	second, err := admission.NewVersionedAttributes(attrs, secondGVK, objectInterfaces)
+	require.NoError(t, err)
+	policy := func(name string, kind schema.GroupVersionKind, label string) generic.PolicyInvocation[*Policy, *PolicyBinding, PolicyEvaluator] {
+		return generic.PolicyInvocation[*Policy, *PolicyBinding, PolicyEvaluator]{
+			Policy:  &Policy{ObjectMeta: metav1.ObjectMeta{Name: name}, Spec: admissionregistrationv1.MutatingAdmissionPolicySpec{Mutations: []admissionregistrationv1.Mutation{{}}}},
+			Binding: &PolicyBinding{ObjectMeta: metav1.ObjectMeta{Name: name + "-binding"}}, Kind: kind,
+			Resource: kind.GroupVersion().WithResource("widgets"), Evaluator: PolicyEvaluator{Mutators: []patch.Patcher{writebackLabelPatcher{label: label}}},
+		}
+	}
+	dispatcher := &dispatcher{authz: writebackAuthorizer{}, typeConverterManager: writebackTypeConverterManager{}}
+	_, statusErr := dispatcher.dispatchInvocations(context.Background(), attrs, objectInterfaces, &writebackAccessor{attrs: map[schema.GroupVersionKind]*admission.VersionedAttributes{firstGVK: first, secondGVK: second}}, []generic.PolicyInvocation[*Policy, *PolicyBinding, PolicyEvaluator]{policy("first", firstGVK, "first"), policy("second", secondGVK, "second")})
+	require.Nil(t, statusErr)
+	labels := object.GetLabels()
+	require.Equal(t, "set", labels["first"])
+	require.Equal(t, "set", labels["second"])
+}
+
+func TestDispatchInvocationsPreservesSameGVKMutations(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "example.test", Version: "v1", Kind: "Widget"}
+	object, attrs, objectInterfaces := newWritebackAttributes(t, gvk, nil, "")
+	versioned, err := admission.NewVersionedAttributes(attrs, gvk, objectInterfaces)
+	require.NoError(t, err)
+	dispatcher := &dispatcher{authz: writebackAuthorizer{}, typeConverterManager: writebackTypeConverterManager{}}
+	_, statusErr := dispatcher.dispatchInvocations(context.Background(), attrs, objectInterfaces, &writebackAccessor{attrs: map[schema.GroupVersionKind]*admission.VersionedAttributes{gvk: versioned}}, []generic.PolicyInvocation[*Policy, *PolicyBinding, PolicyEvaluator]{
+		writebackInvocation(gvk, "first", writebackLabelPatcher{label: "first"}),
+		writebackInvocation(gvk, "second", writebackLabelPatcher{label: "second"}),
+	})
+	require.Nil(t, statusErr)
+	labels := object.GetLabels()
+	require.Equal(t, "set", labels["first"])
+	require.Equal(t, "set", labels["second"])
+}
+
+func TestSyncVersionedAttributesConvertsOldObjectAndKeepsSubresource(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "example.test", Version: "v1", Kind: "Widget"}
+	targetGVK := schema.GroupVersionKind{Group: "example.test", Version: "v1alpha1", Kind: "Widget"}
+	old := newWritebackObject(gvk)
+	old.SetLabels(map[string]string{"old": "yes"})
+	_, attrs, objectInterfaces := newWritebackAttributes(t, gvk, old, "status")
+	versioned, err := admission.NewVersionedAttributes(attrs, targetGVK, objectInterfaces)
+	require.NoError(t, err)
+	require.NoError(t, syncVersionedAttributes(attrs, objectInterfaces, versioned, targetGVK))
+	oldLabels, _, err := unstructured.NestedStringMap(versioned.VersionedOldObject.Object().(*unstructured.Unstructured).Object, "metadata", "labels")
+	require.NoError(t, err)
+	require.Equal(t, "yes", oldLabels["old"])
+	require.Equal(t, targetGVK, versioned.VersionedKind)
+	require.Equal(t, "status", attrs.GetSubresource())
+}
+
+func TestSyncVersionedAttributesConvertsTypedObject(t *testing.T) {
+	inputGVK := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	targetGVK := schema.GroupVersionKind{Group: "apps", Version: "v1alpha1", Kind: "Deployment"}
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	scheme.AddKnownTypeWithName(targetGVK, &unstructured.Unstructured{})
+	object := &appsv1.Deployment{TypeMeta: metav1.TypeMeta{APIVersion: inputGVK.GroupVersion().String(), Kind: inputGVK.Kind}, ObjectMeta: metav1.ObjectMeta{Name: "typed"}}
+	attrs := admission.NewAttributesRecord(object, nil, inputGVK, "", "typed", inputGVK.GroupVersion().WithResource("deployments"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+	objectInterfaces := admission.NewObjectInterfacesFromScheme(scheme)
+	versioned, err := admission.NewVersionedAttributes(attrs, targetGVK, objectInterfaces)
+	require.NoError(t, err)
+	require.NoError(t, syncVersionedAttributes(attrs, objectInterfaces, versioned, targetGVK))
+	require.IsType(t, &unstructured.Unstructured{}, versioned.VersionedObject.Object())
+}
+
+func TestWriteBackVersionedAttributesReturnsConversionErrorAfterDirtyMutation(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "example.test", Version: "v1", Kind: "Widget"}
+	object, attrs, objectInterfaces := newWritebackAttributes(t, gvk, nil, "")
+	versioned, err := admission.NewVersionedAttributes(attrs, gvk, objectInterfaces)
+	require.NoError(t, err)
+	addWritebackLabel(t, versioned, "dirty")
+	failingInterfaces := &admission.RuntimeObjectInterfaces{
+		ObjectCreater:            objectInterfaces.GetObjectCreater(),
+		ObjectTyper:              objectInterfaces.GetObjectTyper(),
+		ObjectDefaulter:          objectInterfaces.GetObjectDefaulter(),
+		ObjectConvertor:          failingWritebackConvertor{ObjectConvertor: objectInterfaces.GetObjectConvertor()},
+		EquivalentResourceMapper: objectInterfaces.GetEquivalentResourceMapper(),
+	}
+	err = writeBackVersionedAttributes(failingInterfaces, versioned)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to convert object")
+	require.Empty(t, object.GetLabels(), "the canonical admission object must remain unchanged on write-back failure")
+}
+
+func TestDispatchInvocationsConversionErrorLeavesCanonicalObjectUnchanged(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "example.test", Version: "v1", Kind: "Widget"}
+	object, attrs, regularInterfaces := newWritebackAttributes(t, gvk, nil, "")
+	versioned, err := admission.NewVersionedAttributes(attrs, gvk, regularInterfaces)
+	require.NoError(t, err)
+	failingInterfaces := &admission.RuntimeObjectInterfaces{ObjectCreater: regularInterfaces.GetObjectCreater(), ObjectTyper: regularInterfaces.GetObjectTyper(), ObjectDefaulter: regularInterfaces.GetObjectDefaulter(), ObjectConvertor: failingWritebackConvertor{ObjectConvertor: regularInterfaces.GetObjectConvertor()}, EquivalentResourceMapper: regularInterfaces.GetEquivalentResourceMapper()}
+	invocation := writebackInvocation(gvk, "dirty", writebackLabelPatcher{label: "dirty"})
+	dispatcher := &dispatcher{authz: writebackAuthorizer{}, typeConverterManager: writebackTypeConverterManager{}}
+	_, statusErr := dispatcher.dispatchInvocations(context.Background(), attrs, failingInterfaces, &writebackAccessor{attrs: map[schema.GroupVersionKind]*admission.VersionedAttributes{gvk: versioned}}, []generic.PolicyInvocation[*Policy, *PolicyBinding, PolicyEvaluator]{invocation})
+	require.NotNil(t, statusErr)
+	require.Empty(t, object.GetLabels())
+}
+
+func TestMutationFailureAfterEarlierSuccessWritesBackEarlierMutation(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "example.test", Version: "v1", Kind: "Widget"}
+	object, attrs, objectInterfaces := newWritebackAttributes(t, gvk, nil, "")
+	versioned, err := admission.NewVersionedAttributes(attrs, gvk, objectInterfaces)
+	require.NoError(t, err)
+	policy := &Policy{ObjectMeta: metav1.ObjectMeta{Name: "policy"}, Spec: admissionregistrationv1.MutatingAdmissionPolicySpec{Mutations: []admissionregistrationv1.Mutation{{}, {}}}}
+	invocation := generic.PolicyInvocation[*Policy, *PolicyBinding, PolicyEvaluator]{
+		Policy: policy, Binding: &PolicyBinding{}, Kind: gvk, Resource: gvk.GroupVersion().WithResource("widgets"),
+		Evaluator: PolicyEvaluator{Mutators: []patch.Patcher{writebackLabelPatcher{label: "success"}, writebackErrorPatcher{}}},
+	}
+	accessor := &writebackAccessor{attrs: map[schema.GroupVersionKind]*admission.VersionedAttributes{gvk: versioned}}
+	dispatcher := &dispatcher{authz: writebackAuthorizer{}, typeConverterManager: writebackTypeConverterManager{}}
+	policyErrors, statusErr := dispatcher.dispatchInvocations(context.Background(), attrs, objectInterfaces, accessor, []generic.PolicyInvocation[*Policy, *PolicyBinding, PolicyEvaluator]{invocation})
+	require.Nil(t, statusErr)
+	require.Len(t, policyErrors, 1)
+	labels := object.GetLabels()
+	require.Equal(t, "set", labels["success"])
+}
+
+func TestDispatchInvocationsCrossGVKFailureKeepsEarlierSuccess(t *testing.T) {
+	inputGVK := schema.GroupVersionKind{Group: "example.test", Version: "v1", Kind: "Widget"}
+	firstGVK := schema.GroupVersionKind{Group: "example.test", Version: "v1alpha1", Kind: "Widget"}
+	secondGVK := schema.GroupVersionKind{Group: "example.test", Version: "v1beta1", Kind: "Widget"}
+	object, attrs, objectInterfaces := newWritebackAttributes(t, inputGVK, nil, "")
+	first, err := admission.NewVersionedAttributes(attrs, firstGVK, objectInterfaces)
+	require.NoError(t, err)
+	second, err := admission.NewVersionedAttributes(attrs, secondGVK, objectInterfaces)
+	require.NoError(t, err)
+	dispatcher := &dispatcher{authz: writebackAuthorizer{}, typeConverterManager: writebackTypeConverterManager{}}
+	policyErrors, statusErr := dispatcher.dispatchInvocations(context.Background(), attrs, objectInterfaces, &writebackAccessor{attrs: map[schema.GroupVersionKind]*admission.VersionedAttributes{firstGVK: first, secondGVK: second}}, []generic.PolicyInvocation[*Policy, *PolicyBinding, PolicyEvaluator]{writebackInvocation(firstGVK, "first", writebackLabelPatcher{label: "first"}), writebackInvocation(secondGVK, "second", writebackErrorPatcher{})})
+	require.Nil(t, statusErr)
+	require.Len(t, policyErrors, 1)
+	require.Equal(t, "set", object.GetLabels()["first"])
+}
+
+func TestDispatchInvocationsReinvocationNoopNeverAndIfNeeded(t *testing.T) {
+	for _, reinvocation := range []admissionregistrationv1.ReinvocationPolicyType{admissionregistrationv1.NeverReinvocationPolicy, admissionregistrationv1.IfNeededReinvocationPolicy} {
+		t.Run(string(reinvocation), func(t *testing.T) {
+			gvk := schema.GroupVersionKind{Group: "example.test", Version: "v1", Kind: "Widget"}
+			object, attrs, objectInterfaces := newWritebackAttributes(t, gvk, nil, "")
+			versioned, err := admission.NewVersionedAttributes(attrs, gvk, objectInterfaces)
+			require.NoError(t, err)
+			counter := 0
+			invocation := writebackInvocationWithPolicy(gvk, "policy", reinvocation, writebackCountingPatcher{counter: &counter})
+			dispatcher := &dispatcher{authz: writebackAuthorizer{}, typeConverterManager: writebackTypeConverterManager{}}
+			accessor := &writebackAccessor{attrs: map[schema.GroupVersionKind]*admission.VersionedAttributes{gvk: versioned}}
+			trigger := writebackInvocationWithPolicy(gvk, "trigger", admissionregistrationv1.NeverReinvocationPolicy, writebackLabelPatcher{label: "trigger"})
+			_, statusErr := dispatcher.dispatchInvocations(context.Background(), attrs, objectInterfaces, accessor, []generic.PolicyInvocation[*Policy, *PolicyBinding, PolicyEvaluator]{invocation, trigger})
+			require.Nil(t, statusErr)
+			attrs.GetReinvocationContext().SetIsReinvoke()
+			_, statusErr = dispatcher.dispatchInvocations(context.Background(), attrs, objectInterfaces, accessor, []generic.PolicyInvocation[*Policy, *PolicyBinding, PolicyEvaluator]{invocation, trigger})
+			require.Nil(t, statusErr)
+			if reinvocation == admissionregistrationv1.IfNeededReinvocationPolicy {
+				require.Equal(t, 2, counter)
+			} else {
+				require.Equal(t, 1, counter)
+			}
+			_ = object
+		})
+	}
+
+	gvk := schema.GroupVersionKind{Group: "example.test", Version: "v1", Kind: "Widget"}
+	_, attrs, objectInterfaces := newWritebackAttributes(t, gvk, nil, "")
+	versioned, err := admission.NewVersionedAttributes(attrs, gvk, objectInterfaces)
+	require.NoError(t, err)
+	invocation := writebackInvocationWithPolicy(gvk, "noop", admissionregistrationv1.IfNeededReinvocationPolicy, writebackNoopPatcher{})
+	dispatcher := &dispatcher{authz: writebackAuthorizer{}, typeConverterManager: writebackTypeConverterManager{}}
+	_, statusErr := dispatcher.dispatchInvocations(context.Background(), attrs, objectInterfaces, &writebackAccessor{attrs: map[schema.GroupVersionKind]*admission.VersionedAttributes{gvk: versioned}}, []generic.PolicyInvocation[*Policy, *PolicyBinding, PolicyEvaluator]{invocation})
+	require.Nil(t, statusErr)
+	require.False(t, attrs.GetReinvocationContext().ShouldReinvoke())
+}
+
+func newWritebackAttributes(t *testing.T, gvk schema.GroupVersionKind, old runtime.Object, subresource string) (*unstructured.Unstructured, admission.Attributes, admission.ObjectInterfaces) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+	for _, version := range []string{"v1alpha1", "v1beta1"} {
+		equivalentGVK := gvk
+		equivalentGVK.Version = version
+		scheme.AddKnownTypeWithName(equivalentGVK, &unstructured.Unstructured{})
+	}
+	object := newWritebackObject(gvk)
+	attrs := admission.NewAttributesRecord(object, old, gvk, "", "demo", gvk.GroupVersion().WithResource("widgets"), subresource, admission.Create, &metav1.CreateOptions{}, false, nil)
+	return object, attrs, admission.NewObjectInterfacesFromScheme(scheme)
+}
+
+func newWritebackObject(gvk schema.GroupVersionKind) *unstructured.Unstructured {
+	object := &unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": gvk.GroupVersion().String(), "kind": gvk.Kind, "metadata": map[string]interface{}{"name": "demo", "labels": map[string]interface{}{}}}}
+	object.SetGroupVersionKind(gvk)
+	return object
+}
+
+func addWritebackLabel(t *testing.T, attr *admission.VersionedAttributes, label string) {
+	t.Helper()
+	object := attr.VersionedObject.Object().(*unstructured.Unstructured).DeepCopy()
+	require.NoError(t, unstructured.SetNestedField(object.Object, "set", "metadata", "labels", label))
+	attr.UpdateObject(object)
+}
+
+func assertWritebackLabel(t *testing.T, attr *admission.VersionedAttributes, labels ...string) {
+	t.Helper()
+	got, _, err := unstructured.NestedStringMap(attr.VersionedObject.Object().(*unstructured.Unstructured).Object, "metadata", "labels")
+	require.NoError(t, err)
+	for _, label := range labels {
+		require.Equal(t, "set", got[label])
+	}
+}
+
+type writebackAccessor struct {
+	attrs map[schema.GroupVersionKind]*admission.VersionedAttributes
+}
+
+func (a *writebackAccessor) VersionedAttribute(gvk schema.GroupVersionKind) (*admission.VersionedAttributes, error) {
+	attr, ok := a.attrs[gvk]
+	if !ok {
+		return nil, fmt.Errorf("missing prewarmed attributes for %s", gvk)
+	}
+	return attr, nil
+}
+
+type writebackTypeConverterManager struct{}
+
+func (writebackTypeConverterManager) GetTypeConverter(schema.GroupVersionKind) managedfields.TypeConverter {
+	return managedfields.NewDeducedTypeConverter()
+}
+
+func (writebackTypeConverterManager) Run(context.Context) {}
+
+type writebackLabelPatcher struct{ label string }
+
+func (p writebackLabelPatcher) Patch(_ context.Context, request patch.Request, _ int64) (runtime.Object, error) {
+	object := request.VersionedAttributes.VersionedObject.Object().(*unstructured.Unstructured).DeepCopy()
+	if err := unstructured.SetNestedField(object.Object, "set", "metadata", "labels", p.label); err != nil {
+		return nil, err
+	}
+	return object, nil
+}
+
+type writebackErrorPatcher struct{}
+
+func (writebackErrorPatcher) Patch(context.Context, patch.Request, int64) (runtime.Object, error) {
+	return nil, errors.New("synthetic mutation failure")
+}
+
+func writebackInvocation(gvk schema.GroupVersionKind, name string, patcher patch.Patcher) generic.PolicyInvocation[*Policy, *PolicyBinding, PolicyEvaluator] {
+	return writebackInvocationWithPolicy(gvk, name, admissionregistrationv1.NeverReinvocationPolicy, patcher)
+}
+
+func writebackInvocationWithPolicy(gvk schema.GroupVersionKind, name string, reinvocation admissionregistrationv1.ReinvocationPolicyType, patcher patch.Patcher) generic.PolicyInvocation[*Policy, *PolicyBinding, PolicyEvaluator] {
+	return generic.PolicyInvocation[*Policy, *PolicyBinding, PolicyEvaluator]{
+		Policy:  &Policy{ObjectMeta: metav1.ObjectMeta{Name: name}, Spec: admissionregistrationv1.MutatingAdmissionPolicySpec{ReinvocationPolicy: reinvocation, Mutations: []admissionregistrationv1.Mutation{{}}}},
+		Binding: &PolicyBinding{ObjectMeta: metav1.ObjectMeta{Name: name + "-binding"}}, Kind: gvk,
+		Resource: gvk.GroupVersion().WithResource("widgets"), Evaluator: PolicyEvaluator{Mutators: []patch.Patcher{patcher}},
+	}
+}
+
+type writebackCountingPatcher struct{ counter *int }
+
+func (p writebackCountingPatcher) Patch(_ context.Context, request patch.Request, _ int64) (runtime.Object, error) {
+	(*p.counter)++
+	object := request.VersionedAttributes.VersionedObject.Object().(*unstructured.Unstructured).DeepCopy()
+	if err := unstructured.SetNestedField(object.Object, "set", "metadata", "labels", "counted"); err != nil {
+		return nil, err
+	}
+	return object, nil
+}
+
+type writebackNoopPatcher struct{}
+
+func (writebackNoopPatcher) Patch(_ context.Context, request patch.Request, _ int64) (runtime.Object, error) {
+	return request.VersionedAttributes.VersionedObject.Object().DeepCopyObject(), nil
+}
+
+type failingWritebackConvertor struct{ runtime.ObjectConvertor }
+
+func (failingWritebackConvertor) Convert(interface{}, interface{}, interface{}) error {
+	return errors.New("synthetic conversion failure")
+}
+
+var _ authorizer.UnconditionalAuthorizer = writebackAuthorizer{}
+
+type writebackAuthorizer struct{}
+
+func (writebackAuthorizer) Authorize(context.Context, authorizer.Attributes) (authorizer.Decision, string, error) {
+	return authorizer.DecisionAllow, "test", nil
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig api-machinery

#### What this PR does / why we need it:

MutatingAdmissionPolicy dispatch can prewarm independent
`VersionedAttributes` snapshots for equivalent GVKs. Previously, each policy
invocation reused its cached snapshot and only the final snapshot was converted
back to the admission object. A later invocation using another equivalent GVK
could therefore overwrite a disjoint mutation made by an earlier invocation.

This change keeps the generic accessor semantics intact and confines sequential
write-through to the mutating dispatcher. Before each invocation, the selected
snapshot is refreshed from the canonical admission object. Dirty mutations are
then written back after that invocation. Change detection remains before
write-back so reinvocation bookkeeping is preserved.

The regression coverage exercises the actual dispatcher with prewarmed
equivalent GVKs and includes retained generic snapshots, concurrent reads,
old-object/subresource conversion, typed objects, conversion failures, partial
failures, and `Never`/`IfNeeded` reinvocation behavior.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The unpatched regression test loses the first of two disjoint mutations. The
generic versioned-attribute accessor is deliberately unchanged; write-through
is limited to MutatingAdmissionPolicy dispatch.

Locally verified with the generic and mutating package suites plus the targeted
tests under the race detector.

#### Does this PR introduce a user-facing change?

```release-note
Fixed MutatingAdmissionPolicy evaluation so each policy invocation observes mutations made by preceding invocations using equivalent GroupVersionKinds (GVKs).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

#### AI usage disclosure:

YES. AI assistance was used for source analysis, implementation, regression-test
development, and independent review. The final diff was rebased onto current
`master` and verified with focused package and race-test controls. The human
author remains responsible for the submitted change.
