### PR TITLE
kubelet: retain pod volume stats during restart backoff

### DIFF
--- a/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -148,6 +148,25 @@ func (p *cadvisorStatsProvider) ListPodStats(ctx context.Context) ([]statsapi.Po
 		podStats.ProcessStats = mergeProcessStats(podStats.ProcessStats, cadvisorInfoToProcessStats(&cinfo))
 	}
 
+	// A Running pod can have no live container samples during restart backoff.
+	// Its volumes are still mounted, so retain the pod for storage collection
+	// without bringing back the filtered container stats.
+	seenPods := make(map[statsapi.PodReference]bool)
+	for key, cinfo := range infos {
+		if strings.HasSuffix(key, ".mount") || !isPodManagedContainer(logger, &cinfo) {
+			continue
+		}
+		ref := buildPodRef(cinfo.Spec.Labels)
+		if _, found := podToStats[ref]; found || seenPods[ref] {
+			continue
+		}
+		seenPods[ref] = true
+		podStatus, found := p.statusProvider.GetPodStatus(types.UID(ref.UID))
+		if found && podStatus.Phase == v1.PodRunning {
+			podToStats[ref] = &statsapi.PodStats{PodRef: ref}
+		}
+	}
+
 	// Add each PodStats to the result.
 	result := make([]statsapi.PodStats, 0, len(podToStats))
 	for _, podStats := range podToStats {

--- a/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -102,7 +102,8 @@ func (p *cadvisorStatsProvider) ListPodStats(ctx context.Context) ([]statsapi.Po
 	filteredInfos, allInfos := filterTerminatedContainerInfoAndAssembleByPodCgroupKey(logger, infos)
 	// Map each container to a pod and update the PodStats with container data.
 	podToStats := map[statsapi.PodReference]*statsapi.PodStats{}
-	for key, cinfo := range filteredInfos {
+	podsWithLiveContainers := make(map[statsapi.PodReference]bool)
+	for key, cinfo := range infos {
 		// On systemd using devicemapper each mount into the container has an
 		// associated cgroup. We ignore them to ensure we do not get duplicate
 		// entries in our summary. For details on .mount units:
@@ -123,6 +124,11 @@ func (p *cadvisorStatsProvider) ListPodStats(ctx context.Context) ([]statsapi.Po
 			podStats = &statsapi.PodStats{PodRef: ref}
 			podToStats[ref] = podStats
 		}
+
+		if _, found := filteredInfos[key]; !found {
+			continue
+		}
+		podsWithLiveContainers[ref] = true
 
 		// Update the PodStats entry with the stats from the container by
 		// adding it to podStats.Containers.
@@ -148,31 +154,18 @@ func (p *cadvisorStatsProvider) ListPodStats(ctx context.Context) ([]statsapi.Po
 		podStats.ProcessStats = mergeProcessStats(podStats.ProcessStats, cadvisorInfoToProcessStats(&cinfo))
 	}
 
-	// A Running pod can have no live container samples during restart backoff.
-	// Its volumes are still mounted, so retain the pod for storage collection
-	// without bringing back the filtered container stats.
-	seenPods := make(map[statsapi.PodReference]bool)
-	for key, cinfo := range infos {
-		if strings.HasSuffix(key, ".mount") || !isPodManagedContainer(logger, &cinfo) {
-			continue
-		}
-		ref := buildPodRef(cinfo.Spec.Labels)
-		if _, found := podToStats[ref]; found || seenPods[ref] {
-			continue
-		}
-		seenPods[ref] = true
-		podStatus, found := p.statusProvider.GetPodStatus(types.UID(ref.UID))
-		if found && podStatus.Phase == v1.PodRunning {
-			podToStats[ref] = &statsapi.PodStats{PodRef: ref}
-		}
-	}
-
 	// Add each PodStats to the result.
 	result := make([]statsapi.PodStats, 0, len(podToStats))
 	for _, podStats := range podToStats {
+		podUID := types.UID(podStats.PodRef.UID)
+		status, found := p.statusProvider.GetPodStatus(podUID)
+		// A Running pod's volumes remain mounted during restart backoff,
+		// even when all of its container samples have been filtered out.
+		if !podsWithLiveContainers[podStats.PodRef] && (!found || status.Phase != v1.PodRunning) {
+			continue
+		}
 		makePodStorageStats(logger, podStats, &rootFsInfo, p.resourceAnalyzer, p.hostStatsProvider, false)
 
-		podUID := types.UID(podStats.PodRef.UID)
 		// Lookup the pod-level cgroup's CPU and memory stats
 		podInfo := getCadvisorPodInfoFromPodUID(podUID, allInfos)
 		if podInfo != nil {
@@ -186,7 +179,6 @@ func (p *cadvisorStatsProvider) ListPodStats(ctx context.Context) ([]statsapi.Po
 			// ProcessStats were accumulated as the containers were iterated.
 		}
 
-		status, found := p.statusProvider.GetPodStatus(podUID)
 		if found && status.StartTime != nil && !status.StartTime.IsZero() {
 			podStats.StartTime = *status.StartTime
 			// only append stats if we were able to get the start time of the pod

--- a/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -161,7 +161,8 @@ func (p *cadvisorStatsProvider) ListPodStats(ctx context.Context) ([]statsapi.Po
 		status, found := p.statusProvider.GetPodStatus(podUID)
 		// A Running pod's volumes remain mounted during restart backoff,
 		// even when all of its container samples have been filtered out.
-		if !podsWithLiveContainers[podStats.PodRef] && (!found || status.Phase != v1.PodRunning) {
+		if !found || status.StartTime == nil || status.StartTime.IsZero() ||
+			(!podsWithLiveContainers[podStats.PodRef] && status.Phase != v1.PodRunning) {
 			continue
 		}
 		makePodStorageStats(logger, podStats, &rootFsInfo, p.resourceAnalyzer, p.hostStatsProvider, false)
@@ -179,11 +180,8 @@ func (p *cadvisorStatsProvider) ListPodStats(ctx context.Context) ([]statsapi.Po
 			// ProcessStats were accumulated as the containers were iterated.
 		}
 
-		if found && status.StartTime != nil && !status.StartTime.IsZero() {
-			podStats.StartTime = *status.StartTime
-			// only append stats if we were able to get the start time of the pod
-			result = append(result, *podStats)
-		}
+		podStats.StartTime = *status.StartTime
+		result = append(result, *podStats)
 	}
 
 	return result, nil

--- a/pkg/kubelet/stats/cadvisor_stats_provider_test.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider_test.go
@@ -903,6 +903,84 @@ func TestCadvisorSameDiskDifferentLocations(t *testing.T) {
 	assert.Equal(*imageFsInfo.Inodes-*imageFsInfo.InodesFree, *containerfs.InodesUsed)
 }
 
+func TestCadvisorListPodStatsWithFilteredContainers(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		phase            v1.PodPhase
+		statusFound      bool
+		started          bool
+		containerRunning bool
+		cgroupsRemoved   bool
+		wantPod          bool
+	}{
+		{name: "crashloop", phase: v1.PodRunning, statusFound: true, started: true, wantPod: true},
+		{name: "restarted", phase: v1.PodRunning, statusFound: true, started: true, containerRunning: true, wantPod: true},
+		{name: "succeeded", phase: v1.PodSucceeded, statusFound: true, started: true},
+		{name: "failed", phase: v1.PodFailed, statusFound: true, started: true},
+		{name: "pending", phase: v1.PodPending, statusFound: true, started: true},
+		{name: "deleted", started: true},
+		{name: "cgroups removed", phase: v1.PodRunning, statusFound: true, started: true, cgroupsRemoved: true},
+		{name: "missing start time", phase: v1.PodRunning, statusFound: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := ktesting.Init(t).Context
+			const podName, namespace = "crashloop", "test"
+			podRef := statsapi.PodReference{Name: podName, Namespace: namespace, UID: "UID" + podName}
+			infos := map[string]cadvisorapi.ContainerInfo{
+				"/":        getTestContainerInfo(0, "", "", ""),
+				"/infra":   getTerminatedContainerInfo(1000, podName, namespace, kubelettypes.PodInfraContainerName),
+				"/app-old": getTerminatedContainerInfo(2000, podName, namespace, "app"),
+				"/app":     getTerminatedContainerInfo(3000, podName, namespace, "app"),
+			}
+			if tc.containerRunning {
+				infos["/app"] = getTestContainerInfo(3000, podName, namespace, "app")
+			}
+			if tc.cgroupsRemoved {
+				delete(infos, "/infra")
+				delete(infos, "/app-old")
+				delete(infos, "/app")
+			}
+			mockCadvisor := cadvisortest.NewMockInterface(t)
+			mockCadvisor.EXPECT().RootFsInfo().Return(cadvisorapi.FsInfo{}, nil)
+			mockCadvisor.EXPECT().ImagesFsInfo(ctx).Return(cadvisorapi.FsInfo{}, nil)
+			mockCadvisor.EXPECT().ContainerInfoV2("/", cadvisorapi.RequestOptions{
+				IdType: cadvisorapi.TypeName, Count: 2, Recursive: true,
+			}).Return(infos, nil)
+			podStatus := v1.PodStatus{Phase: tc.phase}
+			if tc.started {
+				started := metav1.Now()
+				podStatus.StartTime = &started
+			}
+			mockStatus := statustest.NewMockPodStatusProvider(t)
+			mockStatus.EXPECT().GetPodStatus(types.UID(podRef.UID)).Return(podStatus, tc.statusFound).Maybe()
+			usedBytes := uint64(42)
+			volumeStats := []statsapi.VolumeStats{{
+				Name:    "data",
+				PVCRef:  &statsapi.PVCReference{Name: "data", Namespace: namespace},
+				FsStats: statsapi.FsStats{UsedBytes: &usedBytes},
+			}}
+			resourceAnalyzer := &fakeResourceAnalyzer{podVolumeStats: serverstats.PodVolumeStats{PersistentVolumes: volumeStats}}
+			p := NewCadvisorStatsProvider(mockCadvisor, resourceAnalyzer, nil, nil, mockStatus, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil)
+			pods, err := p.ListPodStats(ctx)
+			require.NoError(t, err)
+			if !tc.wantPod {
+				require.Empty(t, pods)
+				return
+			}
+			require.Len(t, pods, 1)
+			assert.Equal(t, podRef, pods[0].PodRef)
+			assert.Equal(t, *podStatus.StartTime, pods[0].StartTime)
+			assert.Equal(t, volumeStats, pods[0].VolumeStats)
+			if tc.containerRunning {
+				require.Len(t, pods[0].Containers, 1)
+				assert.Equal(t, "app", pods[0].Containers[0].Name)
+			} else {
+				assert.Empty(t, pods[0].Containers)
+			}
+		})
+	}
+}
+
 func TestCadvisorListPodStatsWhenContainerLogFound(t *testing.T) {
 	ctx := ktesting.Init(t).Context
 	const (


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When every container sample for a Running pod is filtered out by cAdvisor stats collection, `ListPodStats` omits the pod before collecting its volume stats. A pod in restart backoff can therefore lose its Summary API volume stats and the PVC metrics derived from them even though its volumes remain mounted.

Build pod references in a single pass over the unfiltered cAdvisor data, while collecting container stats only for samples that pass the existing terminated-container filter. Use the existing pod-status lookup to retain pods without live samples only when their cached phase is Running, and preserve the existing start-time requirement.

The regression covers restart backoff, a restarted container, terminal and pending pods, missing pod status, removed cgroups, and missing start time.

#### Which issue(s) this PR is related to:

Fixes #141350

#### Special notes for your reviewer:

Validation on Linux with Go 1.27.1:
- The new crashloop regression fails on unmodified master at `81b21d46dd9`: the pod list is empty instead of containing the Running pod and its volume stats.
- All eight regression cases pass with the fix.
- `go test -p=2 ./pkg/kubelet/stats ./pkg/kubelet/metrics/collectors -count=1` passed.
- `gofmt` and `git diff --check` passed.

Reproduction is at the unit-test level; the reporter's live CSI-backed cluster scenario has not been rerun locally. The CRI stats provider is unchanged.

#### Does this PR introduce a user-facing change?

```release-note
Kubelet's cAdvisor stats provider now retains volume statistics for Running pods when all their container samples are filtered out during restart backoff.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

#### AI usage disclosure:

---
