### PR TITLE
storage: graduate VolumeAttachment declarative validation to stable

### DIFF
--- a/pkg/apis/storage/v1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1/zz_generated.validations.go
@@ -522,7 +522,7 @@ func Validate_VolumeAttachment(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -563,17 +563,17 @@ func Validate_VolumeAttachmentSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
+			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkBeta(); len(e) != 0 {
+			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return

--- a/pkg/apis/storage/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1alpha1/zz_generated.validations.go
@@ -168,7 +168,7 @@ func Validate_VolumeAttachment(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -209,17 +209,17 @@ func Validate_VolumeAttachmentSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
+			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkBeta(); len(e) != 0 {
+			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return

--- a/pkg/apis/storage/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1beta1/zz_generated.validations.go
@@ -522,7 +522,7 @@ func Validate_VolumeAttachment(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -563,17 +563,17 @@ func Validate_VolumeAttachmentSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
 				return // do not proceed
 			}
-			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkBeta(); len(e) != 0 {
+			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkBeta(); len(e) != 0 {
+			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63); len(e) != 0 {
 				errs = append(errs, e...)
 			}
 			return

--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -146,8 +146,7 @@ func ValidateVolumeAttachment(volumeAttachment *storage.VolumeAttachment) field.
 // has valid data.
 func validateVolumeAttachmentSpec(
 	spec *storage.VolumeAttachmentSpec, fldPath *field.Path) field.ErrorList {
-	allErrs := apivalidation.ValidateCSIDriverName(spec.Attacher, fldPath.Child("attacher"), apivalidation.RequiredCovered, apivalidation.FormatCovered, apivalidation.SizeCovered)
-	allErrs = append(allErrs, validateVolumeAttachmentSource(&spec.Source, fldPath.Child("source"))...)
+	allErrs := validateVolumeAttachmentSource(&spec.Source, fldPath.Child("source"))
 	allErrs = append(allErrs, validateNodeName(spec.NodeName, fldPath.Child("nodeName"))...)
 	return allErrs
 }
@@ -223,10 +222,8 @@ func validateVolumeError(e *storage.VolumeError, fldPath *field.Path) field.Erro
 }
 
 // ValidateVolumeAttachmentUpdate validates a VolumeAttachment.
-func ValidateVolumeAttachmentUpdate(new, old *storage.VolumeAttachment) field.ErrorList {
-	allErrs := ValidateVolumeAttachment(new)
-	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(new.Spec, old.Spec, field.NewPath("spec")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
-	return allErrs
+func ValidateVolumeAttachmentUpdate(new, _ *storage.VolumeAttachment) field.ErrorList {
+	return ValidateVolumeAttachment(new)
 }
 
 var supportedVolumeBindingModes = sets.NewString(string(storage.VolumeBindingImmediate), string(storage.VolumeBindingWaitForFirstConsumer))

--- a/pkg/apis/storage/validation/validation_test.go
+++ b/pkg/apis/storage/validation/validation_test.go
@@ -247,16 +247,6 @@ func TestVolumeAttachmentValidation(t *testing.T) {
 		}
 	}
 	migrationEnabledErrorCases := []storage.VolumeAttachment{{
-		// Empty attacher name
-		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-		Spec: storage.VolumeAttachmentSpec{
-			Attacher: "",
-			NodeName: "mynode",
-			Source: storage.VolumeAttachmentSource{
-				PersistentVolumeName: &volumeName,
-			},
-		},
-	}, {
 		// Empty node name
 		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 		Spec: storage.VolumeAttachmentSpec{
@@ -415,7 +405,6 @@ func TestVolumeAttachmentValidation(t *testing.T) {
 
 func TestVolumeAttachmentUpdateValidation(t *testing.T) {
 	volumeName := "foo"
-	newVolumeName := "bar"
 
 	old := storage.VolumeAttachment{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
@@ -483,46 +472,6 @@ func TestVolumeAttachmentUpdateValidation(t *testing.T) {
 	old.Spec.Source.PersistentVolumeName = &volumeName
 
 	errorCases := []storage.VolumeAttachment{{
-		// change attacher
-		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-		Spec: storage.VolumeAttachmentSpec{
-			Attacher: "another-attacher",
-			Source: storage.VolumeAttachmentSource{
-				PersistentVolumeName: &volumeName,
-			},
-			NodeName: "mynode",
-		},
-	}, {
-		// change source volume name
-		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-		Spec: storage.VolumeAttachmentSpec{
-			Attacher: "myattacher",
-			Source: storage.VolumeAttachmentSource{
-				PersistentVolumeName: &newVolumeName,
-			},
-			NodeName: "mynode",
-		},
-	}, {
-		// change node
-		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-		Spec: storage.VolumeAttachmentSpec{
-			Attacher: "myattacher",
-			Source: storage.VolumeAttachmentSource{
-				PersistentVolumeName: &volumeName,
-			},
-			NodeName: "anothernode",
-		},
-	}, {
-		// change source
-		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-		Spec: storage.VolumeAttachmentSpec{
-			Attacher: "myattacher",
-			Source: storage.VolumeAttachmentSource{
-				InlineVolumeSpec: &inlineSpec,
-			},
-			NodeName: "mynode",
-		},
-	}, {
 		// add invalid status
 		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 		Spec: storage.VolumeAttachmentSpec{
@@ -576,16 +525,6 @@ func TestVolumeAttachmentValidationV1(t *testing.T) {
 	}
 
 	errorCases := []storage.VolumeAttachment{{
-		// Invalid attacher name
-		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-		Spec: storage.VolumeAttachmentSpec{
-			Attacher: "invalid-@#$%^&*()",
-			NodeName: "mynode",
-			Source: storage.VolumeAttachmentSource{
-				PersistentVolumeName: &volumeName,
-			},
-		},
-	}, {
 		// Invalid PV name
 		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 		Spec: storage.VolumeAttachmentSpec{

--- a/pkg/registry/storage/volumeattachment/strategy_test.go
+++ b/pkg/registry/storage/volumeattachment/strategy_test.go
@@ -97,9 +97,9 @@ func TestVolumeAttachmentStrategy(t *testing.T) {
 		t.Errorf("unexpected objects difference after creating with status: %v", cmp.Diff(statusVolumeAttachment, volumeAttachment))
 	}
 
-	// Update of spec is disallowed
+	// Update with invalid source is disallowed
 	newVolumeAttachment := volumeAttachment.DeepCopy()
-	newVolumeAttachment.Spec.NodeName = "valid-node-2"
+	newVolumeAttachment.Spec.Source = storage.VolumeAttachmentSource{}
 
 	Strategy.PrepareForUpdate(ctx, newVolumeAttachment, volumeAttachment)
 
@@ -271,7 +271,6 @@ func TestCreatePreventsStatusWrite(t *testing.T) {
 
 func TestVolumeAttachmentValidation(t *testing.T) {
 	invalidPVName := "invalid-!@#$%^&*()"
-	validPVName := "valid-volume-name"
 	tests := []struct {
 		name             string
 		volumeAttachment *storage.VolumeAttachment
@@ -299,29 +298,13 @@ func TestVolumeAttachmentValidation(t *testing.T) {
 			true,
 		},
 		{
-			"invalid attacher name",
-			&storage.VolumeAttachment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
-				},
-				Spec: storage.VolumeAttachmentSpec{
-					Attacher: "invalid!@#$%^&*()",
-					Source: storage.VolumeAttachmentSource{
-						PersistentVolumeName: &validPVName,
-					},
-					NodeName: "valid-node",
-				},
-			},
-			true,
-		},
-		{
 			"invalid volume attachment",
 			&storage.VolumeAttachment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
 				Spec: storage.VolumeAttachmentSpec{
-					Attacher: "invalid!@#$%^&*()",
+					Attacher: "valid-attacher",
 					Source: storage.VolumeAttachmentSource{
 						PersistentVolumeName: nil,
 					},

--- a/staging/src/k8s.io/api/storage/v1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1/generated.proto
@@ -608,7 +608,7 @@ message VolumeAttachment {
 
   // spec represents specification of the desired attach/detach volume behavior.
   // Populated by the Kubernetes system.
-  // +k8s:beta(since: "1.37")=+k8s:immutable
+  // +k8s:immutable
   // +required
   optional VolumeAttachmentSpec spec = 2;
 
@@ -654,9 +654,9 @@ message VolumeAttachmentSpec {
   // attacher indicates the name of the volume driver that MUST handle this
   // request. This is the name returned by GetPluginName().
   // +required
-  // +k8s:beta(since: "1.37")=+k8s:required
-  // +k8s:beta(since: "1.37")=+k8s:format="k8s-long-name-caseless"
-  // +k8s:beta(since: "1.37")=+k8s:maxLength=63
+  // +k8s:required
+  // +k8s:format="k8s-long-name-caseless"
+  // +k8s:maxLength=63
   optional string attacher = 1;
 
   // source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -140,7 +140,7 @@ type VolumeAttachment struct {
 
 	// spec represents specification of the desired attach/detach volume behavior.
 	// Populated by the Kubernetes system.
-	// +k8s:beta(since: "1.37")=+k8s:immutable
+	// +k8s:immutable
 	// +required
 	Spec VolumeAttachmentSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
@@ -172,9 +172,9 @@ type VolumeAttachmentSpec struct {
 	// attacher indicates the name of the volume driver that MUST handle this
 	// request. This is the name returned by GetPluginName().
 	// +required
-	// +k8s:beta(since: "1.37")=+k8s:required
-	// +k8s:beta(since: "1.37")=+k8s:format="k8s-long-name-caseless"
-	// +k8s:beta(since: "1.37")=+k8s:maxLength=63
+	// +k8s:required
+	// +k8s:format="k8s-long-name-caseless"
+	// +k8s:maxLength=63
 	Attacher string `json:"attacher" protobuf:"bytes,1,opt,name=attacher"`
 
 	// source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1alpha1/generated.proto
@@ -135,7 +135,7 @@ message VolumeAttachment {
 
   // spec represents specification of the desired attach/detach volume behavior.
   // Populated by the Kubernetes system.
-  // +k8s:beta(since: "1.37")=+k8s:immutable
+  // +k8s:immutable
   // +required
   optional VolumeAttachmentSpec spec = 2;
 
@@ -181,9 +181,9 @@ message VolumeAttachmentSpec {
   // attacher indicates the name of the volume driver that MUST handle this
   // request. This is the name returned by GetPluginName().
   // +required
-  // +k8s:beta(since: "1.37")=+k8s:required
-  // +k8s:beta(since: "1.37")=+k8s:format="k8s-long-name-caseless"
-  // +k8s:beta(since: "1.37")=+k8s:maxLength=63
+  // +k8s:required
+  // +k8s:format="k8s-long-name-caseless"
+  // +k8s:maxLength=63
   optional string attacher = 1;
 
   // source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/storage/v1alpha1/types.go
@@ -44,7 +44,7 @@ type VolumeAttachment struct {
 
 	// spec represents specification of the desired attach/detach volume behavior.
 	// Populated by the Kubernetes system.
-	// +k8s:beta(since: "1.37")=+k8s:immutable
+	// +k8s:immutable
 	// +required
 	Spec VolumeAttachmentSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
@@ -78,9 +78,9 @@ type VolumeAttachmentSpec struct {
 	// attacher indicates the name of the volume driver that MUST handle this
 	// request. This is the name returned by GetPluginName().
 	// +required
-	// +k8s:beta(since: "1.37")=+k8s:required
-	// +k8s:beta(since: "1.37")=+k8s:format="k8s-long-name-caseless"
-	// +k8s:beta(since: "1.37")=+k8s:maxLength=63
+	// +k8s:required
+	// +k8s:format="k8s-long-name-caseless"
+	// +k8s:maxLength=63
 	Attacher string `json:"attacher" protobuf:"bytes,1,opt,name=attacher"`
 
 	// source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1beta1/generated.proto
@@ -611,7 +611,7 @@ message VolumeAttachment {
 
   // spec represents specification of the desired attach/detach volume behavior.
   // Populated by the Kubernetes system.
-  // +k8s:beta(since: "1.37")=+k8s:immutable
+  // +k8s:immutable
   // +required
   optional VolumeAttachmentSpec spec = 2;
 
@@ -657,9 +657,9 @@ message VolumeAttachmentSpec {
   // attacher indicates the name of the volume driver that MUST handle this
   // request. This is the name returned by GetPluginName().
   // +required
-  // +k8s:beta(since: "1.37")=+k8s:required
-  // +k8s:beta(since: "1.37")=+k8s:format="k8s-long-name-caseless"
-  // +k8s:beta(since: "1.37")=+k8s:maxLength=63
+  // +k8s:required
+  // +k8s:format="k8s-long-name-caseless"
+  // +k8s:maxLength=63
   optional string attacher = 1;
 
   // source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types.go
@@ -145,7 +145,7 @@ type VolumeAttachment struct {
 
 	// spec represents specification of the desired attach/detach volume behavior.
 	// Populated by the Kubernetes system.
-	// +k8s:beta(since: "1.37")=+k8s:immutable
+	// +k8s:immutable
 	// +required
 	Spec VolumeAttachmentSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
@@ -179,9 +179,9 @@ type VolumeAttachmentSpec struct {
 	// attacher indicates the name of the volume driver that MUST handle this
 	// request. This is the name returned by GetPluginName().
 	// +required
-	// +k8s:beta(since: "1.37")=+k8s:required
-	// +k8s:beta(since: "1.37")=+k8s:format="k8s-long-name-caseless"
-	// +k8s:beta(since: "1.37")=+k8s:maxLength=63
+	// +k8s:required
+	// +k8s:format="k8s-long-name-caseless"
+	// +k8s:maxLength=63
 	Attacher string `json:"attacher" protobuf:"bytes,1,opt,name=attacher"`
 
 	// source represents the volume that should be attached.

--- a/test/declarative_validation/storage/volumeattachment/declarative_validation_test.go
+++ b/test/declarative_validation/storage/volumeattachment/declarative_validation_test.go
@@ -70,19 +70,19 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"invalid attacher (required)": {
 			input: mkValidVolumeAttachment(TweakAttacher("")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "attacher"), "").MarkBeta(),
+				field.Required(field.NewPath("spec", "attacher"), ""),
 			},
 		},
 		"attacher with special characters": {
 			input: mkValidVolumeAttachment(TweakAttacher("asdadasd&@!")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "attacher"), "", "").WithOrigin("format=k8s-long-name-caseless").MarkBeta(),
+				field.Invalid(field.NewPath("spec", "attacher"), "", "").WithOrigin("format=k8s-long-name-caseless"),
 			},
 		},
 		"attacher with number of characters exceeds 63": {
 			input: mkValidVolumeAttachment(TweakAttacher(strings.Repeat("a", 64))),
 			expectedErrs: field.ErrorList{
-				field.TooLong(field.NewPath("spec", "attacher"), strings.Repeat("a", 64), 63).WithOrigin("maxLength").MarkBeta(),
+				field.TooLong(field.NewPath("spec", "attacher"), strings.Repeat("a", 64), 63).WithOrigin("maxLength"),
 			},
 		},
 	}
@@ -119,7 +119,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			oldInput: mkValidVolumeAttachment(),
 			newInput: mkValidVolumeAttachment(TweakAttacher("different.com")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec"), nil, "field is immutable").WithOrigin("immutable").MarkBeta(),
+				field.Invalid(field.NewPath("spec"), nil, "field is immutable").WithOrigin("immutable"),
 			},
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area api-validation

#### What this PR does / why we need it:

This PR graduates declarative validation (DV) tags for `VolumeAttachment` from beta to stable.

#### Which issue(s) this PR is related to:

Part of #141532

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```