### PR TITLE
kubectl patch: validate --type when explicitly set to empty string 

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
@@ -191,19 +191,14 @@ func (o *PatchOptions) Validate() error {
 	if o.Local && o.dryRunStrategy == cmdutil.DryRunServer {
 		return fmt.Errorf("cannot specify --local and --dry-run=server - did you mean --dry-run=client?")
 	}
-	if len(o.PatchType) != 0 {
-		if _, ok := patchTypes[strings.ToLower(o.PatchType)]; !ok {
-			return fmt.Errorf("--type must be one of %v, not %q", sets.List(sets.KeySet(patchTypes)), o.PatchType)
-		}
+	if _, ok := patchTypes[strings.ToLower(o.PatchType)]; !ok {
+		return fmt.Errorf("--type must be one of %v, not %q", sets.List(sets.KeySet(patchTypes)), o.PatchType)
 	}
 	return nil
 }
 
 func (o *PatchOptions) RunPatch() error {
-	patchType := types.StrategicMergePatchType
-	if len(o.PatchType) != 0 {
-		patchType = patchTypes[strings.ToLower(o.PatchType)]
-	}
+	patchType := patchTypes[strings.ToLower(o.PatchType)]
 
 	var patchBytes []byte
 	if len(o.PatchFile) > 0 {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch_test.go
@@ -240,3 +240,22 @@ func TestPatchSubresource(t *testing.T) {
 		t.Errorf("unexpected pod status to be set to %s got: %s", expectedStatus, actualStatus)
 	}
 }
+
+func TestPatchEmptyType(t *testing.T) {
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+
+	stream, _, _, _ := genericiooptions.NewTestIOStreams()
+
+	o := NewPatchOptions(stream)
+	o.PatchType = ""
+	o.Patch = `{"metadata":{"labels":{"foo":"bar"}}}`
+
+	err := o.Validate()
+	if err == nil {
+		t.Fatalf("expected error for empty --type flag, but got none")
+	}
+	if !strings.Contains(err.Error(), "--type must be one of") {
+		t.Errorf("unexpected error message: %s", err.Error())
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`kubectl patch --type=""` silently skips validation and falls back to `StrategicMergePatchType` instead of returning an error, because `Validate()` and `RunPatch()` guard the type check with `len(o.PatchType) != 0`. Since `--type` defaults to `strategic`, `o.PatchType` is only empty when a user explicitly passes `--type=""` — so this guard wrongly treats that as "flag not set" and skips validation.

This PR removes the guard so `--type` is always validated, and adds `TestPatchEmptyType` to cover the regression.

Currently learning Kubernetes and would appreciate suggestions to improve my learning process.

#### Which issue(s) this PR is related to:
- Fixes https://github.com/kubernetes/kubernetes/issues/142058

#### Special notes for your reviewer:
Only affects explicitly empty `--type` values; all other values behave as before. Verified manually and all existing package tests still pass.

#### Does this PR introduce a user-facing change?
```release-note
`kubectl patch --type=""` now returns a validation error instead of silently falling back to strategic merge patch.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

#### AI usage disclosure:
YES. I am currently learning Kubernetes, so I used AI assistance.