### PR TITLE
kubelet: skip cgroup reads when pod cgroup is gone during teardown

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -478,7 +478,7 @@ func (m *cgroupCommon) ReduceCPULimits(logger klog.Logger, cgroupName CgroupName
 func readCgroupMemoryConfig(cgroupPath string, memLimitFile string) (*ResourceConfig, error) {
 	memLimit, err := fscommon.GetCgroupParamUint(cgroupPath, memLimitFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read %s for cgroup %v: %v", memLimitFile, cgroupPath, err)
+		return nil, fmt.Errorf("failed to read %s for cgroup %v: %w", memLimitFile, cgroupPath, err)
 	}
 	mLim := int64(memLimit)
 	//TODO(vinaykul,InPlacePodVerticalScaling): Add memory request support

--- a/pkg/kubelet/kubelet_pod_level_resources_status_test.go
+++ b/pkg/kubelet/kubelet_pod_level_resources_status_test.go
@@ -19,6 +19,8 @@ limitations under the License.
 package kubelet
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -94,6 +96,7 @@ func TestConvertToAPIPodLevelResourcesStatus(t *testing.T) {
 			}
 
 			mockPCM := cmtesting.NewMockPodContainerManager(t)
+			mockPCM.EXPECT().Exists(pod).Return(true)
 			mockPCM.EXPECT().GetPodCgroupConfig(pod, v1.ResourceMemory).Return(nil, nil)
 			mockPCM.EXPECT().GetPodCgroupConfig(pod, v1.ResourceCPU).Return(cpuCfg, nil)
 
@@ -106,4 +109,87 @@ func TestConvertToAPIPodLevelResourcesStatus(t *testing.T) {
 			require.Equal(t, tc.expectedMilliCPU, got.Requests.Cpu().MilliValue())
 		})
 	}
+}
+
+func TestConvertToAPIPodLevelResourcesStatusMissingCgroup(t *testing.T) {
+	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+		features.PodLevelResources:                       true,
+		features.InPlacePodLevelResourcesVerticalScaling: true,
+	})
+
+	runningPod := func() *v1.Pod {
+		return &v1.Pod{
+			Spec: v1.PodSpec{
+				Resources: &v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("50m"),
+						v1.ResourceMemory: resource.MustParse("50Mi"),
+					},
+					Limits: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("100m"),
+						v1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+				Containers: []v1.Container{{Name: "pause"}},
+			},
+			Status: v1.PodStatus{Phase: v1.PodRunning},
+		}
+	}
+
+	t.Run("skip cgroup read when pod cgroup is gone", func(t *testing.T) {
+		logger, _ := ktesting.NewTestContext(t)
+		pod := runningPod()
+
+		mockPCM := cmtesting.NewMockPodContainerManager(t)
+		mockPCM.EXPECT().Exists(pod).Return(false)
+
+		mockCM := cmtesting.NewMockContainerManager(t)
+		mockCM.EXPECT().NewPodContainerManager().Return(mockPCM)
+
+		kl := &Kubelet{containerManager: mockCM}
+		got := kl.convertToAPIPodLevelResourcesStatus(logger, pod, v1.PodStatus{})
+		require.NotNil(t, got)
+		require.Equal(t, int64(50), got.Requests.Cpu().MilliValue())
+		require.Equal(t, resource.MustParse("50Mi"), got.Requests[v1.ResourceMemory])
+		require.Equal(t, int64(100), got.Limits.Cpu().MilliValue())
+		require.Equal(t, resource.MustParse("100Mi"), got.Limits[v1.ResourceMemory])
+	})
+
+	t.Run("ENOENT from cgroup read is not fatal", func(t *testing.T) {
+		logger, _ := ktesting.NewTestContext(t)
+		pod := runningPod()
+
+		mockPCM := cmtesting.NewMockPodContainerManager(t)
+		mockPCM.EXPECT().Exists(pod).Return(true)
+		mockPCM.EXPECT().GetPodCgroupConfig(pod, v1.ResourceMemory).Return(nil, os.ErrNotExist)
+		mockPCM.EXPECT().GetPodCgroupConfig(pod, v1.ResourceCPU).Return(nil, os.ErrNotExist)
+
+		mockCM := cmtesting.NewMockContainerManager(t)
+		mockCM.EXPECT().NewPodContainerManager().Return(mockPCM)
+
+		kl := &Kubelet{containerManager: mockCM}
+		got := kl.convertToAPIPodLevelResourcesStatus(logger, pod, v1.PodStatus{})
+		require.NotNil(t, got)
+		require.Equal(t, int64(50), got.Requests.Cpu().MilliValue())
+		require.Equal(t, resource.MustParse("100Mi"), got.Limits[v1.ResourceMemory])
+	})
+
+	t.Run("unwrapped or string-formatted no such file or directory error is not fatal", func(t *testing.T) {
+		logger, _ := ktesting.NewTestContext(t)
+		pod := runningPod()
+
+		mockPCM := cmtesting.NewMockPodContainerManager(t)
+		mockPCM.EXPECT().Exists(pod).Return(true)
+		mockPCM.EXPECT().GetPodCgroupConfig(pod, v1.ResourceMemory).Return(nil, fmt.Errorf("failed to read memory.max for cgroup foo: openat2 ...: no such file or directory"))
+		mockPCM.EXPECT().GetPodCgroupConfig(pod, v1.ResourceCPU).Return(nil, fmt.Errorf("failed to read cpu.max file for cgroup foo: no such file or directory"))
+
+		mockCM := cmtesting.NewMockContainerManager(t)
+		mockCM.EXPECT().NewPodContainerManager().Return(mockPCM)
+
+		kl := &Kubelet{containerManager: mockCM}
+		got := kl.convertToAPIPodLevelResourcesStatus(logger, pod, v1.PodStatus{})
+		require.NotNil(t, got)
+		require.Equal(t, int64(50), got.Requests.Cpu().MilliValue())
+		require.Equal(t, resource.MustParse("100Mi"), got.Limits[v1.ResourceMemory])
+	})
 }

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2225,17 +2225,24 @@ func (kl *Kubelet) convertToAPIPodLevelResourcesStatus(logger klog.Logger, alloc
 	// output inconsistent. We should decide if the information is useful enough to
 	//  outweigh the consistency issues,
 	pcm := kl.containerManager.NewPodContainerManager()
-	memoryConfig, err := pcm.GetPodCgroupConfig(allocatedPod, v1.ResourceMemory)
-	if err != nil {
-		logger.Error(err, "failed to read memory cgroup config for the pod", "podName", allocatedPod.Name)
+	var memoryConfig, cpuConfig *cm.ResourceConfig
+	// During teardown, a terminating pod's phase may still be Running even after
+	// its cgroup has already been removed. Check if the cgroup exists before reading,
+	// and if a race condition still results in ENOENT / not found, log at info level
+	// rather than error.
+	if pcm.Exists(allocatedPod) {
+		var err error
+		memoryConfig, err = pcm.GetPodCgroupConfig(allocatedPod, v1.ResourceMemory)
+		if err != nil {
+			logPodCgroupReadError(logger, err, "failed to read memory cgroup config for the pod", allocatedPod.Name)
+		}
+		cpuConfig, err = pcm.GetPodCgroupConfig(allocatedPod, v1.ResourceCPU)
+		if err != nil {
+			logPodCgroupReadError(logger, err, "failed to read cpu cgroup limits for the pod", allocatedPod.Name)
+		}
 	}
+
 	memoryLimit := cm.MemoryLimitsFromConfig(memoryConfig)
-	cpuConfig, err := pcm.GetPodCgroupConfig(allocatedPod, v1.ResourceCPU)
-	if err != nil {
-		logger.Error(err, "failed to read memory cgroup limits for the pod", "podName", allocatedPod.Name)
-
-	}
-
 	cpuRequest := cm.CPURequestsFromConfig(cpuConfig)
 	cpuLimit := cm.CPULimitsFromConfig(cpuConfig)
 
@@ -2320,6 +2327,24 @@ func (kl *Kubelet) convertToAPIPodLevelResourcesStatus(logger klog.Logger, alloc
 	}
 
 	return resources
+}
+
+// logPodCgroupReadError logs an error reading pod cgroup configuration.
+// If the error indicates the cgroup does not exist (expected if teardown races the existence check),
+// it is logged at V(4) info level instead of error level.
+func logPodCgroupReadError(logger klog.Logger, err error, msg, podName string) {
+	if isPodCgroupNotExist(err) {
+		logger.V(4).Info(msg, "err", err, "podName", podName)
+		return
+	}
+	logger.Error(err, msg, "podName", podName)
+}
+
+func isPodCgroupNotExist(err error) bool {
+	if goerrors.Is(err, os.ErrNotExist) {
+		return true
+	}
+	return strings.Contains(err.Error(), "no such file or directory")
 }
 
 // convertToAPIContainerStatuses converts the given internal container


### PR DESCRIPTION
### What type of PR is this?
/kind bug
/sig node

### What this PR does / why we need it:
Fixes #141927

With `InPlacePodLevelResourcesVerticalScaling` enabled, `convertToAPIPodLevelResourcesStatus` only skipped the cgroup read when `allocatedPod.Status.Phase != v1.PodRunning`.

During teardown, a terminating pod's phase remains `Running` even after its cgroup directory has already been cleaned up and removed by the container runtime / teardown process. As a result, kubelet attempts to read cgroup configs for a nonexistent directory, causing noisy `ENOENT` / `no such file or directory` error logs during every status sync cycle.

This PR fixes this issue:
1. **Pre-flight guard:** Skips calling `GetPodCgroupConfig` when `pcm.Exists(allocatedPod)` is false.
2. **Teardown race handling:** If cgroup teardown races the `Exists` check and returns `ENOENT` / `os.ErrNotExist` / `no such file or directory`, logs it at `V(4)` info level instead of error level.
3. **Proper error wrapping:** Changes `%v` to `%w` in `readCgroupMemoryConfig` so `errors.Is(err, os.ErrNotExist)` correctly unwraps the underlying filesystem error.
4. **Fix logging typo:** Corrects the log message for CPU querying which said `"failed to read memory cgroup limits"` instead of `"failed to read cpu cgroup limits"`.
5. **Unit test coverage:** Adds `TestConvertToAPIPodLevelResourcesStatusMissingCgroup` covering cgroup skip, non-fatal `ENOENT`, and unwrapped not found errors.

### Verification & Proof
Tests pass cleanly and binaries build successfully:

![Kubelet Cgroup Verification Proof](https://raw.githubusercontent.com/Pcmhacker-piro/kubernetes/assets/kubelet_cgroup_verification.png)

### Which issue(s) this PR fixes:
Fixes #141927

### Special notes for your reviewer:
None.

### Does this PR introduce a user-facing change?
```release-note
kubelet: avoid error-level logging when reading pod cgroup configs for terminating pods whose cgroup has already been removed.
```
