### PR TITLE
Fix race where custom resources were served from stale CRD storage

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -160,7 +160,61 @@ type crdInfo struct {
 	// storageVersion is the CRD version used when storing the object in etcd.
 	storageVersion string
 
+	// generation is the metadata.generation of the CRD this info was built from. The API server
+	// advances it on every spec change (see customresourcedefinition.strategy.PrepareForUpdate),
+	// which makes it a cheap way to accept an unchanged spec without comparing it field by field.
+	generation int64
+
 	waitGroup *utilwaitgroup.SafeWaitGroup
+}
+
+// isUpToDateFor reports whether this info can serve crd. It is directional: an info built from a
+// state newer than crd satisfies it, because callers may hold a CRD read earlier in their sync
+// (CRDFinalizer does) and must not force a rebuild.
+//
+// acceptedNames is compared directly because it lives in status, which generation never covers: the
+// naming controller can move an accepted name from one non-empty value to another when a conflicting
+// CRD in the group goes away, without any write to this CRD's spec.
+//
+// A generation at least as new as crd's proves the spec is unchanged, so the common case costs an
+// integer compare and no allocations. The reverse does not hold, which is why a bump falls through to
+// matchesSpecAndNames rather than rebuilding: PrepareForUpdate increments the generation before
+// dropDisabledFields strips fields behind disabled feature gates, so a write that sets such a field
+// bumps the generation while leaving the stored spec untouched.
+func (i *crdInfo) isUpToDateFor(crd *apiextensionsv1.CustomResourceDefinition) bool {
+	if !namesEqual(&crd.Status.AcceptedNames, i.acceptedNames) {
+		return false
+	}
+	return i.generation >= crd.Generation || apiequality.Semantic.DeepEqual(&crd.Spec, i.spec)
+}
+
+// matchesSpecAndNames reports whether this info was built from crd's spec and accepted names. The
+// informer handlers use it to decide whether an event invalidates existing storage. Unlike
+// isUpToDateFor it is exact rather than directional, so it still tears down storage that no longer
+// matches the CRD even when the cached generation runs ahead of the event being processed.
+func (i *crdInfo) matchesSpecAndNames(crd *apiextensionsv1.CustomResourceDefinition) bool {
+	return apiequality.Semantic.DeepEqual(&crd.Spec, i.spec) &&
+		namesEqual(&crd.Status.AcceptedNames, i.acceptedNames)
+}
+
+func namesEqual(a, b *apiextensionsv1.CustomResourceDefinitionNames) bool {
+	if a.Plural != b.Plural || a.Singular != b.Singular || a.Kind != b.Kind || a.ListKind != b.ListKind {
+		return false
+	}
+	if len(a.ShortNames) != len(b.ShortNames) || len(a.Categories) != len(b.Categories) {
+		return false
+	}
+	for i := range a.ShortNames {
+		if a.ShortNames[i] != b.ShortNames[i] {
+			return false
+		}
+	}
+	for i := range a.Categories {
+		if a.Categories[i] != b.Categories[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // crdStorageMap goes from customresourcedefinition to its storage
@@ -297,7 +351,7 @@ func (r *crdHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	terminating := !crd.DeletionTimestamp.IsZero() || apiextensionshelpers.IsCRDConditionTrue(crd, apiextensionsv1.Terminating)
 
-	crdInfo, err := r.getOrCreateServingInfoFor(crd.UID, crd.Name)
+	crdInfo, err := r.getOrCreateServingInfoFor(crd)
 	if apierrors.IsNotFound(err) {
 		r.delegate.ServeHTTP(w, req)
 		return
@@ -466,7 +520,7 @@ func (r *crdHandler) createCustomResourceDefinition(obj interface{}) {
 	if !found {
 		return
 	}
-	if apiequality.Semantic.DeepEqual(&crd.Spec, oldInfo.spec) && apiequality.Semantic.DeepEqual(&crd.Status.AcceptedNames, oldInfo.acceptedNames) {
+	if oldInfo.matchesSpecAndNames(crd) {
 		klog.V(6).Infof("Ignoring customresourcedefinition %s create event because a storage with the same spec and accepted names exists",
 			crd.Name)
 		return
@@ -504,7 +558,7 @@ func (r *crdHandler) updateCustomResourceDefinition(oldObj, newObj interface{}) 
 	if !found {
 		return
 	}
-	if apiequality.Semantic.DeepEqual(&newCRD.Spec, oldInfo.spec) && apiequality.Semantic.DeepEqual(&newCRD.Status.AcceptedNames, oldInfo.acceptedNames) {
+	if oldInfo.matchesSpecAndNames(newCRD) {
 		klog.V(6).Infof("Ignoring customresourcedefinition %s update because neither spec, nor accepted names changed", oldCRD.Name)
 		return
 	}
@@ -604,18 +658,19 @@ func (r *crdHandler) destroy() {
 // GetCustomResourceListerCollectionDeleter returns the ListerCollectionDeleter of
 // the given crd.
 func (r *crdHandler) GetCustomResourceListerCollectionDeleter(crd *apiextensionsv1.CustomResourceDefinition) (finalizer.ListerCollectionDeleter, error) {
-	info, err := r.getOrCreateServingInfoFor(crd.UID, crd.Name)
+	info, err := r.getOrCreateServingInfoFor(crd)
 	if err != nil {
 		return nil, err
 	}
 	return info.storages[info.storageVersion].CustomResource, nil
 }
 
-// getOrCreateServingInfoFor gets the CRD serving info for the given CRD UID if the key exists in the storage map.
-// Otherwise the function fetches the up-to-date CRD using the given CRD name and creates CRD serving info.
-func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crdInfo, error) {
+// getOrCreateServingInfoFor returns the serving info for crd, building it if the cache is empty or
+// holds an entry built from an older CRD state. crd is used only for the lock-free freshness check.
+// a crd newer than the lister is tolerated.
+func (r *crdHandler) getOrCreateServingInfoFor(crd *apiextensionsv1.CustomResourceDefinition) (*crdInfo, error) {
 	storageMap := r.customStorage.Load().(crdStorageMap)
-	if ret, ok := storageMap[uid]; ok {
+	if ret, ok := storageMap[crd.UID]; ok && ret.isUpToDateFor(crd) {
 		return ret, nil
 	}
 
@@ -626,12 +681,12 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 	// If updateCustomResourceDefinition sees an update and happens later, the storage will be deleted and
 	// we will re-create the updated storage on demand. If updateCustomResourceDefinition happens before,
 	// we make sure that we observe the same up-to-date CRD.
-	crd, err := r.crdLister.Get(name)
+	crd, err := r.crdLister.Get(crd.Name)
 	if err != nil {
 		return nil, err
 	}
 	storageMap = r.customStorage.Load().(crdStorageMap)
-	if ret, ok := storageMap[crd.UID]; ok {
+	if ret, ok := storageMap[crd.UID]; ok && ret.isUpToDateFor(crd) {
 		return ret, nil
 	}
 
@@ -1061,6 +1116,7 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 		deprecated:          deprecated,
 		warnings:            warnings,
 		storageVersion:      storageVersion,
+		generation:          crd.Generation,
 		waitGroup:           &utilwaitgroup.SafeWaitGroup{},
 	}
 
@@ -1070,6 +1126,11 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 
 	storageMap2[crd.UID] = ret
 	r.customStorage.Store(storageMap2)
+	// Only tear down a previous info; on a cold cache the map has no entry for this UID and the
+	// lookup yields a nil *crdInfo, which tearDown dereferences.
+	if oldInfo := storageMap[crd.UID]; oldInfo != nil {
+		go r.tearDown(oldInfo)
+	}
 
 	return ret, nil
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler_test.go
@@ -28,6 +28,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"testing"
 	"time"
@@ -42,6 +43,7 @@ import (
 	informers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	listers "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/controller/establish"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -519,7 +521,7 @@ func testHandlerConversion(t *testing.T, enableWatchCache bool) {
 		t.Fatal(err)
 	}
 
-	crdInfo, err := handler.getOrCreateServingInfoFor(crd.UID, crd.Name)
+	crdInfo, err := handler.getOrCreateServingInfoFor(crd)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -647,6 +649,221 @@ func testHandlerConversion(t *testing.T, enableWatchCache bool) {
 			t.Errorf("unexpected event: %#v", event)
 		case <-time.After(time.Second):
 		}
+	}
+}
+
+// TestGetOrCreateServingInfoForFreshness verifies that cached serving info is validated against the
+// CRD state it was built from, not merely by presence of the UID key. See kubernetes#130235: discovery
+// is level-triggered off the shared CRD informer while the handler cached edge-triggered, so the handler
+// could keep serving a stale storage version after discovery had already advertised the new one.
+func TestGetOrCreateServingInfoForFreshness(t *testing.T) {
+	informers := informers.NewSharedInformerFactoryWithOptions(fake.NewSimpleClientset(), 0)
+	crdInformer := informers.Apiextensions().V1().CustomResourceDefinitions()
+
+	server, storageConfig := etcd3testing.NewUnsecuredEtcd3TestClientServer(t)
+	defer server.Terminate(t)
+
+	crd := multiVersionFixture.DeepCopy()
+	crd.Generation = 1
+	if err := crdInformer.Informer().GetStore().Add(crd); err != nil {
+		t.Fatal(err)
+	}
+
+	etcdOptions := options.NewEtcdOptions(storageConfig)
+	etcdOptions.StorageConfig.Codec = unstructured.UnstructuredJSONScheme
+	restOptionsGetter := generic.RESTOptions{
+		StorageConfig:           etcdOptions.StorageConfig.ForResource(schema.GroupResource{Group: crd.Spec.Group, Resource: crd.Spec.Names.Plural}),
+		Decorator:               generic.UndecoratedStorage,
+		EnableGarbageCollection: true,
+		DeleteCollectionWorkers: 1,
+		ResourcePrefix:          crd.Spec.Group + "/" + crd.Spec.Names.Plural,
+		CountMetricPollPeriod:   time.Minute,
+	}
+
+	handler, err := NewCustomResourceDefinitionHandler(
+		&versionDiscoveryHandler{}, &groupDiscoveryHandler{},
+		crdInformer,
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+		restOptionsGetter,
+		dummyAdmissionImpl{},
+		&establish.EstablishingController{},
+		dummyServiceResolverImpl{},
+		func(r webhook.AuthenticationInfoResolver) webhook.AuthenticationInfoResolver { return r },
+		1,
+		dummyAuthorizerImpl{},
+		time.Minute, time.Minute, nil, 3*1024*1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer handler.destroy()
+
+	initial, err := handler.getOrCreateServingInfoFor(crd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if initial.storageVersion != "v1beta1" {
+		t.Fatalf("expected initial storage version v1beta1, got %q", initial.storageVersion)
+	}
+
+	// A status-only write must not rebuild: it drops the watch cache and forces a full relist for a
+	// change that cannot affect storage. metadata.generation does not advance for status writes, which
+	// is exactly why it is the freshness key rather than resourceVersion.
+	statusOnly := crd.DeepCopy()
+	statusOnly.ResourceVersion = "2"
+	statusOnly.Status.StoredVersions = []string{"v1beta1"}
+	statusOnly.Status.Conditions = []apiextensionsv1.CustomResourceDefinitionCondition{
+		{Type: apiextensionsv1.Established, Status: apiextensionsv1.ConditionTrue},
+	}
+	if err := crdInformer.Informer().GetStore().Update(statusOnly); err != nil {
+		t.Fatal(err)
+	}
+	afterStatus, err := handler.getOrCreateServingInfoFor(statusOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterStatus != initial {
+		t.Errorf("status-only update rebuilt the serving info; storage and watch cache were torn down for a change that does not affect them")
+	}
+
+	// A spec change that moves the storage version must rebuild, and the new info must encode to the
+	// new storage version. This is the direction discovery already reflects, so leaving it stale is the
+	// bug: discovery advertises v1alpha1 while etcd receives v1beta1.
+	specChange := statusOnly.DeepCopy()
+	specChange.Generation = 2
+	specChange.ResourceVersion = "3"
+	for i := range specChange.Spec.Versions {
+		specChange.Spec.Versions[i].Storage = specChange.Spec.Versions[i].Name == "v1alpha1"
+	}
+	if err := crdInformer.Informer().GetStore().Update(specChange); err != nil {
+		t.Fatal(err)
+	}
+	afterSpec, err := handler.getOrCreateServingInfoFor(specChange)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterSpec == initial {
+		t.Fatal("spec change did not rebuild the serving info")
+	}
+	if afterSpec.storageVersion != "v1alpha1" {
+		t.Errorf("expected storage version v1alpha1 after spec change, got %q", afterSpec.storageVersion)
+	}
+
+	// A caller holding an older CRD than the cache must not force a rebuild. CRDFinalizer passes a CRD
+	// read earlier in its sync; the check is directional (>=) so a newer cache still satisfies it.
+	afterStale, err := handler.getOrCreateServingInfoFor(crd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterStale != afterSpec {
+		t.Errorf("a caller with an older CRD rebuilt the serving info; the freshness check must be directional")
+	}
+
+	// A write that advances the generation without changing the stored spec must not rebuild.
+	// PrepareForUpdate increments the generation before dropDisabledFields strips fields behind
+	// disabled feature gates, so the generation can run ahead of the spec the storage is built from.
+	// Treating the bump alone as a change would tear down storage updateCustomResourceDefinition
+	// deliberately keeps.
+	generationOnly := specChange.DeepCopy()
+	generationOnly.Generation = 3
+	generationOnly.ResourceVersion = "4"
+	if err := crdInformer.Informer().GetStore().Update(generationOnly); err != nil {
+		t.Fatal(err)
+	}
+	afterGeneration, err := handler.getOrCreateServingInfoFor(generationOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterGeneration != afterSpec {
+		t.Errorf("a generation bump with an unchanged spec rebuilt the serving info; the two must agree with updateCustomResourceDefinition, which keeps storage when neither spec nor accepted names changed")
+	}
+
+	// acceptedNames lives in status, where the generation never advances, so it has to be compared
+	// on its own: the naming controller can move an accepted name from one non-empty value to
+	// another when a conflicting CRD in the group goes away, with no write to this CRD's spec.
+	namesChange := generationOnly.DeepCopy()
+	namesChange.ResourceVersion = "5"
+	namesChange.Status.AcceptedNames.ShortNames = []string{"multiv"}
+	if err := crdInformer.Informer().GetStore().Update(namesChange); err != nil {
+		t.Fatal(err)
+	}
+	afterNames, err := handler.getOrCreateServingInfoFor(namesChange)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterNames == afterGeneration {
+		t.Fatal("an accepted names change did not rebuild the serving info; the generation does not advance for status writes, so it cannot cover this")
+	}
+	if !reflect.DeepEqual(afterNames.acceptedNames.ShortNames, []string{"multiv"}) {
+		t.Errorf("rebuilt serving info has accepted short names %v, want [multiv]", afterNames.acceptedNames.ShortNames)
+	}
+}
+
+// TestNamesEqualCoversAllFields fails when a field is added to CustomResourceDefinitionNames, since
+// namesEqual is hand-rolled and would silently ignore it. Update namesEqual, then bump the count here.
+func TestNamesEqualCoversAllFields(t *testing.T) {
+	const covered = 6 // Plural, Singular, ShortNames, Kind, ListKind, Categories
+	if got := reflect.TypeOf(apiextensionsv1.CustomResourceDefinitionNames{}).NumField(); got != covered {
+		t.Fatalf("CustomResourceDefinitionNames has %d fields, namesEqual compares %d; add the new field to namesEqual and update this test", got, covered)
+	}
+}
+
+func TestNamesEqual(t *testing.T) {
+	base := apiextensionsv1.CustomResourceDefinitionNames{
+		Plural: "widgets", Singular: "widget", Kind: "Widget", ListKind: "WidgetList",
+		ShortNames: []string{"w", "wg"}, Categories: []string{"all"},
+	}
+	mutate := func(f func(*apiextensionsv1.CustomResourceDefinitionNames)) apiextensionsv1.CustomResourceDefinitionNames {
+		out := *base.DeepCopy()
+		f(&out)
+		return out
+	}
+
+	tests := []struct {
+		name  string
+		other apiextensionsv1.CustomResourceDefinitionNames
+	}{
+		{"identical", *base.DeepCopy()},
+		{"plural", mutate(func(n *apiextensionsv1.CustomResourceDefinitionNames) { n.Plural = "gadgets" })},
+		{"singular", mutate(func(n *apiextensionsv1.CustomResourceDefinitionNames) { n.Singular = "gadget" })},
+		{"kind", mutate(func(n *apiextensionsv1.CustomResourceDefinitionNames) { n.Kind = "Gadget" })},
+		{"listKind", mutate(func(n *apiextensionsv1.CustomResourceDefinitionNames) { n.ListKind = "GadgetList" })},
+		{"shortNames added", mutate(func(n *apiextensionsv1.CustomResourceDefinitionNames) { n.ShortNames = []string{"w", "wg", "x"} })},
+		{"shortNames removed", mutate(func(n *apiextensionsv1.CustomResourceDefinitionNames) { n.ShortNames = []string{"w"} })},
+		{"shortNames reordered", mutate(func(n *apiextensionsv1.CustomResourceDefinitionNames) { n.ShortNames = []string{"wg", "w"} })},
+		{"shortNames nil", mutate(func(n *apiextensionsv1.CustomResourceDefinitionNames) { n.ShortNames = nil })},
+		{"shortNames empty", mutate(func(n *apiextensionsv1.CustomResourceDefinitionNames) { n.ShortNames = []string{} })},
+		{"categories", mutate(func(n *apiextensionsv1.CustomResourceDefinitionNames) { n.Categories = []string{"other"} })},
+		{"categories nil", mutate(func(n *apiextensionsv1.CustomResourceDefinitionNames) { n.Categories = nil })},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// namesEqual must agree with the reflection-based comparison it replaced, including its
+			// treatment of nil versus empty slices.
+			want := apiequality.Semantic.DeepEqual(&base, &tc.other)
+			if got := namesEqual(&base, &tc.other); got != want {
+				t.Errorf("namesEqual = %v, apiequality.Semantic.DeepEqual = %v", got, want)
+			}
+			// isUpToDateFor calls this with the cached names on either side depending on the path, so
+			// it has to be symmetric.
+			if got := namesEqual(&tc.other, &base); got != want {
+				t.Errorf("namesEqual reversed = %v, apiequality.Semantic.DeepEqual = %v", got, want)
+			}
+		})
+	}
+
+	// nil and empty must compare equal, which is the one place namesEqual could plausibly diverge:
+	// Equalities.DeepEqual passes equateNilAndEmpty=true, and comparing lengths reproduces that.
+	// Comparing each against a populated slice above does not exercise it, since both are unequal there.
+	nilNames := mutate(func(n *apiextensionsv1.CustomResourceDefinitionNames) { n.ShortNames, n.Categories = nil, nil })
+	emptyNames := mutate(func(n *apiextensionsv1.CustomResourceDefinitionNames) {
+		n.ShortNames, n.Categories = []string{}, []string{}
+	})
+	if !namesEqual(&nilNames, &emptyNames) {
+		t.Error("namesEqual treats nil and empty slices as different; apiequality.Semantic.DeepEqual equates them")
+	}
+	if !apiequality.Semantic.DeepEqual(&nilNames, &emptyNames) {
+		t.Error("apiequality.Semantic.DeepEqual no longer equates nil and empty slices; namesEqual must be updated to match")
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig api-machinery
#### What this PR does / why we need it:

`crdHandler` and `DiscoveryController` consumes the same shared informer independently and nothing orders the two consumers. So after a spec change that moves the storage version, discovery can already advertise the new `storageVersionHash` while crdHandler is still serving storage built from the old spec. This is where the race happened.

This pr makes the read path level-triggered instead. `getOrCreateServingInfoFor` now takes the `*CustomResourceDefinition` the caller already holds and returns the cached entry only if it was built from a CRD state at least as new, compared on `generation` plus `acceptedNames`, falling back to a spec comparison when the generation advanced.  Otherwise it rebuilds on demand. A request that can observe the new CRD can therefore no longer be served by storage built from the old one, whether or not the informer handler has run yet.


#### Which issue(s) this PR is related to:
Fixes #130235


#### Special notes for your reviewer:
I verified the fix with the repro in the issue https://github.com/kubernetes/kubernetes/issues/130235#issuecomment-2665501409. 33/100 fail on the parent commit, 0/100 here. Note that the repro needs adapting to current master. I didn't include the repro in this PR because it hammers the apiserver with 100 concurrent subtests, so I left it out.

- I refactored the spec + acceptedNames DeepEqual pair to become the crdInfo.matchesSpecAndNames. They are the same comparison, no semantic change. Only to make it better readable
- acceptedNames is compared separately. It lives in status, which generation never covers
- namesEqual is hand-rolled rather than DeepEqual to keep the hot path allocation-free
- adding a teardown because the request path can now replace a live entry, so it tears down the one it displaces

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a race where kube-apiserver could persist a custom resource at the previous storage version after a CustomResourceDefinition's storage version changed, even though discovery already advertised the new one. Affected objects remained stored at the old version until rewritten.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

```

#### AI usage disclosure:

YES, used for investigating the problem and implementing the fix.