### PR TITLE
test/e2e/apimachinery: retry transient HTTP errors in waitForOpenAPISchema

### DIFF
--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -669,17 +669,27 @@ func waitForOpenAPISchema(c k8sclientset.Interface, pred func(*spec.Swagger) (bo
 		}
 		resp, err := client.Do(req)
 		if err != nil {
-			return false, err
+			lastMsg = fmt.Sprintf("HTTP request failed: %v", err)
+			return false, nil
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode == http.StatusNotModified {
-			spec = etagSpec
+			if etagSpec != nil {
+				spec = etagSpec
+			} else {
+				etag = ""
+				lastMsg = "received 304 without cached OpenAPI spec"
+				return false, nil
+			}
 		} else if resp.StatusCode != http.StatusOK {
-			return false, fmt.Errorf("unexpected response: %d", resp.StatusCode)
+			lastMsg = fmt.Sprintf("unexpected response: %d", resp.StatusCode)
+			return false, nil
 		} else if bs, err := io.ReadAll(resp.Body); err != nil {
-			return false, err
+			lastMsg = fmt.Sprintf("failed to read response body: %v", err)
+			return false, nil
 		} else if err := json.Unmarshal(bs, spec); err != nil {
-			return false, err
+			lastMsg = fmt.Sprintf("failed to unmarshal spec: %v", err)
+			return false, nil
 		} else {
 			etag = strings.Trim(resp.Header.Get("ETag"), `"`)
 			etagSpec = spec


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
## What does this PR do?
Fixes an issue where `[sig-api-machinery] CustomResourcePublishOpenAPI ... works for multiple CRDs of same group but different versions` flakes in e2e test jobs (such as `ci-kubernetes-e2e-ubuntu-gce-containerd` and `ci-kubernetes-e2e-gci-gce`).

During `waitForOpenAPISchema`, `mustSucceedMultipleTimes(10, ...)` makes multiple HTTP requests with `req.Close = true` (enforcing a new TCP and TLS handshake for each request). Previously, if any transient network error (e.g., `dial tcp ...:443: i/o timeout`) or transient 5xx HTTP status occurred on a single attempt, `waitForOpenAPISchema` returned `false, err`. Because `wait.Poll` immediately aborts upon receiving a non-nil error, the polling loop aborted instantly on the very first transient glitch, causing the test to fail even when the 60-second polling timeout had barely begun.

This PR ensures transient transport and HTTP errors are recorded in `lastMsg` and return `false, nil`, allowing `wait.Poll` to retry until the condition is met 10 consecutive times or the 60s timeout expires.

- fixing: #141950

## Changes proposed in this pull request:

### E2E Test Polling Resilience (`test/e2e/apimachinery/crd_publish_openapi.go`)
- **Graceful Network Error Handling:** When `client.Do(req)` fails with a network or dial timeout error, it records the failure in `lastMsg` and returns `false, nil` so `wait.Poll` retries on the next tick rather than aborting immediately.
- **HTTP Status Resilience:** When non-200 / non-304 status codes are returned while OpenAPI specs are being aggregated by the API server, it updates `lastMsg` and returns `false, nil`.
- **Response Read & Parse Protection:** Catches truncated stream reads or JSON unmarshal failures into `lastMsg` with `false, nil` retry semantics.
- **304 Cache Guard:** Added fallback reset for `etag` if a 304 response is encountered without a cached spec in memory.

## How to test this:
1. Run a mock polling loop simulating transient network packet drops (`dial tcp ... i/o timeout`) on initial attempts followed by a healthy connection.
2. Observe that the unpatched implementation immediately aborts on the first error:
   ```
   FAILED: failed to wait for OpenAPI spec validating condition: Get "https://34.41.18.229/openapi/v2": dial tcp 34.41.18.229:443: i/o timeout; lastMsg:
   ```
3. Run with the patched logic:
   ```
   PASSED: recovered from transient transport errors and succeeded 10 consecutive times.
   ```

### Verification & Visual Proof:

![Test Verification Proof](https://raw.githubusercontent.com/Pcmhacker-piro/kubernetes/assets/test_verification_proof.jpg)

#### Which issue(s) this PR is related to:
Fixes #141950

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs, usage docs, etc.:
```docs
NONE
```

#### AI usage disclosure:
YES: AI assistant used assistively to investigate the e2e flake stack trace, pinpoint the premature abort in `wait.Poll`, write a reproduction test, and draft this PR. All code and verification logic was reviewed and tested.